### PR TITLE
[Feature] Add Uptime and status dorpdown to Dashboard

### DIFF
--- a/beszel/site/src/locales/ar/ar.po
+++ b/beszel/site/src/locales/ar/ar.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# يوم} other {# أيام}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# ساعة} other {# ساعات}}"
@@ -93,6 +96,7 @@ msgstr "وكيل"
 msgid "Alerts"
 msgstr "التنبيهات"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "التوثيق"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "إيقاف مؤقت"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "متوقف مؤقتًا"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "الترتيب حسب"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "الحالة"
 
@@ -809,6 +820,7 @@ msgstr "يتم التفعيل عندما يتجاوز استخدام أي قرص
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "قيد التشغيل"
@@ -817,6 +829,7 @@ msgstr "قيد التشغيل"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "محدث في الوقت الحقيقي. انقر على نظام لعرض المعلومات."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "مدة التشغيل"

--- a/beszel/site/src/locales/bg/bg.po
+++ b/beszel/site/src/locales/bg/bg.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# ден} other {# дни}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# час} other {# часа}}"
@@ -93,6 +96,7 @@ msgstr "Агент"
 msgid "Alerts"
 msgstr "Тревоги"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Документация"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Пауза"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "На пауза"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Сортиране по"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Статус"
 
@@ -809,6 +820,7 @@ msgstr "Задейства се, когато употребата на няко
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Актуализира се в реално време. Натисни на система за да видиш информация."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Време на работа"

--- a/beszel/site/src/locales/cs/cs.po
+++ b/beszel/site/src/locales/cs/cs.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# den} few {# dny} other {# dní}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# Hodina} few {# Hodiny} many {# Hodin} other {# Hodin}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Výstrahy"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentace"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pozastavit"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pozastaveno"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Seřadit podle"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Stav"
 
@@ -809,6 +820,7 @@ msgstr "Spustí se, když využití disku překročí prahovou hodnotu"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Funkční"
@@ -817,6 +829,7 @@ msgstr "Funkční"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Aktualizováno v reálném čase. Klepnutím na systém zobrazíte informace."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Doba provozu"

--- a/beszel/site/src/locales/da/da.po
+++ b/beszel/site/src/locales/da/da.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# day} other {# days}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# hour} other {# hours}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Alarmer"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentation"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pause"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Sat på pause"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sorter efter"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Udløser når brugen af en disk overstiger en tærskel"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Opdateret i realtid. Klik på et system for at se information."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Oppetid"

--- a/beszel/site/src/locales/de/de.po
+++ b/beszel/site/src/locales/de/de.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# Tag} other {# Tage}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# Stunde} other {# Stunden}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Warnungen"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentation"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pause"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pausiert"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr "Ausstehend"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sortieren nach"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Löst aus, wenn die Nutzung einer Festplatte einen Schwellenwert übersc
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "In Echtzeit aktualisiert. Klicke auf ein System, um Informationen anzuzeigen."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Betriebszeit"

--- a/beszel/site/src/locales/en/en.po
+++ b/beszel/site/src/locales/en/en.po
@@ -13,11 +13,14 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# day} other {# days}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# hour} other {# hours}}"
@@ -88,6 +91,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Alerts"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -297,6 +301,7 @@ msgstr "Documentation"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -557,8 +562,13 @@ msgid "Pause"
 msgstr "Pause"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Paused"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr "Pending"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -689,6 +699,7 @@ msgid "Sort By"
 msgstr "Sort By"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -804,6 +815,7 @@ msgstr "Triggers when usage of any disk exceeds a threshold"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Up"
@@ -812,6 +824,7 @@ msgstr "Up"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Updated in real time. Click on a system to view information."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Uptime"

