### PR TITLE
Create service user as system user

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -317,14 +317,14 @@ fi
 if is_alpine; then
   if ! id -u beszel >/dev/null 2>&1; then
     echo "Creating a dedicated user for the Beszel Agent service..."
-    adduser -D -H -s /sbin/nologin beszel
+    adduser -S -D -H -s /sbin/nologin beszel
   fi
   # Add the user to the docker group to allow access to the Docker socket
   addgroup beszel docker
 else
   if ! id -u beszel >/dev/null 2>&1; then
     echo "Creating a dedicated user for the Beszel Agent service..."
-    useradd -M -s /bin/false beszel
+    useradd --system --home-dir /nonexistent --shell /bin/false beszel
   fi
   # Add the user to the docker group to allow access to the Docker socket
   usermod -aG docker beszel


### PR DESCRIPTION
This clearly marks the account as a "service account" to the administrator. Additionally, it's hidden from desktop login managers.

I used long options where possible, since that makes the script easier to read to viewers who aren't familiar with the called tools. Since the useradd used is from `shadow-utils` on all distros except Alpine (where busybox's adduser is used), these options should be available everywhere.

I was thinking about using systemd's `DynamicUser` feature, but wasn't sure if the user isn't used for permission management, so I left this out for now.

Using `/nonexistent` is a marker used in Debian to clearly signal the system administrator that the home directory is missing on purpose.