### PR TITLE
Publish Docker images to GitHub container registry

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -15,9 +15,27 @@ jobs:
           - image: henrygd/beszel
             context: ./beszel
             dockerfile: ./beszel/dockerfile_Hub
+            registry: docker.io
+            username_secret: DOCKERHUB_USERNAME
+            password_secret: DOCKERHUB_TOKEN
           - image: henrygd/beszel-agent
             context: ./beszel
             dockerfile: ./beszel/dockerfile_Agent
+            registry: docker.io
+            username_secret: DOCKERHUB_USERNAME
+            password_secret: DOCKERHUB_TOKEN
+          - image: ghcr.io/${{ github.repository }}/beszel
+            context: ./beszel
+            dockerfile: ./beszel/dockerfile_Hub
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password_secret: GITHUB_TOKEN
+          - image: ghcr.io/${{ github.repository }}/beszel-agent
+            context: ./beszel
+            dockerfile: ./beszel/dockerfile_Agent
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password_secret: GITHUB_TOKEN
     permissions:
       contents: read
       packages: write
@@ -57,8 +75,9 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ matrix.username || secrets[matrix.username_secret] }}
+          password: ${{ secrets[matrix.password_secret] }}
+          registry: ${{ matrix.registry }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action


### PR DESCRIPTION
This pull request proposes a change to publish the Docker images to the GitHub Container Registry (ghcr.io).  
According to the [Docker Hub documentation](https://docs.docker.com/docker-hub/usage/), unauthenticated pulls will be restricted to 10 pulls/h starting April 1, 2025. This limitation may be insufficient in environments with scheduled auto-update mechanisms for multiple containers.

The GitHub Container Registry is free for public repositories and does not appear to have an officially documented rate limit at this time.