### PR TITLE
refactor: simplify `startSystemUpdateTicker` using `time.Tick`

### DIFF
--- a/beszel/internal/hub/hub.go
+++ b/beszel/internal/hub/hub.go
@@ -227,8 +227,8 @@ func (h *Hub) Run() {
 }
 
 func (h *Hub) startSystemUpdateTicker() {
-	ticker := time.NewTicker(15 * time.Second)
-	for range ticker.C {
+	c := time.Tick(15 * time.Second)
+	for range c {
 		h.updateSystems()
 	}
 }


### PR DESCRIPTION
### Description

This pull request makes a small improvement to the `startSystemUpdateTicker` function by using `time.Tick` instead of `time.NewTicker`. This change aligns with Go 1.23's recommendation and can lead to slightly cleaner code.

According to the Go 1.23 documentation, the garbage collector can now recover unreferenced tickers created with `time.Tick`, making `time.NewTicker` method unnecessary in most cases.

Reference:

* time.Tick: https://pkg.go.dev/time#Tick