--- a/beszel/site/src/locales/es/es.po
+++ b/beszel/site/src/locales/es/es.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# día} other {# días}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# hora} other {# horas}}"
@@ -93,6 +96,7 @@ msgstr "Agente"
 msgid "Alerts"
 msgstr "Alertas"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Documentación"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pausar"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pausado"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr "Pendiente"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Ordenar por"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Estado"
 
@@ -809,6 +820,7 @@ msgstr "Se activa cuando el uso de cualquier disco supera un umbral"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Activo"
@@ -817,6 +829,7 @@ msgstr "Activo"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Actualizado en tiempo real. Haga clic en un sistema para ver la información."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Tiempo de actividad"

--- a/beszel/site/src/locales/fa/fa.po
+++ b/beszel/site/src/locales/fa/fa.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# روز} other {# روز}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# ساعت} other {# ساعت}}"
@@ -93,6 +96,7 @@ msgstr "عامل"
 msgid "Alerts"
 msgstr "هشدارها"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "مستندات"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "توقف"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "مکث شده"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "مرتب‌سازی بر اساس"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "وضعیت"
 
@@ -809,6 +820,7 @@ msgstr "هنگامی که استفاده از هر دیسکی از یک آستا
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "به صورت لحظه‌ای به‌روزرسانی می‌شود. برای مشاهده اطلاعات، روی یک سیستم کلیک کنید."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "آپتایم"

--- a/beszel/site/src/locales/fr/fr.po
+++ b/beszel/site/src/locales/fr/fr.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# jour} other {# jours}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# heure} other {# heures}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Alertes"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Documentation"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -559,11 +564,16 @@ msgstr "Demande de réinitialisation du mot de passe reçue"
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Pause"
-msgstr "En pause"
+msgstr ""
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "En pause"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr "En attente"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Trier par"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Statut"
 
@@ -809,6 +820,7 @@ msgstr "Déclenchement lorsque l'utilisation de tout disque dépasse un seuil"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Joignable"
@@ -817,6 +829,7 @@ msgstr "Joignable"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Mis à jour en temps réel. Cliquez sur un système pour voir les informations."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Temps de fonctionnement"

