### PR TITLE
Rename Go module to `github.com/henrygd/beszel`

### DIFF
--- a/beszel/Makefile
+++ b/beszel/Makefile
@@ -27,10 +27,10 @@ build-web-ui:
 	fi
 
 build-agent: tidy
-	GOOS=$(OS) GOARCH=$(ARCH) go build -o ./build/beszel-agent_$(OS)_$(ARCH) -ldflags "-w -s" beszel/cmd/agent
+	GOOS=$(OS) GOARCH=$(ARCH) go build -o ./build/beszel-agent_$(OS)_$(ARCH) -ldflags "-w -s" github.com/henrygd/beszel/cmd/agent
 
 build-hub: tidy $(if $(filter false,$(SKIP_WEB)),build-web-ui)
-	GOOS=$(OS) GOARCH=$(ARCH) go build -o ./build/beszel_$(OS)_$(ARCH) -ldflags "-w -s" beszel/cmd/hub
+	GOOS=$(OS) GOARCH=$(ARCH) go build -o ./build/beszel_$(OS)_$(ARCH) -ldflags "-w -s" github.com/henrygd/beszel/cmd/hub
 
 build: build-agent build-hub
 
@@ -58,9 +58,9 @@ dev-hub:
 
 dev-agent:
 	@if command -v entr >/dev/null 2>&1; then \
-		find ./cmd/agent/*.go ./internal/agent/*.go | entr -r go run beszel/cmd/agent; \
+		find ./cmd/agent/*.go ./internal/agent/*.go | entr -r go run github.com/henrygd/beszel/cmd/agent; \
 	else \
-		go run beszel/cmd/agent; \
+		go run github.com/henrygd/beszel/cmd/agent; \
 	fi
 
 # KEY="..." make -j dev

--- a/beszel/cmd/agent/agent.go
+++ b/beszel/cmd/agent/agent.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"beszel"
-	"beszel/internal/agent"
 	"fmt"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/henrygd/beszel"
+	"github.com/henrygd/beszel/internal/agent"
 )
 
 func main() {

--- a/beszel/cmd/hub/hub.go
+++ b/beszel/cmd/hub/hub.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"beszel"
-	"beszel/internal/hub"
+	"github.com/henrygd/beszel"
+	"github.com/henrygd/beszel/internal/hub"
 
-	_ "beszel/migrations"
+	_ "github.com/henrygd/beszel/migrations"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/spf13/cobra"

--- a/beszel/go.mod
+++ b/beszel/go.mod
@@ -1,4 +1,4 @@
-module beszel
+module github.com/henrygd/beszel
 
 go 1.23
 

--- a/beszel/internal/agent/agent.go
+++ b/beszel/internal/agent/agent.go
@@ -2,12 +2,13 @@
 package agent
 
 import (
-	"beszel"
-	"beszel/internal/entities/system"
 	"context"
 	"log/slog"
 	"os"
 	"strings"
+
+	"github.com/henrygd/beszel"
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/shirou/gopsutil/v4/common"
 )

--- a/beszel/internal/agent/disk.go
+++ b/beszel/internal/agent/disk.go
@@ -1,12 +1,13 @@
 package agent
 
 import (
-	"beszel/internal/entities/system"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/shirou/gopsutil/v4/disk"
 )

--- a/beszel/internal/agent/docker.go
+++ b/beszel/internal/agent/docker.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"beszel/internal/entities/container"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/container"
 
 	"github.com/blang/semver"
 )

--- a/beszel/internal/agent/gpu.go
+++ b/beszel/internal/agent/gpu.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"beszel/internal/entities/system"
 	"bufio"
 	"encoding/json"
 	"fmt"
@@ -11,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"golang.org/x/exp/slog"
 )

--- a/beszel/internal/agent/system.go
+++ b/beszel/internal/agent/system.go
@@ -1,8 +1,6 @@
 package agent
 
 import (
-	"beszel"
-	"beszel/internal/entities/system"
 	"bufio"
 	"fmt"
 	"log/slog"
@@ -10,6 +8,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/henrygd/beszel"
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"

--- a/beszel/internal/agent/update.go
+++ b/beszel/internal/agent/update.go
@@ -1,10 +1,11 @@
 package agent
 
 import (
-	"beszel"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/henrygd/beszel"
 
 	"github.com/blang/semver"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"

--- a/beszel/internal/alerts/alerts.go
+++ b/beszel/internal/alerts/alerts.go
@@ -2,12 +2,13 @@
 package alerts
 
 import (
-	"beszel/internal/entities/system"
 	"fmt"
 	"net/mail"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/containrrr/shoutrrr"
 	"github.com/goccy/go-json"

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -1,8 +1,9 @@
 package system
 
 import (
-	"beszel/internal/entities/container"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/container"
 )
 
 type Stats struct {

--- a/beszel/internal/hub/config.go
+++ b/beszel/internal/hub/config.go
@@ -1,12 +1,13 @@
 package hub
 
 import (
-	"beszel/internal/entities/system"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"

--- a/beszel/internal/hub/hub.go
+++ b/beszel/internal/hub/hub.go
@@ -2,12 +2,13 @@
 package hub
 
 import (
-	"beszel"
-	"beszel/internal/alerts"
-	"beszel/internal/entities/system"
-	"beszel/internal/records"
-	"beszel/internal/users"
-	"beszel/site"
+	"github.com/henrygd/beszel"
+	"github.com/henrygd/beszel/internal/alerts"
+	"github.com/henrygd/beszel/internal/entities/system"
+	"github.com/henrygd/beszel/internal/records"
+	"github.com/henrygd/beszel/internal/users"
+	"github.com/henrygd/beszel/site"
+
 	"context"
 	"crypto/ed25519"
 	"encoding/pem"

--- a/beszel/internal/hub/update.go
+++ b/beszel/internal/hub/update.go
@@ -1,10 +1,11 @@
 package hub
 
 import (
-	"beszel"
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/henrygd/beszel"
 
 	"github.com/blang/semver"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"

--- a/beszel/internal/records/records.go
+++ b/beszel/internal/records/records.go
@@ -2,11 +2,12 @@
 package records
 
 import (
-	"beszel/internal/entities/container"
-	"beszel/internal/entities/system"
 	"log"
 	"math"
 	"time"
+
+	"github.com/henrygd/beszel/internal/entities/container"
+	"github.com/henrygd/beszel/internal/entities/system"
 
 	"github.com/goccy/go-json"
 	"github.com/pocketbase/dbx"

--- a/beszel/internal/users/users.go
+++ b/beszel/internal/users/users.go
@@ -2,9 +2,10 @@
 package users
 
 import (
-	"beszel/migrations"
 	"log"
 	"net/http"
+
+	"github.com/henrygd/beszel/migrations"
 
 	"github.com/pocketbase/pocketbase"
 	"github.com/pocketbase/pocketbase/core"


### PR DESCRIPTION
I've noticed that Beszel isn't currently installable using `go get`. This PR proposes renaming the Go module from `beszel` to `github.com/henrygd/beszel`. This would make it much easier for developers to use Beszel as a library within their own Go projects with a simple `go get github.com/henrygd/beszel`.
  
I've made the necessary changes, but I'm open to feedback and happy to refine them further.