### PR TITLE
[Feature] Add CPU usage breakdown and expend SWAP #931

### DIFF
--- a/beszel/internal/agent/agent.go
+++ b/beszel/internal/agent/agent.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
 )
 
 type Agent struct {
@@ -25,6 +27,7 @@ type Agent struct {
 	systemInfo    system.Info                // Host system info
 	gpuManager    *GPUManager                // Manages GPU data
 	cache         *SessionCache              // Cache for system stats based on primary session ID
+	prevCpuTimes  []cpu.TimesStat            // Previous CPU times for calculating detailed metrics
 }
 
 func NewAgent() *Agent {

--- a/beszel/internal/agent/system.go
+++ b/beszel/internal/agent/system.go
@@ -127,6 +127,7 @@ func (a *Agent) getSystemStats() system.Stats {
 		systemStats.SwapUsed = bytesToGigabytes(v.SwapTotal - v.SwapFree - v.SwapCached)
 		systemStats.SwapTotal = bytesToGigabytes(v.SwapTotal)
 		systemStats.SwapFree = bytesToGigabytes(v.SwapFree)
+		systemStats.SwapCached = bytesToGigabytes(v.SwapCached)
 		// cache + buffers value for default mem calculation
 		cacheBuff := v.Total - v.Free - v.Used
 		// htop memory calculation overrides

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -10,6 +10,10 @@ import (
 type Stats struct {
 	Cpu            float64             `json:"cpu"`
 	MaxCpu         float64             `json:"cpum,omitempty"`
+	CpuUser        float64             `json:"cpuu,omitempty"`
+	CpuSystem      float64             `json:"cpus,omitempty"`
+	CpuIowait      float64             `json:"cpui,omitempty"`
+	CpuSteal       float64             `json:"cpusl,omitempty"`
 	Mem            float64             `json:"m"`
 	MemUsed        float64             `json:"mu"`
 	MemPct         float64             `json:"mp"`
@@ -17,6 +21,8 @@ type Stats struct {
 	MemZfsArc      float64             `json:"mz,omitempty"` // ZFS ARC memory
 	Swap           float64             `json:"s,omitempty"`
 	SwapUsed       float64             `json:"su,omitempty"`
+	SwapTotal      float64             `json:"st,omitempty"`
+	SwapFree       float64             `json:"sf,omitempty"`
 	DiskTotal      float64             `json:"d"`
 	DiskUsed       float64             `json:"du"`
 	DiskPct        float64             `json:"dp"`

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -23,6 +23,7 @@ type Stats struct {
 	SwapUsed       float64             `json:"su,omitempty"`
 	SwapTotal      float64             `json:"st,omitempty"`
 	SwapFree       float64             `json:"sf,omitempty"`
+	SwapCached     float64             `json:"sc,omitempty"`
 	DiskTotal      float64             `json:"d"`
 	DiskUsed       float64             `json:"du"`
 	DiskPct        float64             `json:"dp"`

--- a/beszel/internal/records/records.go
+++ b/beszel/internal/records/records.go
@@ -185,6 +185,7 @@ func (rm *RecordManager) AverageSystemStats(records RecordStats) *system.Stats {
 		sum.DiskWritePs += stats.DiskWritePs
 		sum.NetworkSent += stats.NetworkSent
 		sum.NetworkRecv += stats.NetworkRecv
+		sum.SwapCached += stats.SwapCached
 		// Set peak values
 		sum.MaxCpu = max(sum.MaxCpu, stats.MaxCpu, stats.Cpu)
 		sum.MaxNetworkSent = max(sum.MaxNetworkSent, stats.MaxNetworkSent, stats.NetworkSent)
@@ -265,6 +266,7 @@ func (rm *RecordManager) AverageSystemStats(records RecordStats) *system.Stats {
 		sum.DiskWritePs = twoDecimals(sum.DiskWritePs / count)
 		sum.NetworkSent = twoDecimals(sum.NetworkSent / count)
 		sum.NetworkRecv = twoDecimals(sum.NetworkRecv / count)
+		sum.SwapCached = twoDecimals(sum.SwapCached / count)
 
 		// Average temperatures
 		if sum.Temperatures != nil && tempCount > 0 {

--- a/beszel/internal/records/records.go
+++ b/beszel/internal/records/records.go
@@ -166,12 +166,17 @@ func (rm *RecordManager) AverageSystemStats(records RecordStats) *system.Stats {
 			continue
 		}
 		sum.Cpu += stats.Cpu
+		sum.CpuUser += stats.CpuUser
+		sum.CpuSystem += stats.CpuSystem
+		sum.CpuIowait += stats.CpuIowait
+		sum.CpuSteal += stats.CpuSteal
 		sum.Mem += stats.Mem
 		sum.MemUsed += stats.MemUsed
 		sum.MemPct += stats.MemPct
 		sum.MemBuffCache += stats.MemBuffCache
 		sum.MemZfsArc += stats.MemZfsArc
-		sum.Swap += stats.Swap
+		sum.SwapTotal += stats.SwapTotal
+		sum.SwapFree += stats.SwapFree
 		sum.SwapUsed += stats.SwapUsed
 		sum.DiskTotal += stats.DiskTotal
 		sum.DiskUsed += stats.DiskUsed
@@ -241,12 +246,17 @@ func (rm *RecordManager) AverageSystemStats(records RecordStats) *system.Stats {
 	// Compute averages in place
 	if count > 0 {
 		sum.Cpu = twoDecimals(sum.Cpu / count)
+		sum.CpuUser = twoDecimals(sum.CpuUser / count)
+		sum.CpuSystem = twoDecimals(sum.CpuSystem / count)
+		sum.CpuIowait = twoDecimals(sum.CpuIowait / count)
+		sum.CpuSteal = twoDecimals(sum.CpuSteal / count)
 		sum.Mem = twoDecimals(sum.Mem / count)
 		sum.MemUsed = twoDecimals(sum.MemUsed / count)
 		sum.MemPct = twoDecimals(sum.MemPct / count)
 		sum.MemBuffCache = twoDecimals(sum.MemBuffCache / count)
 		sum.MemZfsArc = twoDecimals(sum.MemZfsArc / count)
-		sum.Swap = twoDecimals(sum.Swap / count)
+		sum.SwapTotal = twoDecimals(sum.SwapTotal / count)
+		sum.SwapFree = twoDecimals(sum.SwapFree / count)
 		sum.SwapUsed = twoDecimals(sum.SwapUsed / count)
 		sum.DiskTotal = twoDecimals(sum.DiskTotal / count)
 		sum.DiskUsed = twoDecimals(sum.DiskUsed / count)

--- a/beszel/site/src/components/charts/swap-chart.tsx
+++ b/beszel/site/src/components/charts/swap-chart.tsx
@@ -81,6 +81,16 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 						isAnimationActive={false}
 						stackId="swap"
 					/>
+					<Area
+						dataKey="stats.sc"
+						name={t`Cached`}
+						type="monotoneX"
+						fill="hsl(var(--chart-3))"
+						fillOpacity={0.3}
+						stroke="hsl(var(--chart-3))"
+						isAnimationActive={false}
+						stackId="swap"
+					/>
 					<ChartLegend content={<ChartLegendContent />} />
 				</AreaChart>
 			</ChartContainer>

--- a/beszel/site/src/components/charts/swap-chart.tsx
+++ b/beszel/site/src/components/charts/swap-chart.tsx
@@ -1,7 +1,7 @@
 import { t } from "@lingui/core/macro";
 
-import { Area, AreaChart, CartesianGrid, YAxis } from "recharts"
-import { ChartContainer, ChartTooltip, ChartTooltipContent, xAxis } from "@/components/ui/chart"
+import { Area, AreaChart, CartesianGrid, Line, YAxis } from "recharts"
+import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip, ChartTooltipContent, xAxis } from "@/components/ui/chart"
 import {
 	useYAxisWidth,
 	cn,
@@ -20,6 +20,17 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 		return null
 	}
 
+	const lastStats = chartData.systemStats.at(-1)?.stats
+	const swapTotal = lastStats?.st ?? lastStats?.s ?? 0.04
+
+	// Debug: log the swap data
+	console.log('Swap chart data:', {
+		swapTotal: lastStats?.st,
+		swapFree: lastStats?.sf,
+		swapUsed: lastStats?.su,
+		legacySwap: lastStats?.s
+	})
+
 	return (
 		<div>
 			<ChartContainer
@@ -33,7 +44,7 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 						direction="ltr"
 						orientation={chartData.orientation}
 						className="tracking-tighter"
-						domain={[0, () => toFixedWithoutTrailingZeros(chartData.systemStats.at(-1)?.stats.s ?? 0.04, 2)]}
+						domain={[0, () => toFixedWithoutTrailingZeros(swapTotal, 2)]}
 						width={yAxisWidth}
 						tickLine={false}
 						axisLine={false}
@@ -47,7 +58,6 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 							<ChartTooltipContent
 								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
 								contentFormatter={(item) => decimalString(item.value) + " GB"}
-								// indicator="line"
 							/>
 						}
 					/>
@@ -59,7 +69,19 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 						fillOpacity={0.4}
 						stroke="hsl(var(--chart-2))"
 						isAnimationActive={false}
+						stackId="swap"
 					/>
+					<Area
+						dataKey="stats.sf"
+						name={t`Free`}
+						type="monotoneX"
+						fill="hsl(var(--chart-1))"
+						fillOpacity={0.3}
+						stroke="hsl(var(--chart-1))"
+						isAnimationActive={false}
+						stackId="swap"
+					/>
+					<ChartLegend content={<ChartLegendContent />} />
 				</AreaChart>
 			</ChartContainer>
 		</div>

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -112,6 +112,7 @@ export interface SystemStats {
 	efs?: Record<string, ExtraFsStats>
 	/** GPU data */
 	g?: Record<string, GPUData>
+	sc?: number // swap cached (gb)
 }
 
 export interface GPUData {

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -58,6 +58,14 @@ export interface SystemStats {
 	cpu: number
 	/** peak cpu */
 	cpum?: number
+	/** cpu user percent */
+	cpuu?: number
+	/** cpu system percent */
+	cpus?: number
+	/** cpu iowait percent */
+	cpui?: number
+	/** cpu steal percent */
+	cpusl?: number
 	/** total memory (gb) */
 	m: number
 	/** memory used (gb) */
@@ -72,6 +80,10 @@ export interface SystemStats {
 	s: number
 	/** swap used (gb) */
 	su: number
+	/** swap total (gb) */
+	st?: number
+	/** swap free (gb) */
+	sf?: number
 	/** disk size (gb) */
 	d: number
 	/** disk used (gb) */


### PR DESCRIPTION
This PR adds the Free/Used/Cache for the SWAP as well as breaksdown the CPU in System/Usser/IOWait/Steal

closes https://github.com/henrygd/beszel/issues/278
closes https://github.com/henrygd/beszel/issues/741

<img width="723" alt="Scherm­afbeelding 2025-06-27 om 23 11 05" src="https://github.com/user-attachments/assets/91ba97b9-a099-4039-9fd3-639b855457f3" />
<img width="721" alt="Scherm­afbeelding 2025-06-27 om 23 16 49" src="https://github.com/user-attachments/assets/0815e31d-97dd-4ed7-af66-36e965ab1c03" />
