### PR TITLE
add GITHUB_TOKEN fallback to run goreleaser in forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,4 @@ jobs:
           version: latest
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Occasionally, I test new versions of Beszel before they are officially released. For convenience, I usually just set a tag on a commit in the main branch of my fork, which automatically triggers the GoReleaser workflow to build new binaries.

Since forks typically do not have any secrets configured (and don’t require them for simply building binaries without actually releasing them) I have added a fallback for the GitHub token in the workflow. This change allows the workflow to run in a fork without any additional configuration.  
The actual release steps (publishing to winget, Homebrew, Scoop, etc.) will still fail in this setup, but that’s expected and doesn’t matter for this use case. A draft release containing the binaries is still created in the fork repository before any attempts to publish to external repositories are made.