### PR TITLE
[QoL] Add Bug and Feature Request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_FORM.yml
@@ -1,0 +1,71 @@
+name: Bug Report
+description: Use this template to report a bug or issue.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! You should only use this form for issues, to request a change or feature use the [feature request form](https://github.com/henrygd/beszel).
+  - type: checkboxes
+    attributes:
+      label: Pre-work
+      description: |
+        Before opening an issue make sure you've checked the resources below first, any issues that could have been solved by reading the docs or existing issues will be closed.
+      options:
+      - label: I have read the [docs](https://beszel.dev/guide/what-is-beszel).
+        required: true
+      - label: I have searched open and closed issues.
+        required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Explain the issue you experienced, please be clear and concise.
+      placeholder: I went to the coffee pot and it was empty.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: In a perfect world, what should have happened?
+      placeholder: When I got to the coffee pot, it should have been full.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Describe how to reproduce the issue in repeatable steps.
+      placeholder: |
+        1. Go to the coffee pot.
+        2. Make more coffee.
+        3. Pour it into a cup.
+    validations:
+      required: true
+  - type: dropdown
+    id: deployment-environment
+    attributes:
+      label: Deployment Environment
+      description: How did you deploy the application?
+      options:
+        - Docker Compose
+        - Docker Run
+        - Binary
+      default: 0
+    validations:
+      required: true
+  - type: input
+    id: browsers
+    attributes:
+      label: What browser(s) are you seeing the problem on?
+      placeholder: Chrome, Firefox, Safari, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT_FORM.yml
@@ -62,7 +62,14 @@ body:
       label: What browser(s) are you seeing the problem on?
       placeholder: Chrome, Firefox, Safari, etc.
     validations:
-      required: true
+      required: false
+  - type: input
+    id: operating-system
+    attributes:
+      label: What Operation System are you seeing the problem on?
+      placeholder: Ubuntu, Rocky Linux, Windows, MacOs, etc.
+    validations:
+      required: false
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Use this template for requesting a new feature or change.
 title: "[Feature]: "
-labels: ["enhancement", "needs-review"]
+labels: ["enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Use this template for requesting a new feature or change.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        You should only use this form to request a change or new feature, to report a bug or issue use the [bug report form](https://github.com/henrygd/beszel).
+  - type: checkboxes
+    attributes:
+      label: Pre-work
+      options:
+      - label: I have searched open and closed feature request to make sure this or similar feature request does not already exist.
+        required: true
+  - type: dropdown
+    id: idea-section
+    attributes:
+      label: Which part of the application does your feature belong to?
+      description: Select the section of the application that your feature pertains to.
+      options:
+        - Charts
+        - Notifications
+        - Metrics Collection
+        - Other
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Describe the solution or feature you'd like, you should also mention if this solves a problem.
+      placeholder: Be sure to keep it clear and concise.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST_FORM.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Use this template for requesting a new feature or change.
 title: "[Feature]: "
-labels: ["enhancement"]
+labels: ["enhancement", "needs-review"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/orgs/community/discussions
+    about: Please ask and answer questions here.
+  - name: GitHub Security Bug Bounty
+    url: https://bounty.github.com/
+    about: Please report security vulnerabilities here.


### PR DESCRIPTION
As this project gets more and more popular there will be more Feature Requests and bug reports. As there is currently no structure for these. This PR add templates for both of them. Which hopefully makes your life a bit easier 😄 

## Bug Template

- Add checkbox that the docs has been checked
- Add checkbos that open and closed issues has been searched for similar  problems. 
- Add `description` field
- Add `Expected Behavior` field
- Add `Steps to Reproduce` field
- Add multiple fields to collection information about the installation

## Feature Request Template
- Add checkbos that open and closed requests has been searched for similar requests.
- Add dropdown to select the section (Charts, Notifications, metrics collection etc)
- Add description field 

Let me know if you want any changes to this, happy to adjust it to your wishes 😄 
