### PR TITLE
remove forced lowercasing of password placeholders in login page

### DIFF
--- a/beszel/site/src/components/login/auth-form.tsx
+++ b/beszel/site/src/components/login/auth-form.tsx
@@ -154,7 +154,7 @@ export function UserAuthForm({
 									type="password"
 									autoComplete="current-password"
 									disabled={isLoading || isOauthLoading}
-									className="ps-9 placeholder:lowercase"
+									className="ps-9 placeholder"
 								/>
 								{errors?.password && <p className="px-1 text-xs text-red-600">{errors.password}</p>}
 							</div>
@@ -172,7 +172,7 @@ export function UserAuthForm({
 										type="password"
 										autoComplete="current-password"
 										disabled={isLoading || isOauthLoading}
-										className="ps-9 placeholder:lowercase"
+										className="ps-9 placeholder"
 									/>
 									{errors?.passwordConfirm && <p className="px-1 text-xs text-red-600">{errors.passwordConfirm}</p>}
 								</div>


### PR DESCRIPTION
In some languages (e.g., German), nouns begin with a capital letter. This PR removes the forced lowercasing of password placeholders on the login page to display the text exactly as translated in the language files.

Before:
![beszel_lowercase](https://github.com/user-attachments/assets/60fc39bb-df31-4d05-9e38-9ad94010b826)

After:
![image](https://github.com/user-attachments/assets/b70722b1-4ea1-43af-80c2-6270eaef52d8)