--- a/beszel/site/src/locales/hr/hr.po
+++ b/beszel/site/src/locales/hr/hr.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dan} other {# dani}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# sat} other {# sati}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Upozorenja"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentacija"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pauza"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pauzirano"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sortiraj po"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Pokreće se kada iskorištenost bilo kojeg diska premaši prag"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Ažurirano odmah. Kliknite na sistem za više informacija."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Vrijeme rada"

--- a/beszel/site/src/locales/hu/hu.po
+++ b/beszel/site/src/locales/hu/hu.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# nap} other {# nap}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# óra} other {# óra}}"
@@ -93,6 +96,7 @@ msgstr "Ügynök"
 msgid "Alerts"
 msgstr "Riasztások"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentáció"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Szüneteltetés"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Szüneteltetve"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Rendezés"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Állapot"
 
@@ -809,6 +820,7 @@ msgstr "Bekapcsol, ha a lemez érzékelő túllép egy küszöbértéket"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Valós időben frissítve. Kattintson egy rendszerre az információk megtekintéséhez."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Üzemidő"

--- a/beszel/site/src/locales/is/is.po
+++ b/beszel/site/src/locales/is/is.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dagur} other {# dagar}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# klukkustund} other {# klukkustundir}}"
@@ -93,6 +96,7 @@ msgstr ""
 msgid "Alerts"
 msgstr "Tilkynningar"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Skjal"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pása"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Í bið"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Raða eftir"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Staða"
 
@@ -809,6 +820,7 @@ msgstr "Virkjast þegar diska notkun fer yfir þröskuld"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Uppfærist í rauntíma. Veldu kerfi til að skoða upplýsingar."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr ""

--- a/beszel/site/src/locales/it/it.po
+++ b/beszel/site/src/locales/it/it.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# giorno} other {# giorni}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# ora} other {# ore}}"
@@ -93,6 +96,7 @@ msgstr "Agente"
 msgid "Alerts"
 msgstr "Avvisi"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Documentazione"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pausa"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "In pausa"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Ordina per"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Stato"
 
@@ -809,6 +820,7 @@ msgstr "Attiva quando l'utilizzo di un disco supera una soglia"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Attivo"
@@ -817,6 +829,7 @@ msgstr "Attivo"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Aggiornato in tempo reale. Clicca su un sistema per visualizzare le informazioni."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Tempo di attività"

--- a/beszel/site/src/locales/ja/ja.po
+++ b/beszel/site/src/locales/ja/ja.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# 日} other {# 日}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# 時間} other {# 時間}}"
@@ -93,6 +96,7 @@ msgstr "エージェント"
 msgid "Alerts"
 msgstr "アラート"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "ドキュメント"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "一時停止"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "一時停止中"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "並び替え基準"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "ステータス"
 
@@ -809,6 +820,7 @@ msgstr "ディスクの使用量がしきい値を超えたときにトリガー
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "正常"
@@ -817,6 +829,7 @@ msgstr "正常"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "リアルタイムで更新されます。システムをクリックして情報を表示します。"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "稼働時間"

--- a/beszel/site/src/locales/ko/ko.po
+++ b/beszel/site/src/locales/ko/ko.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# 일} other {# 일}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# 시간} other {# 시간}}"
@@ -93,6 +96,7 @@ msgstr "에이전트"
 msgid "Alerts"
 msgstr "알림"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "문서"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "일시 중지"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "일시정지됨"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "정렬 기준"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "상태"
 
@@ -809,6 +820,7 @@ msgstr "디스크 사용량이 임계값을 초과할 때 트리거됩니다."
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "온라인"
@@ -817,6 +829,7 @@ msgstr "온라인"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "실시간으로 업데이트됩니다. 시스템을 클릭하여 정보를 확인하세요."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "가동 시간"

--- a/beszel/site/src/locales/nl/nl.po
+++ b/beszel/site/src/locales/nl/nl.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dag} other {# dagen}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# uur} other {# uren}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Waarschuwingen"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Documentatie"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pauze"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Gepauzeerd"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sorteren op"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Triggert wanneer het gebruik van een schijf een drempelwaarde overschrij
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Online"
@@ -817,6 +829,7 @@ msgstr "Online"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "In realtime bijgewerkt. Klik op een systeem om informatie te bekijken."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Actief"

--- a/beszel/site/src/locales/no/no.po
+++ b/beszel/site/src/locales/no/no.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dag} other {# dager}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# time} other {# timer}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Alarmer"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentasjon"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pause"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pauset"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sorter Etter"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Slår inn når forbruk av hvilken som helst disk overstiger en grensever
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Oppe"
@@ -817,6 +829,7 @@ msgstr "Oppe"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Oppdatert i sanntid. Klikk på et system for å se mer informasjon."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Oppetid"

--- a/beszel/site/src/locales/pl/pl.po
+++ b/beszel/site/src/locales/pl/pl.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dzień} few {# dni} many {# dni} other {# dni}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {godzinę} few {# godziny} many {# godzin} other {# godziny}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Alerty"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentacja"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pauza"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Wstrzymane"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sortuj według"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Wyzwalane, gdy wykorzystanie któregokolwiek dysku przekroczy ustalony p
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Aktualizowane w czasie rzeczywistym. Kliknij system, aby zobaczyć informacje."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Czas pracy"

--- a/beszel/site/src/locales/pt/pt.po
+++ b/beszel/site/src/locales/pt/pt.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dia} other {# dias}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# hora} other {# horas}}"
@@ -93,6 +96,7 @@ msgstr "Agente"
 msgid "Alerts"
 msgstr "Alertas"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Documentação"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Pausar"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pausado"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Ordenar Por"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Dispara quando o uso de qualquer disco excede um limite"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Atualizado em tempo real. Clique em um sistema para ver informações."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Tempo de Atividade"

--- a/beszel/site/src/locales/ru/ru.po
+++ b/beszel/site/src/locales/ru/ru.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# день} other {# дней}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# час} other {# часов}}"
@@ -93,6 +96,7 @@ msgstr "Агент"
 msgid "Alerts"
 msgstr "Оповещения"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Документация"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Пауза"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Приостановлено"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Сортировать по"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Статус"
 
@@ -809,6 +820,7 @@ msgstr "Срабатывает, когда использование любог
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "В сети"
@@ -817,6 +829,7 @@ msgstr "В сети"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Обновляется в реальном времени. Нажмите на систему, чтобы просмотреть информацию."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Время работы"

--- a/beszel/site/src/locales/sl/sl.po
+++ b/beszel/site/src/locales/sl/sl.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dan} two {# dneva} few {# dni} other {# dni}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# ura} two {# uri} few {# ur} other {# ur}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Opozorila"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentacija"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Premor"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Zaustavljeno"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Razvrsti po"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Sproži se, ko uporaba katerega koli diska preseže prag"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Posodobljeno v realnem času. Za ogled informacij kliknite na sistem."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Čas delovanja"

--- a/beszel/site/src/locales/sv/sv.po
+++ b/beszel/site/src/locales/sv/sv.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# dag} other {# dagar}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# timme} other {# timmar}}"
@@ -93,6 +96,7 @@ msgstr "Agent"
 msgid "Alerts"
 msgstr "Larm"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokumentation"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Paus"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Pausad"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sortera efter"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Status"
 
@@ -809,6 +820,7 @@ msgstr "Utlöses när användningen av någon disk överskrider ett tröskelvär
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Uppdateras i realtid. Klicka på ett system för att visa information."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Drifttid"

--- a/beszel/site/src/locales/tr/tr.po
+++ b/beszel/site/src/locales/tr/tr.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# gün} other {# gün}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# saat} other {# saat}}"
@@ -93,6 +96,7 @@ msgstr "Aracı"
 msgid "Alerts"
 msgstr "Uyarılar"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Dokümantasyon"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Duraklat"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Duraklatıldı"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sıralama Ölçütü"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Durum"
 
@@ -809,6 +820,7 @@ msgstr "Herhangi bir diskin kullanımı bir eşiği aştığında tetiklenir"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Gerçek zamanlı olarak güncellenir. Bilgileri görüntülemek için bir sisteme tıklayın."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Çalışma Süresi"

--- a/beszel/site/src/locales/uk/uk.po
+++ b/beszel/site/src/locales/uk/uk.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# день} few {# дні} many {# днів} other {# дня}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# година} few {# години} many {# годин} other {# години}}"
@@ -93,6 +96,7 @@ msgstr "Агент"
 msgid "Alerts"
 msgstr "Сповіщення"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Документація"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "Призупинити"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "Призупинено"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Сортувати за"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Статус"
 
@@ -809,6 +820,7 @@ msgstr "Спрацьовує, коли використання будь-яко�
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "Працює"
@@ -817,6 +829,7 @@ msgstr "Працює"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Оновлюється в реальному часі. Натисніть на систему, щоб переглянути інформацію."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Час роботи"

--- a/beszel/site/src/locales/vi/vi.po
+++ b/beszel/site/src/locales/vi/vi.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# ngày} other {# ngày}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# giờ} other {# giờ}}"
@@ -93,6 +96,7 @@ msgstr "Tác nhân"
 msgid "Alerts"
 msgstr "Cảnh báo"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "Tài liệu"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,7 +567,12 @@ msgid "Pause"
 msgstr "Tạm dừng"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
+msgstr ""
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
 msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "Sắp xếp theo"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "Trạng thái"
 
@@ -809,6 +820,7 @@ msgstr "Kích hoạt khi sử dụng bất kỳ đĩa nào vượt quá ngưỡn
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "Cập nhật theo thời gian thực. Nhấp vào một hệ thống để xem thông tin."
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "Thời gian hoạt động"

--- a/beszel/site/src/locales/zh-CN/zh-CN.po
+++ b/beszel/site/src/locales/zh-CN/zh-CN.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# 天} other {# 天}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# 小时} other {# 小时}}"
@@ -93,6 +96,7 @@ msgstr "客户端"
 msgid "Alerts"
 msgstr "警报"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "文档"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "暂停"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "已暂停"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "排序依据"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "状态"
 
@@ -809,6 +820,7 @@ msgstr "当任何磁盘的使用率超过阈值时触发"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr "启动"
@@ -817,6 +829,7 @@ msgstr "启动"
 msgid "Updated in real time. Click on a system to view information."
 msgstr "实时更新。点击系统查看信息。"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "正常运行时间"

--- a/beszel/site/src/locales/zh-HK/zh-HK.po
+++ b/beszel/site/src/locales/zh-HK/zh-HK.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# 天} other {# 天}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# 小時} other {# 小時}}"
@@ -93,6 +96,7 @@ msgstr "客户端"
 msgid "Alerts"
 msgstr "警報"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "文件"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "暫停"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "已暫停"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "排序依據"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "狀態"
 
@@ -809,6 +820,7 @@ msgstr "當任何磁碟的使用超過閾值時觸發"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "實時更新。點擊系統查看信息。"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "正常運行時間"

--- a/beszel/site/src/locales/zh/zh.po
+++ b/beszel/site/src/locales/zh/zh.po
@@ -18,11 +18,14 @@ msgstr ""
 "X-Crowdin-File: /main/beszel/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 16\n"
 
+#. placeholder {0}: Math.trunc(uptime / 86400)
 #. placeholder {0}: Math.trunc(system.info?.u / 86400)
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{0, plural, one {# day} other {# days}}"
 msgstr "{0, plural, one {# 天} other {# 天}}"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "{hours, plural, one {# hour} other {# hours}}"
 msgstr "{hours, plural, one {# 小時} other {# 小時}}"
@@ -93,6 +96,7 @@ msgstr "代理"
 msgid "Alerts"
 msgstr "警報"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/alerts/alert-button.tsx
 msgid "All Systems"
@@ -302,6 +306,7 @@ msgstr "文件"
 
 #. Context: System is down
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 #: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Down"
@@ -562,8 +567,13 @@ msgid "Pause"
 msgstr "暫停"
 
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 msgid "Paused"
 msgstr "已暂停"
+
+#: src/components/systems-table/systems-table.tsx
+msgid "Pending"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -694,6 +704,7 @@ msgid "Sort By"
 msgstr "排序"
 
 #: src/lib/utils.ts
+#: src/components/systems-table/systems-table.tsx
 msgid "Status"
 msgstr "狀態"
 
@@ -809,6 +820,7 @@ msgstr "當任何磁碟使用率超過閾值時觸發"
 
 #. Context: System is up
 #: src/components/systems-table/systems-table.tsx
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Up"
 msgstr ""
@@ -817,6 +829,7 @@ msgstr ""
 msgid "Updated in real time. Click on a system to view information."
 msgstr "實時更新。點擊系統顯示資訊。"
 
+#: src/components/systems-table/systems-table.tsx
 #: src/components/routes/system.tsx
 msgid "Uptime"
 msgstr "運行時間"


### PR DESCRIPTION
This PR adds system uptime to the Dashboard and introduces a dropdown filter to view systems by status: Up, Down, or Paused.

closes https://github.com/henrygd/beszel/issues/612
closes https://github.com/henrygd/beszel/issues/791
<img width="1439" alt="Scherm­afbeelding 2025-06-27 om 00 17 36" src="https://github.com/user-attachments/assets/44c02f60-1bc3-4ada-bc8a-9823d83817b6" />
