### PR TITLE
Adds a version listing in the hub for each agent

### DIFF
--- a/beszel/internal/agent/agent.go
+++ b/beszel/internal/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"beszel"
 	"beszel/internal/entities/container"
 	"beszel/internal/entities/system"
 	"bytes"
@@ -143,6 +144,7 @@ func (a *Agent) getSystemStats() (*system.Info, *system.Stats) {
 		Cpu:     systemStats.Cpu,
 		MemPct:  systemStats.MemPct,
 		DiskPct: systemStats.DiskPct,
+		Vers:    beszel.Version,
 	}
 
 	// add host info

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -45,6 +45,7 @@ type Info struct {
 	Cpu     float64 `json:"cpu"`
 	MemPct  float64 `json:"mp"`
 	DiskPct float64 `json:"dp"`
+	Vers    string  `json:"v"`
 }
 
 // Final data structure to return to the hub

--- a/beszel/site/src/components/systems-table/systems-table.tsx
+++ b/beszel/site/src/components/systems-table/systems-table.tsx
@@ -55,6 +55,7 @@ import {
 	PauseCircleIcon,
 	PlayCircleIcon,
 	Trash2Icon,
+	Wifi,
 } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import { $systems, pb } from '@/lib/stores'
@@ -134,6 +135,14 @@ export default function SystemsTable() {
 					)
 				},
 				header: ({ column }) => sortableHeader(column, 'System', Server),
+			},
+			{
+				accessorKey: 'info.v',
+				cell: (info) => {
+					return(
+						<div>{info.getValue() as string}</div>)
+					},
+					header: ({ column }) => sortableHeader(column, 'Version', Wifi),
 			},
 			{
 				accessorKey: 'info.cpu',

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -6,6 +6,7 @@ export interface SystemRecord extends RecordModel {
 	status: 'up' | 'down' | 'paused' | 'pending'
 	port: string
 	info: SystemInfo
+	agentVersion: string
 }
 
 export interface SystemInfo {


### PR DESCRIPTION
Resubmit of #109 to fulfill #105 

The only somewhat messy thing that I had to do following the refactor was to add an import for the main _module_ (not sure if that is the right terminology when using Go) in the `internal/agent/agent.go` as the version information was moved outside of the agent module itself.

Additionally, it adds an import for the _Wifi_ icon to be used on the hub table.