### PR TITLE
[Feature] Collect the OS and CPU Architecture 

### DIFF
--- a/beszel/internal/agent/agent.go
+++ b/beszel/internal/agent/agent.go
@@ -22,7 +22,7 @@ type Agent struct {
 	netIoStats    system.NetIoStats          // Keeps track of bandwidth usage
 	dockerManager *dockerManager             // Manages Docker API requests
 	sensorConfig  *SensorConfig              // Sensors config
-	systemInfo    system.Info                // Host system info
+	SystemInfo    system.Info                // Host system info
 	gpuManager    *GPUManager                // Manages GPU data
 	cache         *SessionCache              // Cache for system stats based on primary session ID
 }
@@ -91,7 +91,7 @@ func (a *Agent) gatherStats(sessionID string) *system.CombinedData {
 
 	*cachedData = system.CombinedData{
 		Stats: a.getSystemStats(),
-		Info:  a.systemInfo,
+		Info:  a.SystemInfo,
 	}
 	slog.Debug("System stats", "data", cachedData)
 

--- a/beszel/internal/agent/docker.go
+++ b/beszel/internal/agent/docker.go
@@ -294,7 +294,7 @@ func newDockerManager(a *Agent) *dockerManager {
 
 	// If using podman, return client
 	if strings.Contains(dockerHost, "podman") {
-		a.systemInfo.Podman = true
+		a.SystemInfo.Podman = true
 		manager.goodDockerVersion = true
 		return manager
 	}

--- a/beszel/internal/agent/sensors.go
+++ b/beszel/internal/agent/sensors.go
@@ -80,7 +80,7 @@ func (a *Agent) updateTemperatures(systemStats *system.Stats) {
 	}
 
 	// reset high temp
-	a.systemInfo.DashboardTemp = 0
+	a.SystemInfo.DashboardTemp = 0
 
 	temps, err := a.getTempsWithPanicRecovery(sensors.TemperaturesWithContext)
 	if err != nil {
@@ -123,9 +123,9 @@ func (a *Agent) updateTemperatures(systemStats *system.Stats) {
 		// set dashboard temperature
 		switch a.sensorConfig.primarySensor {
 		case "":
-			a.systemInfo.DashboardTemp = max(a.systemInfo.DashboardTemp, sensor.Temperature)
+			a.SystemInfo.DashboardTemp = max(a.SystemInfo.DashboardTemp, sensor.Temperature)
 		case sensorName:
-			a.systemInfo.DashboardTemp = sensor.Temperature
+			a.SystemInfo.DashboardTemp = sensor.Temperature
 		}
 		systemStats.Temperatures[sensorName] = twoDecimals(sensor.Temperature)
 	}

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -89,6 +89,9 @@ type Info struct {
 	GpuPct        float64 `json:"g,omitempty"`
 	DashboardTemp float64 `json:"dt,omitempty"`
 	Os            Os      `json:"os"`
+	OsName        string  `json:"on,omitempty"`    // OS name (e.g., "Ubuntu", "CentOS", "Windows 11")
+	OsVersion     string  `json:"ov,omitempty"`    // OS version (e.g., "22.04", "10.0.19045")
+	OsArch        string  `json:"oa,omitempty"`    // OS architecture (e.g., "x86_64", "arm64")
 }
 
 // Final data structure to return to the hub

--- a/beszel/site/src/components/systems-table/systems-table.tsx
+++ b/beszel/site/src/components/systems-table/systems-table.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ui/alert-dialog"
 
 import { SystemRecord } from "@/types"
+import { Os } from "@/lib/enums"
 import {
 	MoreHorizontalIcon,
 	ArrowUpDownIcon,
@@ -61,6 +62,7 @@ import {
 	Settings2Icon,
 	EyeIcon,
 	PenBoxIcon,
+	AppleIcon,
 } from "lucide-react"
 import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { $systems, pb } from "@/lib/stores"
@@ -68,7 +70,7 @@ import { useStore } from "@nanostores/react"
 import { cn, copyToClipboard, decimalString, isReadOnlyUser, useLocalStorage } from "@/lib/utils"
 import AlertsButton from "../alerts/alert-button"
 import { $router, Link, navigate } from "../router"
-import { EthernetIcon, GpuIcon, ThermometerIcon } from "../ui/icons"
+import { EthernetIcon, GpuIcon, ThermometerIcon, TuxIcon, WindowsIcon, FreeBsdIcon } from "../ui/icons"
 import { useLingui, Trans } from "@lingui/react/macro"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card"
 import { Input } from "../ui/input"
@@ -260,6 +262,57 @@ export default function SystemsTable() {
 							})}
 						>
 							{decimalString(val)} °C
+						</span>
+					)
+				},
+			},
+			{
+				accessorFn: (originalRow) => {
+					const info = originalRow.info
+					if (info.on && info.ov) {
+						return `${info.on} ${info.ov}`
+					}
+					return info.k || ""
+				},
+				id: "os",
+				name: () => t`OS`,
+				size: 120,
+				hideSort: true,
+				Icon: TuxIcon,
+				header: sortableHeader,
+				cell(info) {
+					const system = info.row.original
+					const osText = info.getValue() as string
+					if (!osText) {
+						return null
+					}
+					
+					// Get OS icon based on OS type
+					const getOsIcon = () => {
+						switch (system.info.os) {
+							case Os.Darwin:
+								return AppleIcon
+							case Os.Windows:
+								return WindowsIcon
+							case Os.FreeBSD:
+								return FreeBsdIcon
+							default:
+								return TuxIcon
+						}
+					}
+					
+					const OsIcon = getOsIcon()
+					
+					return (
+						<span
+							className={cn("flex gap-1.5 items-center tabular-nums", {
+								"ps-1": viewMode === "table",
+							})}
+						>
+							<OsIcon className="h-3.5 w-3.5" />
+							<span className="truncate" title={osText}>
+								{osText}
+							</span>
 						</span>
 					)
 				},

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -51,6 +51,12 @@ export interface SystemInfo {
 	dt?: number
 	/** operating system */
 	os?: Os
+	/** OS name (e.g., "Ubuntu", "CentOS", "Windows 11") */
+	on?: string
+	/** OS version (e.g., "22.04", "10.0.19045") */
+	ov?: string
+	/** OS architecture (e.g., "x86_64", "arm64") */
+	oa?: string
 }
 
 export interface SystemStats {


### PR DESCRIPTION
This PR adds the collection of the OS and CPU Architecture, to be show on the Dashboard and System Info. 

closes https://github.com/henrygd/beszel/issues/891
closes https://github.com/henrygd/beszel/issues/909

<img width="1458" alt="Scherm­afbeelding 2025-06-27 om 08 58 20" src="https://github.com/user-attachments/assets/f7c4ae80-135d-4b3a-ae9a-dc83ed399949" />
<img width="1428" alt="Scherm­afbeelding 2025-06-27 om 08 58 13" src="https://github.com/user-attachments/assets/86dd4066-bab1-413f-89ef-987e035fed4a" />
