### PR TITLE
Fix GitHub.com access issues in mainland China & Add checksum support

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -4,22 +4,32 @@ version=0.0.1
 # Define default values
 PORT=45876
 UNINSTALL=false
+CHINA_MAINLAND=false
+GITHUB_URL="https://github.com"
+GITHUB_API_URL="https://api.github.com"
 
 # Read command line options
-while getopts "k:p:uh" opt; do
+while getopts "k:p:uhc" opt; do
   case $opt in
-    k) KEY="$OPTARG";;
-    p) PORT="$OPTARG";;
-    u) UNINSTALL=true;;
-    h) printf "Beszel Agent installation script\n\n"
-       printf "Usage: ./install-agent.sh [options]\n\n"
-       printf "Options: \n"
-       printf "  -k  : SSH key (required, or interactive if not provided)\n"
-       printf "  -p  : Port (default: $PORT)\n"
-       printf "  -u  : Uninstall Beszel Agent\n"
-       printf "  -h  : Display this help message\n"
-       exit 0;;
-    ?) echo "Invalid option: -$OPTARG"; exit 1;;
+  k) KEY="$OPTARG" ;;
+  p) PORT="$OPTARG" ;;
+  u) UNINSTALL=true ;;
+  c) CHINA_MAINLAND=true ;;
+  h)
+    printf "Beszel Agent installation script\n\n"
+    printf "Usage: ./install-agent.sh [options]\n\n"
+    printf "Options: \n"
+    printf "  -k  : SSH key (required, or interactive if not provided)\n"
+    printf "  -p  : Port (default: $PORT)\n"
+    printf "  -u  : Uninstall Beszel Agent\n"
+    printf "  -c  : Using GitHub mirror sources to resolve network timeout issues in mainland China\n"
+    printf "  -h  : Display this help message\n"
+    exit 0
+    ;;
+  ?)
+    echo "Invalid option: -$OPTARG"
+    exit 1
+    ;;
   esac
 done
 
@@ -64,6 +74,20 @@ if [ "$UNINSTALL" = true ]; then
   exit 0
 fi
 
