### PR TITLE
Add docker support in Debian package

### DIFF
--- a/supplemental/debian/postinstall.sh
+++ b/supplemental/debian/postinstall.sh
@@ -31,6 +31,12 @@ if ! getent passwd "$SERVICE_USER" >/dev/null; then
 		--gecos "System user for $SERVICE"
 fi
 
+# Enable docker
+if ! getent group docker | grep -q "$SERVICE_USER"; then
+	echo "Adding $SERVICE_USER to docker group"
+	usermod -aG docker "$SERVICE_USER"
+fi
+
 # Create config file if it doesn't already exist
 if [ ! -f "$CONFIG_FILE" ]; then
 	touch "$CONFIG_FILE"


### PR DESCRIPTION
Enable docker in the Debian package to match the main install script

# Testing

Upgrade

```
dpkg: warning: downgrading beszel-agent (0.11.1) to (0.0.0~SNAPSHOT-b05966d)
(Reading database ... 118364 files and directories currently installed.)
Preparing to unpack beszel-agent_0.0.0-SNAPSHOT-b05966d_linux_amd64.deb ...
Unpacking beszel-agent (0.0.0~SNAPSHOT-b05966d) over (0.11.1) ...
Setting up beszel-agent (0.0.0~SNAPSHOT-b05966d) ...
Adding beszel to docker group
```

```
$ grep docker /etc/group
docker:x:987:beszel
```

On fresh install without docker, doesn't add

```
Unpacking beszel-agent (0.0.0~SNAPSHOT-b05966d) ...
Setting up beszel-agent (0.0.0~SNAPSHOT-b05966d) ...
Creating beszel group
Creating beszel user
Created symlink '/etc/systemd/system/multi-user.target.wants/beszel-agent.service' → '/usr/lib/systemd/system/beszel-agent.service'.
```