### PR TITLE
adding reading agent ssh key from file

### DIFF
--- a/beszel/cmd/agent/agent.go
+++ b/beszel/cmd/agent/agent.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"io/ioutil"
 )
 
 func main() {
@@ -25,7 +26,16 @@ func main() {
 	if pubKeyEnv, exists := os.LookupEnv("KEY"); exists {
 		pubKey = []byte(pubKeyEnv)
 	} else {
-		log.Fatal("KEY environment variable is not set")
+		keyFile := os.Getenv("KEY_FILE")
+		if keyFile != "" {
+			if keyData, err := ioutil.ReadFile(keyFile); err == nil {
+				pubKey = keyData
+			} else {
+				log.Fatalf("Failed to read key from file '%s': %v", keyFile, err)
+			}
+		} else {
+			log.Fatal("KEY environment variable is not set, and KEY_FILE environment variable is not set")
+		}
 	}
 
 	addr := ":45876"


### PR DESCRIPTION
This PR adds support for reading the agent SSH key from a file. This allows storing the agent key as a docker secret. 

I'm not a Go dev so let me know if there's a better way to do this but it's pretty straightforward