### PR TITLE
Add Install scripts for agent/hub + documentation in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,73 @@ If you don't need network stats, remove that line from the compose file and map 
 
 ### Binary
 
+#### Beszel Agent
+
+##### Prerequisites
+
+- Debian or Ubuntu distribution
+
+- System administrator privileges
+
+##### Installation
+
+To install Beszel Agent, follow these steps:
+
+1. Download the Beszel Agent installation script: wget https://raw.githubusercontent.com/henrygd/beszel/master/install-agent.sh
+
+2. Make the script executable: chmod +x install-agent.sh
+
+3. Run the script with the desired options:
+
+- ./install-agent.sh -k <ssh_key> -p <port> (specify the SSH key and port)
+
+- ./install-agent.sh -h (display the help message)
+
+4. Follow the prompts to complete the installation
+
+##### Uninstallation
+
+1. To uninstall Beszel Agent, follow these steps:
+
+2. Run the installation script with the -u option: ./install-agent.sh -u
+
+Follow the prompts to complete the uninstallation
+
+#### Beszel Hub
+
+##### Prerequisites
+
+- Debian or Ubuntu distribution
+
+- System administrator privileges
+
+##### Installation
+
+To install Beszel Hub, follow these steps:
+
+1. Download the Beszel Hub installation script: wget https://raw.githubusercontent.com/henrygd/beszel/master/install-hub.sh
+
+2. Make the script executable: chmod +x install-hub.sh
+
+3. Run the script:
+
+- ./install-hub.sh
+
+- ./install-hub.sh -h (display the help message)
+
+4. Follow the prompts to complete the installation
+
+##### Uninstallation
+
+To uninstall Beszel Hub, follow these steps:
+
+
+
+1. Run the installation script with the -u option: ./install-hub.sh -u
+
+2. Follow the prompts to complete the uninstallation
+
+### Alternative Binary
 Download and run the latest binaries from the [releases page](https://github.com/henrygd/beszel/releases) or use the commands below.
 
 #### Hub

--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+version=0.0.1
+# Define default values
+PORT=45876
+
+# Read command line options
+while getopts ":k:p:uh" opt; do
+  case $opt in
+    k) KEY="$OPTARG";;
+    p) PORT="$OPTARG";;
+    u) UNINSTALL="true";;
+    h) echo "Beszel Agent installation script"; echo ""
+       echo "Usage: ./install.sh [options]"; echo ""
+       echo "Options: "
+       echo "  -k  : SSH key (required, or interactive if not provided)"; echo ""
+       echo "  -p  : Port (default: $PORT)"; echo ""
+       echo "  -u  : Uninstall the Beszel Agent"; echo ""
+       echo "  -h  : Display this help message"; echo ""
+       exit 0;;
+    \?) echo "Invalid option: -$OPTARG"; exit 1;;
+  esac
+done
+
+if [ "$UNINSTALL" = "true" ]; then
+  # Stop and disable the Beszel Agent service
+  echo "Stopping and disabling the Beszel Agent service..."
+  sudo systemctl stop beszel-agent.service
+  sudo systemctl disable beszel-agent.service
+
+  # Remove the systemd service file
+  echo "Removing the systemd service file..."
+  sudo rm /etc/systemd/system/beszel-agent.service
+
+  # Reload the systemd daemon
+  echo "Reloading the systemd daemon..."
+  sudo systemctl daemon-reload
+
+  # Remove the Beszel Agent directory
+  echo "Removing the Beszel Agent directory..."
+  sudo rm -rf /opt/beszel-agent
+
+  # Remove the dedicated user for the Beszel Agent service
+  echo "Removing the dedicated user for the Beszel Agent service..."
+  sudo userdel beszel
+
+  echo "The Beszel Agent has been uninstalled successfully!"
+else
+  # Check if the distribution is supported
+  if [ "$(cat /etc/os-release | grep '^ID=')" != "ID=debian" ] && [ "$(cat /etc/os-release | grep '^ID=')" != "ID=ubuntu" ] && [ "$(cat /etc/os-release | grep '^ID_LIKE=')" != "ID_LIKE=debian" ]; then
+    echo "Error: This script only supports Debian and Ubuntu distributions."
+    exit 1
+  fi
+
+  # If no SSH key is provided, ask for the SSH key interactively
+  if [ -z "$KEY" ]; then
+    read -p "Enter your SSH key: " KEY
+  fi
+
+  # Check if necessary packages are installed
+  sudo apt update
+  sudo apt install -y tar curl
+
+  # Create a dedicated user for the service if it doesn't exist
+  if ! id -u beszel-agent > /dev/null 2>&1; then
+    echo "Creating a dedicated user for the Beszel Agent service..."
+    sudo useradd -m -s /bin/false beszel
+  fi
+
+  # Create the directory for the Beszel Agent
+  if [ ! -d "/opt/beszel-agent" ]; then
+    echo "Creating the directory for the Beszel Agent..."
+    sudo mkdir -p /opt/beszel-agent
+    sudo chown beszel:beszel /opt/beszel-agent
+    sudo chmod 755 /opt/beszel-agent
+  fi
+
+  # Download and install the Beszel Agent
+  echo "Downloading and installing the Beszel Agent..."
+  curl -sL "https://github.com/henrygd/beszel/releases/latest/download/beszel-agent_$(uname -s)_$(uname -m | sed 's/x86_64/amd64/' | sed 's/armv7l/arm/' | sed 's/aarch64/arm64/').tar.gz" | tar -xz -C /opt/beszel-agent -f - beszel-agent
+  sudo chown beszel:beszel /opt/beszel-agent/beszel-agent
+  sudo chmod 755 /opt/beszel-agent/beszel-agent
+
+  # Create the systemd service
+  echo "Creating the systemd service for the Beszel Agent..."
+  sudo tee /etc/systemd/system/beszel-agent.service <<EOF
+[Unit]
+Description=Beszel Agent Service
+After=network.target
+
+[Service]
+Environment="PORT=$PORT"
+Environment="KEY=$KEY"
+ExecStart=/opt/beszel-agent/beszel-agent
+User=beszel
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  # Load and start the service
+  echo "Loading and starting the Beszel Agent service..."
+  sudo systemctl daemon-reload
+  sudo systemctl enable beszel-agent.service
+  sudo systemctl start beszel-agent.service
+
+  # Check if the service is running
+  if [ "$(systemctl is-active beszel-agent.service)" != "active" ]; then
+    echo "Error: The Beszel Agent service is not running."
+    exit 1
+  fi
+
+  echo "The Beszel Agent has been installed and configured successfully! It is now running on port $PORT."
+fi

