### PR TITLE
Create Debian package for beszel-agent

### DIFF
--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -71,21 +71,38 @@ archives:
 nfpms:
   - id: beszel-agent
     package_name: beszel-agent
-    maintainer: henrygd
+    description: |-
+      Agent for Beszel
+      Beszel is a lightweight server monitoring platform that includes Docker
+      statistics, historical data, and alert functions. It has a friendly web
+      interface, simple configuration, and is ready to use out of the box.
+      It supports automatic backup, multi-user, OAuth authentication, and
+      API access.
+    maintainer: henrygd <hank@henrygd.me>
+    section: net
     builds:
       - beszel-agent
     formats:
       - deb
+    dependencies:
+      - libc6
     contents:
-     - src: ../supplemental/debian/copyright
-       dst: usr/share/doc/beszel-agent/copyright
-       packager: deb
-     - src: ../supplemental/debian/beszel-agent.service
-       dst: lib/systemd/system/beszel-agent.service
-       packager: deb
+      - src: ../supplemental/debian/beszel-agent.service
+        dst: lib/systemd/system/beszel-agent.service
+        packager: deb
+      - src: ../supplemental/debian/copyright
+        dst: usr/share/doc/beszel-agent/copyright
+        packager: deb
+      - src: ../supplemental/debian/lintian-overrides
+        dst: usr/share/lintian/overrides/beszel-agent
+        packager: deb
     scripts:
       postinstall: ../supplemental/debian/postinstall.sh
+      postremove: ../supplemental/debian/postrm.sh
     deb:
+      predepends:
+        - adduser
+        - debconf
       scripts:
         templates: ../supplemental/debian/templates
         # Currently broken due to a bug in goreleaser

--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -68,6 +68,30 @@ archives:
       {{- .Os }}_
       {{- .Arch }}
 
+nfpms:
+  - id: beszel-agent
+    package_name: beszel-agent
+    maintainer: henrygd
+    builds:
+      - beszel-agent
+    formats:
+      - deb
+    contents:
+     - src: ../supplemental/debian/copyright
+       dst: usr/share/doc/beszel-agent/copyright
+       packager: deb
+     - src: ../supplemental/debian/beszel-agent.service
+       dst: lib/systemd/system/beszel-agent.service
+       packager: deb
+    scripts:
+      postinstall: ../supplemental/debian/postinstall.sh
+    deb:
+      scripts:
+        templates: ../supplemental/debian/templates
+        # Currently broken due to a bug in goreleaser
+        # https://github.com/goreleaser/goreleaser/issues/5487
+        #config: ../supplemental/debian/config.sh
+
 release:
   draft: true
 

--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -98,6 +98,7 @@ nfpms:
         packager: deb
     scripts:
       postinstall: ../supplemental/debian/postinstall.sh
+      preremove: ../supplemental/debian/prerm.sh
       postremove: ../supplemental/debian/postrm.sh
     deb:
       predepends:

--- a/supplemental/debian/beszel-agent.service
+++ b/supplemental/debian/beszel-agent.service
@@ -5,16 +5,28 @@ After=network-online.target
 
 [Service]
 Environment="PORT=45876"
+# Port number can be overridden in beszel-agent.conf if needed
 EnvironmentFile=/etc/beszel-agent.conf
 ExecStart=/usr/bin/beszel-agent
 User=beszel
 Restart=on-failure
-# TODO: See if we can apply more security hardening here
-# TODO: Audit using `systemd-analyze security beszel-agent.service`
-ProtectSystem=yes
-ProtectHome=yes
+StateDirectory=beszel-agent
+
+# Security/sandboxing settings
+KeyringMode=private
+LockPersonality=yes
 NoNewPrivileges=yes
 PrivateTmp=yes
+ProtectClock=yes
+ProtectHome=read-only
+ProtectHostname=yes
+ProtectKernel=yes
+ProtectKernelLogs=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RemoveIPC=yes
+RestrictSUIDSGID=true
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=multi-user.target

--- a/supplemental/debian/beszel-agent.service
+++ b/supplemental/debian/beszel-agent.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Beszel Agent Service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Environment="PORT=45876"
+EnvironmentFile=/etc/beszel-agent.conf
+ExecStart=/usr/bin/beszel-agent
+User=beszel
+Restart=on-failure
+# TODO: See if we can apply more security hardening here
+# TODO: Audit using `systemd-analyze security beszel-agent.service`
+ProtectSystem=yes
+ProtectHome=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/supplemental/debian/config.sh
+++ b/supplemental/debian/config.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+. /usr/share/debconf/confmodule
+db_version 2.0
+
+db_input high beszel-agent/key || true
+db_go

