### PR TITLE
chore: add restartsec to systemd service file

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -235,6 +235,7 @@ Environment="KEY=$KEY"
 ExecStart=/opt/beszel-agent/beszel-agent
 User=beszel
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/supplemental/scripts/install-hub.sh
+++ b/supplemental/scripts/install-hub.sh
@@ -105,6 +105,7 @@ ExecStart=/opt/beszel/beszel serve --http "0.0.0.0:$PORT"
 WorkingDirectory=/opt/beszel
 User=beszel
 Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Some linux distro(like suse) would complain if user set `Restart=always`, but have not included any `StartLimitIntervalSec`, `StartLimitBurst`, or `RestartSec` directives to prevent the service from entering an infinite Start request repeated too quickly loop

```
luna:~ # systemctl status beszel-hub
× beszel-hub.service - Beszel Hub Service
     Loaded: loaded (/etc/systemd/system/beszel-hub.service; enabled; preset: disabled)
     Active: failed (Result: start-limit-hit) since Tue 2024-12-03 21:35:01 CST; 2s ago
   Duration: 42ms
    Process: 13519 ExecStart=/opt/beszel/beszel serve --http 0.0.0.0:10002 (code=exited, status=0/SUCCESS)
   Main PID: 13519 (code=exited, status=0/SUCCESS)
        CPU: 18ms

Dec 03 21:35:01 luna systemd[1]: beszel-hub.service: Scheduled restart job, restart counter is at 5.
Dec 03 21:35:01 luna systemd[1]: beszel-hub.service: Start request repeated too quickly.
Dec 03 21:35:01 luna systemd[1]: beszel-hub.service: Failed with result 'start-limit-hit'.
Dec 03 21:35:01 luna systemd[1]: Failed to start Beszel Hub Service.
```