--- a/supplemental/scripts/install-hub.sh
+++ b/supplemental/scripts/install-hub.sh
@@ -49,6 +49,10 @@ else
     echo "Error: This script only supports Debian and Ubuntu distributions."
     exit 1
   fi
+  
+  # Check if necessary packages are installed
+  sudo apt update
+  sudo apt install -y tar curl
 
   # Create a dedicated user for the service
   if ! id -u beszel > /dev/null 2>&1; then

--- a/supplemental/scripts/install-hub.sh
+++ b/supplemental/scripts/install-hub.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+version=0.0.1
+# Define default values
+
+# Read command line options
+while getopts ":uh" opt; do
+  case $opt in
+    u) UNINSTALL="true";;
+    h) echo "Beszel Hub installation script"; echo ""
+       echo "Usage: ./install.sh [options]"; echo ""
+       echo "Options: "
+       echo "  -u  : Uninstall the Beszel Hub"; echo ""
+       echo "  -h  : Display this help message"; echo ""
+       exit 0;;
+    \?) echo "Invalid option: -$OPTARG"; exit 1;;
+  esac
+done
+
+if [ "$UNINSTALL" = "true" ]; then
+  # Stop and disable the Beszel Hub service
+  echo "Stopping and disabling the Beszel Hub service..."
+  sudo systemctl stop beszel-hub.service
+  sudo systemctl disable beszel-hub.service
+
+  # Remove the systemd service file
+  echo "Removing the systemd service file..."
+  sudo rm /etc/systemd/system/beszel-hub.service
+
+  # Reload the systemd daemon
+  echo "Reloading the systemd daemon..."
+  sudo systemctl daemon-reload
+
+  # Remove the Beszel Hub binary
+  echo "Removing the Beszel Hub binary..."
+  sudo rm /opt/beszel/beszel
+
+  # Remove the Beszel Hub directory
+  echo "Removing the Beszel Hub directory..."
+  sudo rm -rf /opt/beszel
+
+  # Remove the dedicated user
+  echo "Removing the dedicated user..."
+  sudo userdel beszel
+
+  echo "The Beszel Hub has been uninstalled successfully!"
+else
+  # Check if the distribution is supported
+  if [ "$(cat /etc/os-release | grep '^ID=')" != "ID=debian" ] && [ "$(cat /etc/os-release | grep '^ID=')" != "ID=ubuntu" ] && [ "$(cat /etc/os-release | grep '^ID_LIKE=')" != "ID_LIKE=debian" ]; then
+    echo "Error: This script only supports Debian and Ubuntu distributions."
+    exit 1
+  fi
+
+  # Create a dedicated user for the service
+  if ! id -u beszel > /dev/null 2>&1; then
+    echo "Creating a dedicated user for the Beszel Hub service..."
+    sudo useradd -m -s /bin/false beszel
+  fi
+
+  # Download and install the Beszel Hub
+  echo "Downloading and installing the Beszel Hub..."
+  curl -sL "https://github.com/henrygd/beszel/releases/latest/download/beszel_$(uname -s)_$(uname -m | sed 's/x86_64/amd64/' | sed 's/armv7l/arm/' | sed 's/aarch64/arm64/').tar.gz" | tar -xz -O beszel | tee ./beszel >/dev/null && chmod +x beszel
+  sudo mkdir -p /opt/beszel
+  sudo mv ./beszel /opt/beszel/beszel
+  sudo chown beszel:beszel /opt/beszel/beszel
+
+  # Create the systemd service
+  echo "Creating the systemd service for the Beszel Hub..."
+  sudo tee /etc/systemd/system/beszel-hub.service <<EOF
+[Unit]
+Description=Beszel Hub Service
+After=network.target
+
+[Service]
+ExecStart=/opt/beszel/beszel
+User=beszel
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  # Load and start the service
+  echo "Loading and starting the Beszel Hub service..."
+  sudo systemctl daemon-reload
+  sudo systemctl enable beszel-hub.service
+  sudo systemctl start beszel-hub.service
+
+  # Check if the service is running
+  if [ "$(systemctl is-active beszel-hub.service)" != "active" ]; then
+    echo "Error: The Beszel Hub service is not running."
+    exit 1
+  fi
+
+  echo "The Beszel Hub has been installed and configured successfully! It is now accessible on port 8090."
+fi


### PR DESCRIPTION
As discussed in issue #41, I've created installation scripts for Beszel Agent and Hub to simplify the deployment process. This pull request builds on top of the changes introduced in #77 .

The installation scripts are designed to work on Debian and Ubuntu distributions, and they handle the installation and configuration of the Beszel Agent and Hub services.

Please review the changes and let me know if you have any feedback or suggestions. I'm open to making adjustments and improvements! 😊