### PR TITLE
fix: readme link for Monitoring additional disks, partitions, or remote mounts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Use `./beszel update` and `./beszel-agent update` to update to the latest versio
 | Name                | Default | Description                                                                              |
 | ------------------- | ------- | ---------------------------------------------------------------------------------------- |
 | `DOCKER_HOST`       | unset   | Overrides the docker host (docker.sock) if using a proxy.[^socket]                       |
-| `EXTRA_FILESYSTEMS` | unset   | See [Monitoring additional disks / partitions](#monitoring-additional-disks--partitions) |
+| `EXTRA_FILESYSTEMS` | unset   | See [Monitoring additional disks / partitions](##monitoring-additional-disks-partitions-or-remote-mounts) |
 | `FILESYSTEM`        | unset   | Device, partition, or mount point to use for root disk stats.                            |
 | `KEY`               | unset   | Public SSH key to use for authentication. Provided in hub.                               |
 | `LOG_LEVEL`         | info    | Logging level. Valid values: "debug", "info", "warn", "error".                           |

--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Use `./beszel update` and `./beszel-agent update` to update to the latest versio
 | Name                | Default | Description                                                                              |
 | ------------------- | ------- | ---------------------------------------------------------------------------------------- |
 | `DOCKER_HOST`       | unset   | Overrides the docker host (docker.sock) if using a proxy.[^socket]                       |
-| `EXTRA_FILESYSTEMS` | unset   | See [Monitoring additional disks / partitions](##monitoring-additional-disks-partitions-or-remote-mounts) |
+| `EXTRA_FILESYSTEMS` | unset   | See [Monitoring additional disks, partitions, or remote mounts](#monitoring-additional-disks-partitions-or-remote-mounts) |
 | `FILESYSTEM`        | unset   | Device, partition, or mount point to use for root disk stats.                            |
 | `KEY`               | unset   | Public SSH key to use for authentication. Provided in hub.                               |
 | `LOG_LEVEL`         | info    | Logging level. Valid values: "debug", "info", "warn", "error".                           |


### PR DESCRIPTION
This PR fixes the link for Monitoring additional disks, partitions, or remote mounts section in README.md file.