### PR TITLE
Custom data support

### DIFF
--- a/beszel/site/src/components/charts/extra-data-chart.tsx
+++ b/beszel/site/src/components/charts/extra-data-chart.tsx
@@ -11,7 +11,7 @@ import {
 	chartMargin,
 } from "@/lib/utils"
 // import Spinner from '../spinner'
-import { ChartData, EDataConfig, EDataKey } from "@/types"
+import { ChartData, EDataConfig } from "@/types"
 import { memo, useMemo } from "react"
 import { useLingui } from "@lingui/react/macro"
 
@@ -19,12 +19,10 @@ import { useLingui } from "@lingui/react/macro"
 type DataKeys = [string, string, number, number]
 
 export default memo(function ExtraDataChart({
-	maxToggled = false,
 	eDataConfig,
 	chartData,
 	max,
 }: {
-	maxToggled?: boolean
 	eDataConfig: EDataConfig
 	chartData: ChartData
 	max?: number
@@ -32,15 +30,11 @@ export default memo(function ExtraDataChart({
 	const { yAxisWidth, updateYAxisWidth } = useYAxisWidth()
 	const { i18n } = useLingui()
 
-	const { chartTime } = chartData
-
-	const showMax = chartTime !== "1h" && maxToggled
-
 	const dataKeys: DataKeys[] = useMemo(() => {
 		// [label, key, color, opacity]
-		const dataKeysBuilder = []
-		for (const [key, value] of eDataConfig.keys) {
-			dataKeysBuilder.push([value.label, key, value.color, value.opacity])
+		const dataKeysBuilder: DataKeys[] = []
+		for (const [key, value] of Object.entries(eDataConfig.keys)) {
+			dataKeysBuilder.push([t`${value.label}`, key, value.color, value.opacity])
 		}
 		return dataKeysBuilder
 	}, [eDataConfig.name, i18n.locale])
@@ -68,7 +62,7 @@ export default memo(function ExtraDataChart({
 						domain={[0, max ?? "auto"]}
 						tickFormatter={(value) => {
 							const val = toFixedWithoutTrailingZeros(value, 2)
-							return updateYAxisWidth(val + unit)
+							return updateYAxisWidth(val + eDataConfig.unit)
 						}}
 						tickLine={false}
 						axisLine={false}
@@ -88,7 +82,7 @@ export default memo(function ExtraDataChart({
 					{dataKeys.map((key, i) => {
 						const color = `hsl(var(--chart-${key[2]}))`
 						return (
-							<Area
+							<Line
 								key={i}
 								dataKey={key[1]}
 								name={key[0]}

--- a/beszel/site/src/components/charts/extra-data-chart.tsx
+++ b/beszel/site/src/components/charts/extra-data-chart.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/core/macro"
 
-import { Line, LineChart, CartesianGrid, YAxis } from "recharts"
+import { Area, AreaChart, CartesianGrid, YAxis } from "recharts"
 import { ChartContainer, ChartTooltip, ChartTooltipContent, xAxis } from "@/components/ui/chart"
 import {
 	useYAxisWidth,
@@ -30,7 +30,7 @@ export default memo(function ExtraDataChart({
 	const { yAxisWidth, updateYAxisWidth } = useYAxisWidth()
 	const { i18n } = useLingui()
 
-	const dataKeys: DataKeys[] = useMemo(() => {
+	const dataKeys = useMemo(() => {
 		// [label, key, color, opacity]
 		const dataKeysBuilder: DataKeys[] = []
 		for (const [key, value] of Object.entries(eDataConfig.keys)) {
@@ -39,12 +39,10 @@ export default memo(function ExtraDataChart({
 		return dataKeysBuilder
 	}, [eDataConfig.name, i18n.locale])
 
-	// console.log('Rendered at', new Date())
-
 	if (chartData.systemStats.length === 0) {
 		return null
 	}
-
+	
 	return (
 		<div>
 			<ChartContainer
@@ -52,7 +50,7 @@ export default memo(function ExtraDataChart({
 					"opacity-100": yAxisWidth,
 				})}
 			>
-				<LineChart accessibilityLayer data={chartData.systemStats} margin={chartMargin}>
+				<AreaChart accessibilityLayer data={chartData.systemStats} margin={chartMargin}>
 					<CartesianGrid vertical={false} />
 					<YAxis
 						direction="ltr"
@@ -61,8 +59,8 @@ export default memo(function ExtraDataChart({
 						width={yAxisWidth}
 						domain={[0, max ?? "auto"]}
 						tickFormatter={(value) => {
-							const val = toFixedWithoutTrailingZeros(value, 2)
-							return updateYAxisWidth(val + eDataConfig.unit)
+							const val = toFixedWithoutTrailingZeros(value, 2) + eDataConfig.unit
+							return updateYAxisWidth(val)
 						}}
 						tickLine={false}
 						axisLine={false}
@@ -74,7 +72,9 @@ export default memo(function ExtraDataChart({
 						content={
 							<ChartTooltipContent
 								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
-								contentFormatter={(item) => decimalString(item) + eDataConfig.unit}
+								contentFormatter={({ value }) => {
+									return decimalString(value) + eDataConfig.unit
+								}}
 								// indicator="line"
 							/>
 						}
@@ -82,20 +82,20 @@ export default memo(function ExtraDataChart({
 					{dataKeys.map((key, i) => {
 						const color = `hsl(var(--chart-${key[2]}))`
 						return (
-							<Line
+							<Area
 								key={i}
-								dataKey={key[1]}
+								dataKey={`stats.eData.${key[1]}`}
 								name={key[0]}
 								type="monotoneX"
-								dot={false}
-								strokeWidth={1.5}
+								fill={color}
+								fillOpacity={key[3]}
 								stroke={color}
 								isAnimationActive={false}
 							/>
 						)
 					})}
 					{/* <ChartLegend content={<ChartLegendContent />} /> */}
-				</LineChart>
+				</AreaChart>
 			</ChartContainer>
 		</div>
 	)

--- a/beszel/site/src/components/charts/extra-data-chart.tsx
+++ b/beszel/site/src/components/charts/extra-data-chart.tsx
@@ -1,0 +1,108 @@
+import { t } from "@lingui/core/macro"
+
+import { Line, LineChart, CartesianGrid, YAxis } from "recharts"
+import { ChartContainer, ChartTooltip, ChartTooltipContent, xAxis } from "@/components/ui/chart"
+import {
+	useYAxisWidth,
+	cn,
+	formatShortDate,
+	toFixedWithoutTrailingZeros,
+	decimalString,
+	chartMargin,
+} from "@/lib/utils"
+// import Spinner from '../spinner'
+import { ChartData, EDataConfig, EDataKey } from "@/types"
+import { memo, useMemo } from "react"
+import { useLingui } from "@lingui/react/macro"
+
+/** [label, key, color, opacity] */
+type DataKeys = [string, string, number, number]
+
+export default memo(function ExtraDataChart({
+	maxToggled = false,
+	eDataConfig,
+	chartData,
+	max,
+}: {
+	maxToggled?: boolean
+	eDataConfig: EDataConfig
+	chartData: ChartData
+	max?: number
+}) {
+	const { yAxisWidth, updateYAxisWidth } = useYAxisWidth()
+	const { i18n } = useLingui()
+
+	const { chartTime } = chartData
+
+	const showMax = chartTime !== "1h" && maxToggled
+
+	const dataKeys: DataKeys[] = useMemo(() => {
+		// [label, key, color, opacity]
+		const dataKeysBuilder = []
+		for (const [key, value] of eDataConfig.keys) {
+			dataKeysBuilder.push([value.label, key, value.color, value.opacity])
+		}
+		return dataKeysBuilder
+	}, [eDataConfig.name, i18n.locale])
+
+	// console.log('Rendered at', new Date())
+
+	if (chartData.systemStats.length === 0) {
+		return null
+	}
+
+	return (
+		<div>
+			<ChartContainer
+				className={cn("h-full w-full absolute aspect-auto bg-card opacity-0 transition-opacity", {
+					"opacity-100": yAxisWidth,
+				})}
+			>
+				<LineChart accessibilityLayer data={chartData.systemStats} margin={chartMargin}>
+					<CartesianGrid vertical={false} />
+					<YAxis
+						direction="ltr"
+						orientation={chartData.orientation}
+						className="tracking-tighter"
+						width={yAxisWidth}
+						domain={[0, max ?? "auto"]}
+						tickFormatter={(value) => {
+							const val = toFixedWithoutTrailingZeros(value, 2)
+							return updateYAxisWidth(val + unit)
+						}}
+						tickLine={false}
+						axisLine={false}
+					/>
+					{xAxis(chartData)}
+					<ChartTooltip
+						animationEasing="ease-out"
+						animationDuration={150}
+						content={
+							<ChartTooltipContent
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								contentFormatter={(item) => decimalString(item) + eDataConfig.unit}
+								// indicator="line"
+							/>
+						}
+					/>
+					{dataKeys.map((key, i) => {
+						const color = `hsl(var(--chart-${key[2]}))`
+						return (
+							<Area
+								key={i}
+								dataKey={key[1]}
+								name={key[0]}
+								type="monotoneX"
+								dot={false}
+								strokeWidth={1.5}
+								stroke={color}
+								isAnimationActive={false}
+							/>
+						)
+					})}
+					{/* <ChartLegend content={<ChartLegendContent />} /> */}
+				</LineChart>
+			</ChartContainer>
+		</div>
+	)
+})

--- a/beszel/site/src/components/routes/system.tsx
+++ b/beszel/site/src/components/routes/system.tsx
@@ -678,7 +678,7 @@ export default function SystemDetail({ name }: { name: string }) {
 								description={t`${eDataConf.description}`}
 								cornerEl={maxValSelect}
 							>
-								<ExtraDataChart maxToggled={maxValues} />
+								<ExtraDataChart eDataConfig={eDataConfig} chartData={chartData} maxToggled={maxValues} />
 							</ChartCard>
 						)
 					})}

--- a/beszel/site/src/components/routes/system.tsx
+++ b/beszel/site/src/components/routes/system.tsx
@@ -131,6 +131,7 @@ export default function SystemDetail({ name }: { name: string }) {
 	const [bottomSpacing, setBottomSpacing] = useState(0)
 	const [chartLoading, setChartLoading] = useState(true)
 	const isLongerChart = chartTime !== "1h"
+	conts 
 
 	useEffect(() => {
 		document.title = `${name} / Beszel`
@@ -145,6 +146,10 @@ export default function SystemDetail({ name }: { name: string }) {
 			$containerFilter.set("")
 		}
 	}, [name])
+
+	useEffect(() => {
+
+	}, 
 
 	// function resetCharts() {
 	// 	setSystemStats([])
@@ -659,6 +664,24 @@ export default function SystemDetail({ name }: { name: string }) {
 							)
 						})}
 					</div>
+				)}
+
+				{/* extra data charts */}
+				{Object.keys(system.eDataConfigs ?? {}).length > 0 && (
+					{Object.keys(system.eDataConfigs ?? {}).map((key) => {
+						const eDataConf = system.eDataConfigs[key]
+						return (
+							<ChartCard
+								empty={dataEmpty}
+								grid={grid}
+								title={`${eDataConf.title}`}
+								description={t`${eDataConf.description}`}
+								cornerEl={maxValSelect}
+							>
+								<ExtraDataChart maxToggled={maxValues} />
+							</ChartCard>
+						)
+					})}
 				)}
 			</div>
 

--- a/beszel/site/src/components/routes/system.tsx
+++ b/beszel/site/src/components/routes/system.tsx
@@ -131,7 +131,6 @@ export default function SystemDetail({ name }: { name: string }) {
 	const [bottomSpacing, setBottomSpacing] = useState(0)
 	const [chartLoading, setChartLoading] = useState(true)
 	const isLongerChart = chartTime !== "1h"
-	conts 
 
 	useEffect(() => {
 		document.title = `${name} / Beszel`
@@ -146,10 +145,6 @@ export default function SystemDetail({ name }: { name: string }) {
 			$containerFilter.set("")
 		}
 	}, [name])
-
-	useEffect(() => {
-
-	}, 
 
 	// function resetCharts() {
 	// 	setSystemStats([])

--- a/beszel/site/src/components/routes/system.tsx
+++ b/beszel/site/src/components/routes/system.tsx
@@ -47,6 +47,7 @@ const DiskChart = lazy(() => import("../charts/disk-chart"))
 const SwapChart = lazy(() => import("../charts/swap-chart"))
 const TemperatureChart = lazy(() => import("../charts/temperature-chart"))
 const GpuPowerChart = lazy(() => import("../charts/gpu-power-chart"))
+const ExtraDataChart = lazy(() => import("../charts/extra-data-chart"))
 
 const cache = new Map<string, any>()
 
@@ -662,22 +663,19 @@ export default function SystemDetail({ name }: { name: string }) {
 				)}
 
 				{/* extra data charts */}
-				{Object.keys(system.eDataConfigs ?? {}).length > 0 && (
-					{Object.keys(system.eDataConfigs ?? {}).map((key) => {
-						const eDataConf = system.eDataConfigs[key]
-						return (
-							<ChartCard
-								empty={dataEmpty}
-								grid={grid}
-								title={`${eDataConf.title}`}
-								description={t`${eDataConf.description}`}
-								cornerEl={maxValSelect}
-							>
-								<ExtraDataChart eDataConfig={eDataConfig} chartData={chartData} maxToggled={maxValues} />
-							</ChartCard>
-						)
-					})}
-				)}
+				<div className="grid xl:grid-cols-2 gap-4">
+					<div key={"bat"} className="contents">
+						<ChartCard
+							empty={dataEmpty}
+							grid={grid}
+							title={`Battery`}
+							description={t`Battery Charge`}
+							cornerEl={maxValSelect}
+						>
+							<ExtraDataChart eDataConfig={{name:'bat', title:'Battery', description:'Battery Charge', unit:'%', keys:{bat:{label:'Charge', color:1, opacity:0.5}}}} chartData={chartData} />
+						</ChartCard>
+					</div>
+				</div>
 			</div>
 
 			{/* add space for tooltip if more than 12 containers */}

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -16,6 +16,7 @@ export interface SystemRecord extends RecordModel {
 	port: string
 	info: SystemInfo
 	v: string
+	eDataConfigs: Record<string, EDataConfig>
 }
 
 export interface SystemInfo {
@@ -100,6 +101,8 @@ export interface SystemStats {
 	efs?: Record<string, ExtraFsStats>
 	/** GPU data */
 	g?: Record<string, GPUData>
+	/** extra data */
+	edata?: Record<string, number>
 }
 
 export interface GPUData {
@@ -175,6 +178,20 @@ export interface ChartTimeData {
 		format: (timestamp: string) => string
 		getOffset: (endTime: Date) => Date
 	}
+}
+
+/** External Data Config - For using custom data */
+export type EDataConfig = {
+	title: string
+	description: string
+	keys: Record<string, EDataKey>
+}
+
+export type EDataKey = {
+	unit: string
+	label: string
+	color: number
+	opacity: number
 }
 
 export type UserSettings = {

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -180,15 +180,16 @@ export interface ChartTimeData {
 }
 
 /** External Data Config - For using custom data */
-export type EDataConfig = {
+export interface ExtraDataConfig extends RecordModel {
+	systemId: string
 	name: string
 	title: string
 	description: string
 	unit: string
-	keys: Record<string, EDataKey>
+	keys: Record<string, ExtraDataKey>
 }
 
-export type EDataKey = {
+export type ExtraDataKey = {
 	label: string
 	color: number
 	opacity: number

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -182,13 +182,14 @@ export interface ChartTimeData {
 
 /** External Data Config - For using custom data */
 export type EDataConfig = {
+	name: string
 	title: string
 	description: string
+	unit: string
 	keys: Record<string, EDataKey>
 }
 
 export type EDataKey = {
-	unit: string
 	label: string
 	color: number
 	opacity: number

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -16,7 +16,6 @@ export interface SystemRecord extends RecordModel {
 	port: string
 	info: SystemInfo
 	v: string
-	eDataConfigs: Record<string, EDataConfig>
 }
 
 export interface SystemInfo {
@@ -102,7 +101,7 @@ export interface SystemStats {
 	/** GPU data */
 	g?: Record<string, GPUData>
 	/** extra data */
-	edata?: Record<string, number>
+	eData?: Record<string, number>
 }
 
 export interface GPUData {


### PR DESCRIPTION
This is a work in progress!

# Description

Adds support for arbitrary numeric data in the form of "extra data" (`eData`). The functionality is as follows

1) Store the extra data in `system_stats.stats.eData` as a key-value pair. This is easily done by watching for new records and updating them.
2) Create a record under the `extra_data_configs` collection. Each record is 1 chart for 1 system. Depending on the parameters, we can display several different extra variables on the chart. 

We can utilize the Pocketbase API to add what we want using a separate process. This way, minimal changes have to be made to Beszel's code and the system is easily modifiable. 

# Battery Charge Example

[beszel_bat.mjs](https://github.com/pitbox46/beszel-extra-agent/blob/main/beszel_bat.mjs)
<img src="https://github.com/user-attachments/assets/0c6bc47b-841b-4571-a9e3-a28560444080" width="50%" />
(I have the laptop to keep the battery at ~80%, so I expect the graph to be flat)

# Todo 

- [ ]  Implement the `extra_data_configs` collection in Beszel (unsure how how to do this)
- [x] Add example battery charge example
- [ ] Documentation