### PR TITLE
fix docker edge tag

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           images: ${{ matrix.image }}
           tags: |
-            type=edge,enable=true
+            type=raw,value=edge
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
The tag `type=edge` feature in docker/metadata-action [by design](https://github.com/docker/metadata-action/blob/be19121bfd18b9c1ac415d9571d4f67b9b357886/src/meta.ts#L298) only works for GitHub workflow runs that are triggered by branch commits as it is intended for worklows that are being executed on a commit basis.  

This PR updates the workflow to use the raw tag type instead, which better reflects the desired behavior.  
However, please note that with this change, the edge tag will also be generated even when the tag that triggered the release is not on the default branch.
