### PR TITLE
fix(install): suppress scoop output to avoid nssm path pollution (related to #915)

### DIFF
--- a/supplemental/scripts/install-agent.ps1
+++ b/supplemental/scripts/install-agent.ps1
@@ -182,7 +182,7 @@ function Install-BeszelAgentWithScoop {
     scoop bucket add beszel https://github.com/henrygd/beszel-scoops | Out-Null
     
     Write-Host "Installing / updating beszel-agent..."
-    scoop install beszel-agent
+    scoop install beszel-agent | Out-Null
     
     if (-not (Test-CommandExists "beszel-agent")) {
         throw "Failed to install beszel-agent"


### PR DESCRIPTION
- This PR fixes an issue related to #915.

- Suppressed the output of “scoop install beszel-agent” so that the service path contains only the executable location, preventing NSSM from storing the install message.

### Problem Screenshot

![problem-screentshot](https://github.com/user-attachments/assets/61e24f67-b956-4640-8ca5-0d1a34f02e0a)

### Environment

- ❌ Problem occurred on: **Windows Server 2019 Standard**
- ✅ Issue resolved and verified on: **Windows Server 2019 Standard**
