### PR TITLE
feat(release): add riscv agent builds to goreleaser config

### DIFF
--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -35,11 +35,16 @@ builds:
       - arm64
       - arm
       - mips64
+      - riscv64
     ignore:
       - goos: freebsd
         goarch: arm
       - goos: windows
         goarch: arm
+      - goos: darwin
+        goarch: riscv64
+      - goos: windows
+        goarch: riscv64
 
 archives:
   - id: beszel


### PR DESCRIPTION
This change adds a riscv build config to for the agent to goreleaser. As far as I am aware, only freebsd and linux supports this, so ignore mac and windows.

Verified to work on a [VisionFive 2 SBC](https://www.starfivetech.com/en/site/boards).

I have not updated any installation scripts as that looks like witchcraft to me.