### PR TITLE
fix IPv6 connection problem

### DIFF
--- a/beszel/internal/hub/hub.go
+++ b/beszel/internal/hub/hub.go
@@ -14,6 +14,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -371,11 +372,11 @@ func (h *Hub) deleteSystemConnection(record *models.Record) {
 }
 
 func (h *Hub) createSystemConnection(record *models.Record) (*ssh.Client, error) {
-	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%s", record.GetString("host"), record.GetString("port")), h.sshClientConfig)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
+        client, err := ssh.Dial("tcp", net.JoinHostPort(record.GetString("host"), record.GetString("port")), h.sshClientConfig)
+        if err != nil {
+                return nil, err
+        }
+        return client, nil
 }
 
 func (h *Hub) createSSHClientConfig() error {


### PR DESCRIPTION
https://github.com/henrygd/beszel/blob/4e64d9efad9299c29f96c8a892adbad89c726ab8/beszel/internal/hub/hub.go#L374

The primary issue with the code is its inability to handle IPv6 addresses. The hostname we provides may include hostname or both IPv4 and IPv6 addresses. However, the `ssh.Dial` function expects an address in the format host:port, which might not be directly compatible with IPv6 addresses, especially when they contain multiple colons. So i use `net.JoinHostPort` to fix ipv6 address at createSystemConnection.

![image](https://github.com/user-attachments/assets/8585ae5d-ea24-4049-b7d4-e71c620ac5f8)

After fix, it can handle ipv6 address currectly now. I tested with dualstack domain, single ipv4/ipv6 domain and single ipv4/ipv6 address, it all works fine now.

The only change for IPv6 address now is not require a `[]`, just input the ip.

![image](https://github.com/user-attachments/assets/7e2dc4df-a15d-4d6a-876c-6b360ea93f07)