+if [ "$CHINA_MAINLAND" = true ]; then
+  printf "\nConfirmed to use GitHub mirrors (ghp.ci) for download beszel-agent?\nThis helps to install Agent properly in mainland China. (Y/n): "
+  read USE_MIRROR
+  USE_MIRROR=${USE_MIRROR:-Y}
+  if [ "$USE_MIRROR" = "Y" ] || [ "$USE_MIRROR" = "y" ]; then
+    GITHUB_URL="https://ghp.ci/https://github.com"
+    # In China, only github.com is blocked, while api.github.com is not (for now).
+    # GITHUB_API_URL="https://api.github.com"
+    echo "Using GitHub Mirror for downloads..."
+  else
+    echo "GitHub mirrors will not be used for installation."
+  fi
+fi
+
 # Function to check if a package is installed
 package_installed() {
   command -v "$1" >/dev/null 2>&1
@@ -71,26 +95,36 @@ package_installed() {
 
 # Check for package manager and install necessary packages if not installed
 if package_installed apt-get; then
-  if ! package_installed tar || ! package_installed curl; then
+  if ! package_installed tar || ! package_installed curl || ! package_installed sha256sum; then
     apt-get update
-    apt-get install -y tar curl
+    apt-get install -y tar curl coreutils
   fi
 elif package_installed yum; then
-  if ! package_installed tar || ! package_installed curl; then
-    yum install -y tar curl
+  if ! package_installed tar || ! package_installed curl || ! package_installed sha256sum; then
+    yum install -y tar curl coreutils
   fi
 elif package_installed pacman; then
-  if ! package_installed tar || ! package_installed curl; then
-    pacman -Sy --noconfirm tar curl
+  if ! package_installed tar || ! package_installed curl || ! package_installed sha256sum; then
+    pacman -Sy --noconfirm tar curl coreutils
   fi
 else
-  echo "Warning: Please ensure 'tar' and 'curl' are installed."
+  echo "Warning: Please ensure 'tar' and 'curl' and 'sha256sum (coreutils)' are installed."
 fi
 
 # If no SSH key is provided, ask for the SSH key interactively
 if [ -z "$KEY" ]; then
   printf "Enter your SSH key: "
   read KEY
+fi
+
+# Verify checksum
+if command -v sha256sum >/dev/null; then
+  CHECK_CMD="sha256sum"
+elif command -v md5 >/dev/null; then
+  CHECK_CMD="md5 -q"
+else
+  echo "No MD5 checksum utility found"
+  exit 1
 fi
 
 # Create a dedicated user for the service if it doesn't exist
@@ -111,11 +145,51 @@ fi
 
 # Download and install the Beszel Agent
 echo "Downloading and installing the agent..."
-curl -sL "https://github.com/henrygd/beszel/releases/latest/download/beszel-agent_$(uname -s)_$(uname -m | sed 's/x86_64/amd64/' | sed 's/armv7l/arm/' | sed 's/aarch64/arm64/').tar.gz" \
-  | tar -xz -O beszel-agent | tee ./beszel-agent >/dev/null
-mv ./beszel-agent /opt/beszel-agent/beszel-agent
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/armv7l/arm/' | sed 's/aarch64/arm64/')
+FILE_NAME="beszel-agent_${OS}_${ARCH}.tar.gz"
+LATEST_VERSION=$(curl -s "$GITHUB_API_URL""/repos/henrygd/beszel/releases/latest" | grep -o '"tag_name": "v[^"]*"' | cut -d'"' -f4 | tr -d 'v')
+if [ -z "$LATEST_VERSION" ]; then
+  echo "Failed to get latest version"
+  exit 1
+fi
+
+echo "Downloading and installing agent version ${LATEST_VERSION} from ${GITHUB_URL} ..."
+
+# Download checksums file
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR" || exit 1
+CHECKSUM=$(curl -sL "$GITHUB_URL/henrygd/beszel/releases/download/v${LATEST_VERSION}/beszel_${LATEST_VERSION}_checksums.txt" | grep "$FILE_NAME" | cut -d' ' -f1)
+if [ -z "$CHECKSUM" ] || ! echo "$CHECKSUM" | grep -qE "^[a-fA-F0-9]{64}$"; then
+  echo "Failed to get checksum or invalid checksum format"
+  exit 1
+fi
+
+if ! curl -#L "$GITHUB_URL/henrygd/beszel/releases/download/v${LATEST_VERSION}/$FILE_NAME" -o "$FILE_NAME"; then
+  echo "Failed to download the agent from ""$GITHUB_URL/henrygd/beszel/releases/download/v${LATEST_VERSION}/$FILE_NAME"
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+if [ "$($CHECK_CMD "$FILE_NAME" | cut -d' ' -f1)" != "$CHECKSUM" ]; then
+  echo "Checksum verification failed: $($CHECK_CMD "$FILE_NAME" | cut -d' ' -f1) & $CHECKSUM"
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+if ! tar -xzf "$FILE_NAME" beszel-agent; then
+  echo "Failed to extract the agent"
+  rm -rf "$TEMP_DIR"
+  exit 1
+fi
+
+mv beszel-agent /opt/beszel-agent/beszel-agent
 chown beszel:beszel /opt/beszel-agent/beszel-agent
 chmod 755 /opt/beszel-agent/beszel-agent
+
+# Cleanup
+rm -rf "$TEMP_DIR"
 
 # Create the systemd service
 echo "Creating the systemd service for the agent..."

--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -9,27 +9,57 @@ GITHUB_URL="https://github.com"
 GITHUB_API_URL="https://api.github.com"
 
 # Read command line options
-while getopts "k:p:uhc" opt; do
-  case $opt in
-  k) KEY="$OPTARG" ;;
-  p) PORT="$OPTARG" ;;
-  u) UNINSTALL=true ;;
-  c) CHINA_MAINLAND=true ;;
-  h)
-    printf "Beszel Agent installation script\n\n"
-    printf "Usage: ./install-agent.sh [options]\n\n"
-    printf "Options: \n"
-    printf "  -k  : SSH key (required, or interactive if not provided)\n"
-    printf "  -p  : Port (default: $PORT)\n"
-    printf "  -u  : Uninstall Beszel Agent\n"
-    printf "  -c  : Using GitHub mirror sources to resolve network timeout issues in mainland China\n"
-    printf "  -h  : Display this help message\n"
-    exit 0
-    ;;
-  ?)
-    echo "Invalid option: -$OPTARG"
-    exit 1
-    ;;
+TEMP=$(getopt -o 'k:p:uh' --long 'china-mirrors,help' -n 'install-agent.sh' -- "$@")
+
+if [ $? -ne 0 ]; then
+  echo 'Failed to parse command line arguments' >&2
+  exit 1
+fi
+
+eval set -- "$TEMP"
+unset TEMP
+
+while true; do
+  case "$1" in
+    '-k')
+      KEY="$2"
+      shift 2
+      continue
+      ;;
+    '-p')
+      PORT="$2"
+      shift 2
+      continue
+      ;;
+    '-u')
+      UNINSTALL=true
+      shift
+      continue
+      ;;
+    '--china-mirrors')
+      CHINA_MAINLAND=true
+      shift
+      continue
+      ;;
+    '-h'|'--help')
+      printf "Beszel Agent installation script\n\n"
+      printf "Usage: ./install-agent.sh [options]\n\n"
+      printf "Options: \n"
+      printf "  -k                : SSH key (required, or interactive if not provided)\n"
+      printf "  -p                : Port (default: $PORT)\n"
+      printf "  -u                : Uninstall Beszel Agent\n"
+      printf "  --china-mirrors   : Using GitHub mirror sources to resolve network timeout issues in mainland China\n"
+      printf "  -h, --help        : Display this help message\n"
+      exit 0
+      ;;
+    '--')
+      shift
+      break
+      ;;
+    *)
+      echo "Invalid option: $1" >&2
+      exit 1
+      ;;
   esac
 done
 


### PR DESCRIPTION
### Problem

Users in mainland China frequently encounter issues when installing beszel-agent:

- GitHub access is blocked or extremely slow
- Downloads frequently timeout and fail
- MitM Risks Frequent in the internet

### Solution
This commit adds support for GitHub mirrors to resolve network issues:

- New `--china-mirrors` flag to use ghp.ci mirror for reliable downloads
- Implement checksum verification for downloaded files
- Add progress bar for file downloads
- Better error messages for troubleshooting

### Usage

```sh
# Install using China-friendly mirror
./install-agent.sh --china-mirrors ...
```

### Additional Notes

The ghp.ci mirror is widely used in China and provides reliable access to GitHub resources. This solution follows similar patterns used by other popular open-source projects to support users in mainland China.

---

Thank you for taking the time to review this PR!

If you feel that this improvement would be helpful to the community, please feel free to discuss it with me. I'm also happy to make changes based on your suggestions to ensure code quality and user experience.