--- a/supplemental/debian/copyright
+++ b/supplemental/debian/copyright
@@ -1,0 +1,8 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Beszel
+Upstream-Contact: henrygd <hank@henrygd.me>
+Source: https://beszel.dev/
+
+Files: *
+Copyright: 2024 henrygd
+License: MIT

--- a/supplemental/debian/lintian-overrides
+++ b/supplemental/debian/lintian-overrides
@@ -1,0 +1,11 @@
+# No changelog in the repo at the moment. This would be good to fix
+beszel-agent: no-changelog
+# Current unable to fix these due to Goreleaser bug
+# https://github.com/goreleaser/goreleaser/issues/5487
+beszel-agent: no-debconf-config
+beszel-agent: postinst-uses-db-input
+# Needs to be fixed in Beszel build
+beszel-agent: hardening-no-pie
+beszel-agent: hardening-no-relro
+# Maybe one day
+beszel-agent: no-manual-page

--- a/supplemental/debian/postinstall.sh
+++ b/supplemental/debian/postinstall.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+[ "$1" = "configure" ] || exit 0
+
+CONFIG_FILE=/etc/beszel-agent.conf
+SERVICE=beszel-agent
+SERVICE_USER=beszel
+
+. /usr/share/debconf/confmodule
+
+# This would normally be in the config control file, however this is currently
+# broken in goreleaser. Temporarily do it here.
+# https://github.com/goreleaser/goreleaser/issues/5487
+db_version 2.0
+db_input high beszel-agent/key || true
+db_go
+
+# Create group and user
+if ! getent group "$SERVICE_USER" >/dev/null; then
+	echo "Creating $SERVICE_USER group"
+	addgroup --quiet --system "$SERVICE_USER"
+fi
+
+if ! getent passwd "$SERVICE_USER" >/dev/null; then
+	echo "Creating $SERVICE_USER user"
+	adduser --quiet --system "$SERVICE_USER" \
+		--ingroup "$SERVICE_USER" \
+		--no-create-home \
+		--gecos "System user for $SERVICE"
+fi
+
+# Create config file if it doesn't already exist
+if [ ! -f "$CONFIG_FILE" ]; then
+	touch "$CONFIG_FILE"
+	chmod 0600 "$CONFIG_FILE"
+	chown "$SERVICE_USER":"$SERVICE_USER" "$CONFIG_FILE"
+fi;
+
+# Only add key to config if it's not already present
+if ! grep -q "^KEY=" "$CONFIG_FILE"; then
+	db_get beszel-agent/key
+	echo "KEY=$RET" > "$CONFIG_FILE"
+fi;
+
+deb-systemd-helper enable "$SERVICE".service
+deb-systemd-invoke start "$SERVICE".service || echo "could not start $SERVICE.service!"

--- a/supplemental/debian/postinstall.sh
+++ b/supplemental/debian/postinstall.sh
@@ -27,6 +27,7 @@ if ! getent passwd "$SERVICE_USER" >/dev/null; then
 	adduser --quiet --system "$SERVICE_USER" \
 		--ingroup "$SERVICE_USER" \
 		--no-create-home \
+		--home /nonexistent \
 		--gecos "System user for $SERVICE"
 fi
 

--- a/supplemental/debian/postinstall.sh
+++ b/supplemental/debian/postinstall.sh
@@ -45,4 +45,5 @@ if ! grep -q "^KEY=" "$CONFIG_FILE"; then
 fi;
 
 deb-systemd-helper enable "$SERVICE".service
+systemctl daemon-reload
 deb-systemd-invoke start "$SERVICE".service || echo "could not start $SERVICE.service!"

--- a/supplemental/debian/postrm.sh
+++ b/supplemental/debian/postrm.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "purge" ]; then
+	. /usr/share/debconf/confmodule
+	db_purge
+	rm /etc/beszel-agent.conf
+fi

--- a/supplemental/debian/prerm.sh
+++ b/supplemental/debian/prerm.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+SERVICE=beszel-agent
+
+deb-systemd-invoke stop "$SERVICE".service
+if [ "$1" = "remove" ]; then
+	deb-systemd-helper purge "$SERVICE".service
+fi

--- a/supplemental/debian/templates
+++ b/supplemental/debian/templates
@@ -1,0 +1,3 @@
+Template: beszel-agent/key
+Type: string
+Description: SSH public key provided by beszel hub

