### PR TITLE
fix: json.Unmarshal not resetting struct fields

### DIFF
--- a/beszel/internal/records/records.go
+++ b/beszel/internal/records/records.go
@@ -155,6 +155,7 @@ func (rm *RecordManager) AverageSystemStats(records RecordStats) system.Stats {
 
 	var stats system.Stats
 	for i := range records {
+		stats = system.Stats{} // Zero the struct before unmarshalling
 		json.Unmarshal(records[i].Stats, &stats)
 		sum.Cpu += stats.Cpu
 		sum.Mem += stats.Mem


### PR DESCRIPTION
### Description

`json.Unmarshal` was reusing the same `Stats` struct, leading to incorrect values when unmarshaling multiple JSON strings. This commit creates a new `Stats` instance in each loop iteration to resolve the issue.

A reproducible example is available on Go Playground: https://go.dev/play/p/HnZ8-z7hgXq

