### PR TITLE
Update add-system.tsx docker-compose.yml template.

### DIFF
--- a/beszel/site/src/components/add-system.tsx
+++ b/beszel/site/src/components/add-system.tsx
@@ -61,6 +61,7 @@ export const SystemDialog = memo(({ setOpen, system }: { setOpen: (open: boolean
 
 	function copyDockerCompose(port: string) {
 		copyToClipboard(`services:
+  version: "3"
   beszel-agent:
     image: "henrygd/beszel-agent"
     container_name: "beszel-agent"


### PR DESCRIPTION
Adding `version: "3"` makes this compatible with more recent docker tools.

Otherwise get error:

```
ERROR: The Compose file './docker-compose.yml' is invalid because:
Unsupported config option for services: 'beszel-agent'
```