### PR TITLE
fix: prevent multiple simultaneous requests to pocketbase in updateSystemList function .

### DIFF
--- a/beszel/site/src/lib/utils.ts
+++ b/beszel/site/src/lib/utils.ts
@@ -66,7 +66,7 @@ export const updateSystemList = async () => {
             return;
         }
     } finally {
-		isFetchingSystems
+		isFetchingSystems = false
 	}
 };
 

--- a/beszel/site/src/lib/utils.ts
+++ b/beszel/site/src/lib/utils.ts
@@ -42,23 +42,34 @@ const verifyAuth = () => {
 		})
 }
 
+let isFetchingSystems = false;
+
 export const updateSystemList = async () => {
-	try {
-		const records = await pb
-			.collection<SystemRecord>("systems")
-			.getFullList({ sort: "+name", fields: "id,name,host,info,status" })
-		if (records.length) {
-			$systems.set(records)
-		} else {
-			verifyAuth()
-		}
-	} catch (err) {
-		// @ts-ignore supress pocketbase auto cancellation error
-		if (err.isAbort) {
-			return
-		}
+
+	if (isFetchingSystems) return;
+	isFetchingSystems = true
+
+    try {
+        const records = await pb
+            .collection<SystemRecord>("systems")
+            .getFullList({ sort: "+name", fields: "id,name,host,info,status" });
+
+        if (records.length) {
+            $systems.set(records);
+        } else {
+            verifyAuth();
+        }
+    } catch (e: any) {
+        // Suppressing pocketbase auto-cancellation error
+
+        if (e.isAbort || e.status === 0) { 
+            return;
+        }
+    } finally {
+		isFetchingSystems
 	}
-}
+};
+
 
 export const updateAlerts = () => {
 	pb.collection("alerts")


### PR DESCRIPTION
![410209879-31dd2f4c-7c6b-4ce4-9c6a-9e7c19100cd2](https://github.com/user-attachments/assets/ce05a7f3-3a67-4b25-861b-5f34110ce969)

- Suppress pocketbase autocancellation.
- Ensuring only one request at a time with isFetchingSystems variable.