### PR TITLE
Fix for edge case on checking age of docker container

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -175,8 +175,9 @@ func getDockerStats() ([]*ContainerStats, error) {
 		ctr.IdShort = ctr.Id[:12]
 		validIds[ctr.IdShort] = struct{}{}
 		// check if container is less than 1 minute old (possible restart)
+		// additionally check if container has status of starting
 		// note: can't use Created field because it's not updated on restart
-		if strings.HasSuffix(ctr.Status, "seconds") {
+		if strings.Contains(ctr.Status, "seconds") || strings.Contains(ctr.Status, "starting") {
 			// if so, remove old container data
 			deleteContainerStatsSync(ctr.IdShort)
 		}


### PR DESCRIPTION
There are a few small edge cases while checking if a container is possible restarting/has restarted where instead of the typical `Up 20 seconds` message in the status field, you will instead see something like `Up 20 seconds (health: starting)` or `Up 20 seconds (healthy)` where the strings.HasSuffix() method will not locate the "seconds" string even though it is present.

It might not be necessary to include the additional check for the actual "starting" string. However, in the event of a container boot looping like in issues #103 and #57, this might assist in filtering out errant data. However, I was not able to force a situation wherein I could actually test if this would work. 