--- a/supplemental/debian/templates
+++ b/supplemental/debian/templates
@@ -1,3 +1,5 @@
 Template: beszel-agent/key
 Type: string
-Description: SSH public key provided by beszel hub
+Description: SSH public key provided by beszel hub:
+ If you leave this blank, you will need to configure it in 
+ /etc/beszel-agent.conf before starting Beszel.


### PR DESCRIPTION
Adds a Debian package to the build. Currently, only `beszel-agent` is packaged, but a package for `beszel-hub` could be added too. Since the SSH key is a required configuration option, the package prompts for it during installation.

This is the first step. The next step would be to set up a Debian repo for the packages.

# Test Plan
Run the build:
```bash
goreleaser release --snapshot --clean
```
This produces four `.deb` files in the `dist` directory, for amd64, arm64, armv6, riscv64, and mips64_hardfloat (architectures were already configured in the goreleaser config)

Create a new Debian VM
Install package:
```bash
cd /tmp
wget https://d.ls/debian/beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb
sudo apt install ./beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb
```

Output:
```
daniel@debtest:/tmp$ wget https://d.ls/debian/beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb
--2025-01-26 15:08:18--  https://d.ls/debian/beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb
Resolving d.ls (d.ls)... 185.197.30.201, 2a04:bdc7:100:ed8a::1
Connecting to d.ls (d.ls)|185.197.30.201|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 3150376 (3.0M) [application/octet-stream]
Saving to: ‘beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb’

beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_am 100%[=============================================================================================>]   3.00M  --.-KB/s    in 0.1s    

2025-01-26 15:08:19 (23.5 MB/s) - ‘beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb’ saved [3150376/3150376]

daniel@debtest:/tmp$ sudo apt install ./beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'beszel-agent' instead of './beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb'
The following NEW packages will be installed:
  beszel-agent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 0 B/3,150 kB of archives.
After this operation, 7,303 kB of additional disk space will be used.
Get:1 /tmp/beszel-agent_0.9.1-SNAPSHOT-e3aea63_linux_amd64.deb beszel-agent amd64 0.9.1~SNAPSHOT-e3aea63 [3,150 kB]
Preconfiguring packages ...
Selecting previously unselected package beszel-agent.
(Reading database ... 26393 files and directories currently installed.)
Preparing to unpack .../beszel-agent_0.9.1-SNAPSHOT-1747b00_linux_amd64.deb ...
Unpacking beszel-agent (0.9.1~SNAPSHOT-1747b00) ...
Setting up beszel-agent (0.9.1~SNAPSHOT-1747b00) ...
Creating beszel group
Creating beszel user
Created symlink /etc/systemd/system/multi-user.target.wants/beszel-agent.service → /lib/systemd/system/beszel-agent.service.
```

During the installation, it prompts for the SSH key:
![image](https://github.com/user-attachments/assets/e9280d56-09fa-4815-b471-9ce860e62aef)

Verify key is written to `/etc/beszel-agent.conf`:
```
daniel@debtest:/tmp$ sudo cat /etc/beszel-agent.conf 
KEY=ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMiXhkOoriWaBgKbXa8/DTAR91nvRoi42AjRmTu1gsTG
```

Verify systemd unit is enabled and automatically started after installation:
```
daniel@debtest:/tmp$ sudo service beszel-agent status
● beszel-agent.service - Beszel Agent Service
     Loaded: loaded (/lib/systemd/system/beszel-agent.service; disabled; preset: enabled)
     Active: active (running) since Sun 2025-01-26 15:08:55 PST; 5min ago
   Main PID: 3982 (beszel-agent)
      Tasks: 6 (limit: 2315)
     Memory: 6.9M
        CPU: 79ms
     CGroup: /system.slice/beszel-agent.service
             └─3982 /usr/bin/beszel-agent

Jan 26 15:08:55 debtest systemd[1]: Started beszel-agent.service - Beszel Agent Service.
Jan 26 15:08:55 debtest beszel-agent[3982]: 2025/01/26 15:08:55 INFO Detected root device name=vda1
Jan 26 15:08:55 debtest beszel-agent[3982]: 2025/01/26 15:08:55 INFO Detected network interface name=enp1s0 sent=292698 recv=16869221
Jan 26 15:08:55 debtest beszel-agent[3982]: 2025/01/26 15:08:55 INFO Starting SSH server address=:45876
```

Verify connecting to it from Beszel Hub works:
![image](https://github.com/user-attachments/assets/2f31b33c-6850-409b-9ef7-07c56c514910)
