### PR TITLE
Fixes edge cases where container health message does not have expected suffix

### DIFF
--- a/beszel/internal/agent/agent.go
+++ b/beszel/internal/agent/agent.go
@@ -190,8 +190,9 @@ func (a *Agent) getDockerStats() ([]*container.Stats, error) {
 		ctr.IdShort = ctr.Id[:12]
 		validIds[ctr.IdShort] = struct{}{}
 		// check if container is less than 1 minute old (possible restart)
+		// also check if container health is listed as starting to catch potential boot loops
 		// note: can't use Created field because it's not updated on restart
-		if strings.HasSuffix(ctr.Status, "seconds") {
+		if strings.Contains(ctr.Status, "seconds") || strings.Contains(ctr.Status, "starting") {
 			// if so, remove old container data
 			a.deleteContainerStatsSync(ctr.IdShort)
 		}


### PR DESCRIPTION
Resubmit for #111

Once again, I'm not 100% sure the addition of the check for the "starting" string will necessarily fix #103, but it shouldn't hurt. The only downside is that containers which do not have a properly configured health check will not load data. 