### PR TITLE
add beszel-agent startup arguments

### DIFF
--- a/beszel/cmd/agent/agent.go
+++ b/beszel/cmd/agent/agent.go
@@ -3,6 +3,7 @@ package main
 import (
 	"beszel"
 	"beszel/internal/agent"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -10,26 +11,53 @@ import (
 )
 
 func main() {
+	// Define flags for key and port
+	keyFlag := flag.String("key", "", "Public key")
+	portFlag := flag.String("port", "45876", "Port number")
+
+	flag.Usage = func() {
+		fmt.Printf("Usage: %s [options] [subcommand]\n", os.Args[0])
+		fmt.Println("\nOptions:")
+		flag.PrintDefaults()
+		fmt.Println("\nSubcommands:")
+		fmt.Println("  version      Display the version")
+		fmt.Println("  help         Display this help message")
+		fmt.Println("  update       Update the agent to the latest version")
+	}
+
+	// Parse the flags
+	flag.Parse()
+
 	// handle flags / subcommands
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "-v":
+		case "version":
 			fmt.Println(beszel.AppName+"-agent", beszel.Version)
+			os.Exit(0)
+		case "help":
+			flag.Usage()
+			os.Exit(0)
 		case "update":
 			agent.Update()
+			os.Exit(0)
 		}
-		os.Exit(0)
 	}
 
-	// Try to get the key from the KEY environment variable.
-	key, _ := agent.GetEnv("KEY")
-	pubKey := []byte(key)
+	var pubKey []byte
+	// Override the key if the -key flag is provided
+	if *keyFlag != "" {
+		pubKey = []byte(*keyFlag)
+	} else {
+		// Try to get the key from the KEY environment variable.
+		key, _ := agent.GetEnv("KEY")
+		pubKey = []byte(key)
+	}
 
 	// If KEY is not set, try to read the key from the file specified by KEY_FILE.
 	if len(pubKey) == 0 {
 		keyFile, exists := agent.GetEnv("KEY_FILE")
 		if !exists {
-			log.Fatal("Must set KEY or KEY_FILE environment variable")
+			log.Fatal("Must set KEY or KEY_FILE environment variable or supply as input argument. Use 'beszel-agent help' for more information.")
 		}
 		var err error
 		pubKey, err = os.ReadFile(keyFile)
@@ -38,7 +66,10 @@ func main() {
 		}
 	}
 
-	addr := ":45876"
+	// Init with default port
+	addr := ":" + *portFlag
+	
+	//Use port from ENV if it exists
 	// TODO: change env var to ADDR
 	if portEnvVar, exists := agent.GetEnv("PORT"); exists {
 		// allow passing an address in the form of "127.0.0.1:45876"
@@ -46,6 +77,11 @@ func main() {
 			portEnvVar = ":" + portEnvVar
 		}
 		addr = portEnvVar
+	}
+
+	// Override the default and ENV port if the -port flag is provided and is non default
+	if *portFlag != "45876" {
+		addr = ":" + *portFlag
 	}
 
 	agent.NewAgent().Run(pubKey, addr)


### PR DESCRIPTION
I'm running the beszel-agent on Windows as a permanently running scheduled task in system context to avoid needing alternative programs like NSSM for running it in the background. As the Windows task scheduler provides support for supplying startup arguments I prefer to directly supply key and port via the commandline to be able to manage everything at one place.  

Changes:

* Added support for `-key` and `-port` flags to allow users to specify the public key and port number directly from the command line.
* Updated the usage information to provide a clear guide on available options and subcommands.
* Modified the logic to prioritize the `-key` flag over the `KEY` environment variable and the `-port` flag over the `PORT` environment variable.
* Enhanced error messaging to include instructions for using the `help` subcommand when the key is not provided.
* changed the version command to `version` instead of `-v` to allign with the other command like `help` and `update`