### PR TITLE
Adding GPU overview to the Overview Page

### DIFF
--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -29,6 +29,7 @@ type Stats struct {
 	Temperatures   map[string]float64  `json:"t,omitempty"`
 	ExtraFs        map[string]*FsStats `json:"efs,omitempty"`
 	GPUData        map[string]GPUData  `json:"g,omitempty"`
+	GPUnum         int                 `json:"gn"`
 }
 
 type GPUData struct {

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -33,13 +33,14 @@ type Stats struct {
 }
 
 type GPUData struct {
-	Name        string  `json:"n"`
-	Temperature float64 `json:"-"`
-	MemoryUsed  float64 `json:"mu,omitempty"`
-	MemoryTotal float64 `json:"mt,omitempty"`
-	Usage       float64 `json:"u"`
-	Power       float64 `json:"p,omitempty"`
-	Count       float64 `json:"-"`
+	Name          string  `json:"n"`
+	Temperature   float64 `json:"-"`
+	MemoryUsed    float64 `json:"mu,omitempty"`
+	MemoryTotal   float64 `json:"mt,omitempty"`
+	MemoryPercent float64 `json:"mp,omitempty"`
+	Usage         float64 `json:"u"`
+	Power         float64 `json:"p,omitempty"`
+	Count         float64 `json:"-"`
 }
 
 type FsStats struct {
@@ -76,6 +77,7 @@ type Info struct {
 	Bandwidth     float64 `json:"b"`
 	AgentVersion  string  `json:"v"`
 	Podman        bool    `json:"p,omitempty"`
+	Stats         Stats   `json:"stats"`
 }
 
 // Final data structure to return to the hub

--- a/beszel/internal/hub/hub.go
+++ b/beszel/internal/hub/hub.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -303,6 +304,19 @@ func (h *Hub) updateSystem(record *core.Record) {
 
 	if systemData.Stats.GPUData != nil {
 		systemData.Stats.GPUnum = len(systemData.Stats.GPUData)
+
+		// update the MemoryPercentage for the GPU's (If the MemoryTotal value is not 0)
+		for i := 0; i < systemData.Stats.GPUnum; i++ {
+			key := strconv.Itoa(i)
+
+			gpu := systemData.Stats.GPUData[key]
+
+			if gpu.MemoryTotal != 0 {
+				gpu.MemoryPercent = gpu.MemoryUsed / gpu.MemoryTotal
+			}
+
+			systemData.Stats.GPUData[key] = gpu
+		}
 	}
 
 	// add the stats object to the systemData.Info

--- a/beszel/internal/hub/hub.go
+++ b/beszel/internal/hub/hub.go
@@ -297,6 +297,17 @@ func (h *Hub) updateSystem(record *core.Record) {
 		h.updateSystemStatus(record, "down")
 		return
 	}
+
+	// check how many GPU's there are
+	systemData.Stats.GPUnum = 0
+
+	if systemData.Stats.GPUData != nil {
+		systemData.Stats.GPUnum = len(systemData.Stats.GPUData)
+	}
+
+	// add the stats object to the systemData.Info
+	systemData.Info.Stats = systemData.Stats
+
 	// update system record
 	record.Set("status", "up")
 	record.Set("info", systemData.Info)

--- a/beszel/site/src/components/systems-table/systems-table.tsx
+++ b/beszel/site/src/components/systems-table/systems-table.tsx
@@ -172,6 +172,109 @@ export default function SystemsTable() {
 				header: ({ column }) => sortableHeader(column),
 			},
 			{
+				accessorKey: "info.stats.g",
+				id: t`GPU Utilisation`,
+				invertSorting: true,
+				cell(info) {
+					const gpuCount = info.row.original.info.stats.gn; // Number of GPUs
+			
+					if (gpuCount === 0) {
+						return <span>No GPU</span>;
+					}
+
+					const gpuStats = info.row.original.info.stats.g!; // GPU stats object // If the Gpu count is greater than 0, then the g object must exist
+		
+					return (
+						<div className="flex items-center gap-3">
+							<div className="flex flex-col gap-1">
+								{Array.from({ length: gpuCount }).map((_, i) => {
+
+									const utilisation = gpuStats[i]?.u || 0;
+
+									return (
+										<div key={i} className="flex items-center gap-2">
+											<span>{i+1}</span>
+											<div
+												className="relative bg-muted w-full h-3 rounded-sm overflow-hidden"
+												title={`GPU ${i + 1}: ${utilisation}%`}
+												style={{ maxWidth: "250px", minWidth:'100px' }}
+											>
+												
+												<div
+													className={cn(
+														"absolute inset-0 h-full",
+														(utilisation < 65 && "bg-green-500") ||
+															(utilisation < 90 && "bg-yellow-500") ||
+															"bg-red-500"
+													)}
+													style={{
+														width: `${utilisation}%`,
+													}}
+												></div>
+											</div>
+											<span className="text-sm tabular-nums" style={{maxWidth:"50px", minWidth:"30px"}}>{Math.round(utilisation)}%</span>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					);
+				},
+				icon: CpuIcon,
+				header: ({ column }) => sortableHeader(column),
+			},
+			{
+				accessorKey: "info.stats.g",
+				id: t`GPU Memory`,
+				invertSorting: true,
+				cell(info) {
+					const gpuCount = info.row.original.info.stats.gn; // Number of GPUs
+			
+					if (gpuCount === 0) {
+						return <span>No GPU</span>;
+					}
+		
+					const gpuStats = info.row.original.info.stats.g!; // GPU stats object // If the Gpu count is greater than 0, then the g object must exist
+
+					return (
+						<div className="flex items-center gap-3">
+							<div className="flex flex-col gap-1">
+								{Array.from({ length: gpuCount }).map((_, i) => {
+									const memoryPercent = gpuStats![i]?.mp || 0; 
+									const memoryUsed = gpuStats![i]?.mu || 0; 
+									const memoryTotal = gpuStats![i]?.mt || 0;
+									return (
+										<div key={i} className="flex items-center gap-2">
+											<span>{i+1}</span>
+											<div
+												className="relative bg-muted w-full h-3 rounded-sm overflow-hidden"
+												title={`GPU ${i + 1}: ${memoryUsed}MB / ${memoryTotal}MB`}
+												style={{ maxWidth: "250px", minWidth:'100px' }}
+											>
+												<div
+													className={cn(
+														"absolute inset-0 h-full",
+														(memoryPercent < 0.65 && "bg-green-500") ||
+															(memoryPercent < 0.90 && "bg-yellow-500") ||
+															"bg-red-500"
+													)}
+													style={{
+														width: `${memoryPercent*100}%`,
+													}}
+												></div>
+											</div>
+											<span className="text-sm tabular-nums" style={{maxWidth:"50px", minWidth:"30px"}}>{Math.round(memoryPercent *100)}%</span>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					);
+				},
+				icon: CpuIcon,
+				header: ({ column }) => sortableHeader(column),
+			},
+			{
 				accessorKey: "info.dp",
 				id: t`Disk`,
 				invertSorting: true,
@@ -195,7 +298,7 @@ export default function SystemsTable() {
 							})}
 						>
 							{decimalString(val, val >= 100 ? 1 : 2)} MB/s
-						</span>
+							</span>
 					)
 				},
 			},

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -36,6 +36,8 @@ export interface SystemInfo {
 	v: string
 	/** system is using podman */
 	p?: boolean
+	/** copy of the latest SystemStats */
+	stats:SystemStats
 }
 
 export interface SystemStats {
@@ -85,6 +87,8 @@ export interface SystemStats {
 	efs?: Record<string, ExtraFsStats>
 	/** GPU data */
 	g?: Record<string, GPUData>
+	/** Number of GPUs */
+	gn: number
 }
 
 export interface GPUData {
@@ -98,6 +102,8 @@ export interface GPUData {
 	u: number
 	/** power (w) */
 	p?: number
+	/** Memory percentage (%) */
+	mp?: number
 }
 
 export interface ExtraFsStats {


### PR DESCRIPTION
I've added an Overview for the utilisation and Memory usage to the Overview page. Similar to #449   

The modification is only on the Hub side.  

In the info object there is now the latest stats object as well, there is a GPU number field and the GPUData object contains a memory percentage field.  

Preview:
<img width="1356" alt="Screenshot 2025-01-24 at 13 50 07" src="https://github.com/user-attachments/assets/2fdf2a6a-1738-4666-b4d1-c15e400705e2" />
