### PR TITLE
[Feature][0.12.0-Beta] Enhance Load Average Display, Charting & Alert Grouping

### DIFF
--- a/beszel/Makefile
+++ b/beszel/Makefile
@@ -56,7 +56,7 @@ dev-hub: export ENV=dev
 dev-hub:
 	mkdir -p ./site/dist && touch ./site/dist/index.html
 	@if command -v entr >/dev/null 2>&1; then \
-		find ./cmd/hub ./internal/{alerts,hub,records,users} -name "*.go" | entr -r -s "cd ./cmd/hub && go run . serve"; \
+		find ./cmd/hub/*.go ./internal/{alerts,hub,records,users}/*.go | entr -r -s "cd ./cmd/hub && go run . serve --http 0.0.0.0:8090"; \
 	else \
 		cd ./cmd/hub && go run . serve --http 0.0.0.0:8090; \
 	fi

--- a/beszel/internal/agent/system.go
+++ b/beszel/internal/agent/system.go
@@ -251,6 +251,7 @@ func (a *Agent) getSystemStats() system.Stats {
 
 	// update base system info
 	a.systemInfo.Cpu = systemStats.Cpu
+	a.systemInfo.LoadAvg1 = systemStats.LoadAvg1
 	a.systemInfo.LoadAvg5 = systemStats.LoadAvg5
 	a.systemInfo.LoadAvg15 = systemStats.LoadAvg15
 	a.systemInfo.MemPct = systemStats.MemPct

--- a/beszel/internal/alerts/alerts.go
+++ b/beszel/internal/alerts/alerts.go
@@ -47,6 +47,7 @@ type SystemAlertStats struct {
 	NetSent      float64            `json:"ns"`
 	NetRecv      float64            `json:"nr"`
 	Temperatures map[string]float32 `json:"t"`
+	LoadAvg1     float64            `json:"l1"`
 	LoadAvg5     float64            `json:"l5"`
 	LoadAvg15    float64            `json:"l15"`
 }

--- a/beszel/internal/alerts/alerts_system.go
+++ b/beszel/internal/alerts/alerts_system.go
@@ -54,6 +54,9 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 			}
 			val = data.Info.DashboardTemp
 			unit = "°C"
+		case "LoadAvg1":
+			val = data.Info.LoadAvg1
+			unit = ""
 		case "LoadAvg5":
 			val = data.Info.LoadAvg5
 			unit = ""
@@ -196,6 +199,8 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 					}
 					alert.mapSums[key] += temp
 				}
+			case "LoadAvg1":
+				alert.val += stats.LoadAvg1
 			case "LoadAvg5":
 				alert.val += stats.LoadAvg5
 			case "LoadAvg15":

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -92,9 +92,9 @@ type Info struct {
 	GpuPct        float64 `json:"g,omitempty" cbor:"12,keyasint,omitempty"`
 	DashboardTemp float64 `json:"dt,omitempty" cbor:"13,keyasint,omitempty"`
 	Os            Os      `json:"os" cbor:"14,keyasint"`
-	LoadAvg1      float64 `json:"l1,omitempty" cbor:"15,keyasint,omitempty,omitzero"`
-	LoadAvg5      float64 `json:"l5,omitempty" cbor:"16,keyasint,omitempty,omitzero"`
-	LoadAvg15     float64 `json:"l15,omitempty" cbor:"17,keyasint,omitempty,omitzero"`
+	LoadAvg1      float64 `json:"l1,omitempty" cbor:"15,keyasint,omitempty"`
+	LoadAvg5      float64 `json:"l5,omitempty" cbor:"16,keyasint,omitempty"`
+	LoadAvg15     float64 `json:"l15,omitempty" cbor:"17,keyasint,omitempty"`
 }
 
 // Final data structure to return to the hub

--- a/beszel/internal/entities/system/system.go
+++ b/beszel/internal/entities/system/system.go
@@ -92,8 +92,9 @@ type Info struct {
 	GpuPct        float64 `json:"g,omitempty" cbor:"12,keyasint,omitempty"`
 	DashboardTemp float64 `json:"dt,omitempty" cbor:"13,keyasint,omitempty"`
 	Os            Os      `json:"os" cbor:"14,keyasint"`
-	LoadAvg5      float64 `json:"l5,omitempty" cbor:"15,keyasint,omitempty,omitzero"`
-	LoadAvg15     float64 `json:"l15,omitempty" cbor:"16,keyasint,omitempty,omitzero"`
+	LoadAvg1      float64 `json:"l1,omitempty" cbor:"15,keyasint,omitempty,omitzero"`
+	LoadAvg5      float64 `json:"l5,omitempty" cbor:"16,keyasint,omitempty,omitzero"`
+	LoadAvg15     float64 `json:"l15,omitempty" cbor:"17,keyasint,omitempty,omitzero"`
 }
 
 // Final data structure to return to the hub

--- a/beszel/migrations/1_collections_snapshot_0_12_0.go
+++ b/beszel/migrations/1_collections_snapshot_0_12_0.go
@@ -76,6 +76,7 @@ func init() {
 					"Disk",
 					"Temperature",
 					"Bandwidth",
+					"LoadAvg1",
 					"LoadAvg5",
 					"LoadAvg15"
 				]

--- a/beszel/site/src/components/alerts/alert-button.tsx
+++ b/beszel/site/src/components/alerts/alert-button.tsx
@@ -94,14 +94,6 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 			}
 		})
 
-		// Separate load average alerts from other alerts
-		const loadAverageAlerts = data.filter((d) => 
-			d.name === "LoadAvg1" || d.name === "LoadAvg5" || d.name === "LoadAvg15"
-		)
-		const otherAlerts = data.filter((d) => 
-			d.name !== "LoadAvg1" && d.name !== "LoadAvg5" && d.name !== "LoadAvg15"
-		)
-
 		return (
 			<>
 				<DialogHeader>
@@ -131,19 +123,9 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 					</TabsList>
 					<TabsContent value="system">
 						<div className="grid gap-3">
-							{otherAlerts.map((d) => (
+							{data.map((d) => (
 								<SystemAlert key={d.name} system={system} data={d} systemAlerts={systemAlerts} />
 							))}
-							<Collapsible
-								title={t`Load Average`}
-								defaultOpen={false}
-								icon={<HourglassIcon className="h-4 w-4" />}
-								description={<Trans>Triggers when load average exceeds a threshold</Trans>}
-							>
-								{loadAverageAlerts.map((d) => (
-									<SystemAlert key={d.name} system={system} data={d} systemAlerts={systemAlerts} />
-								))}
-							</Collapsible>
 						</div>
 					</TabsContent>
 					<TabsContent value="global">
@@ -160,19 +142,9 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 							<Trans>Overwrite existing alerts</Trans>
 						</label>
 						<div className="grid gap-3">
-							{otherAlerts.map((d) => (
+							{data.map((d) => (
 								<SystemAlertGlobal key={d.name} data={d} overwrite={overwriteExisting} />
 							))}
-							<Collapsible
-								title={t`Load Average`}
-								defaultOpen={false}
-								icon={<HourglassIcon className="h-4 w-4" />}
-								description={<Trans>Triggers when load average exceeds a threshold</Trans>}
-							>
-								{loadAverageAlerts.map((d) => (
-									<SystemAlertGlobal key={d.name} data={d} overwrite={overwriteExisting} />
-								))}
-							</Collapsible>
 						</div>
 					</TabsContent>
 				</Tabs>

--- a/beszel/site/src/components/alerts/alert-button.tsx
+++ b/beszel/site/src/components/alerts/alert-button.tsx
@@ -11,13 +11,14 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog"
-import { BellIcon, GlobeIcon, ServerIcon } from "lucide-react"
+import { BellIcon, GlobeIcon, ServerIcon, HourglassIcon } from "lucide-react"
 import { alertInfo, cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { AlertRecord, SystemRecord } from "@/types"
 import { $router, Link } from "../router"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Checkbox } from "../ui/checkbox"
+import { Collapsible } from "../ui/collapsible"
 import { SystemAlert, SystemAlertGlobal } from "./alerts-system"
 import { getPagePath } from "@nanostores/router"
 
@@ -93,6 +94,14 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 			}
 		})
 
+		// Separate load average alerts from other alerts
+		const loadAverageAlerts = data.filter((d) => 
+			d.name === "LoadAvg1" || d.name === "LoadAvg5" || d.name === "LoadAvg15"
+		)
+		const otherAlerts = data.filter((d) => 
+			d.name !== "LoadAvg1" && d.name !== "LoadAvg5" && d.name !== "LoadAvg15"
+		)
+
 		return (
 			<>
 				<DialogHeader>
@@ -122,9 +131,19 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 					</TabsList>
 					<TabsContent value="system">
 						<div className="grid gap-3">
-							{data.map((d) => (
+							{otherAlerts.map((d) => (
 								<SystemAlert key={d.name} system={system} data={d} systemAlerts={systemAlerts} />
 							))}
+							<Collapsible
+								title={t`Load Average`}
+								defaultOpen={false}
+								icon={<HourglassIcon className="h-4 w-4" />}
+								description={<Trans>Triggers when load average exceeds a threshold</Trans>}
+							>
+								{loadAverageAlerts.map((d) => (
+									<SystemAlert key={d.name} system={system} data={d} systemAlerts={systemAlerts} />
+								))}
+							</Collapsible>
 						</div>
 					</TabsContent>
 					<TabsContent value="global">
@@ -141,9 +160,19 @@ function AlertDialogContent({ system }: { system: SystemRecord }) {
 							<Trans>Overwrite existing alerts</Trans>
 						</label>
 						<div className="grid gap-3">
-							{data.map((d) => (
+							{otherAlerts.map((d) => (
 								<SystemAlertGlobal key={d.name} data={d} overwrite={overwriteExisting} />
 							))}
+							<Collapsible
+								title={t`Load Average`}
+								defaultOpen={false}
+								icon={<HourglassIcon className="h-4 w-4" />}
+								description={<Trans>Triggers when load average exceeds a threshold</Trans>}
+							>
+								{loadAverageAlerts.map((d) => (
+									<SystemAlertGlobal key={d.name} data={d} overwrite={overwriteExisting} />
+								))}
+							</Collapsible>
 						</div>
 					</TabsContent>
 				</Tabs>

--- a/beszel/site/src/components/charts/load-average-chart.tsx
+++ b/beszel/site/src/components/charts/load-average-chart.tsx
@@ -1,0 +1,123 @@
+import { CartesianGrid, Line, LineChart, YAxis } from "recharts"
+
+import {
+	ChartContainer,
+	ChartLegend,
+	ChartLegendContent,
+	ChartTooltip,
+	ChartTooltipContent,
+	xAxis,
+} from "@/components/ui/chart"
+import {
+	useYAxisWidth,
+	cn,
+	formatShortDate,
+	toFixedWithoutTrailingZeros,
+	decimalString,
+	chartMargin,
+} from "@/lib/utils"
+import { ChartData } from "@/types"
+import { memo, useMemo } from "react"
+import { t } from "@lingui/core/macro"
+
+export default memo(function LoadAverageChart({ chartData }: { chartData: ChartData }) {
+	const { yAxisWidth, updateYAxisWidth } = useYAxisWidth()
+
+	if (chartData.systemStats.length === 0) {
+		return null
+	}
+
+	/** Format load average data for chart */
+	const newChartData = useMemo(() => {
+		const newChartData = { data: [], colors: {} } as {
+			data: Record<string, number | string>[]
+			colors: Record<string, string>
+		}
+		
+		// Define colors for the three load average lines
+		const colors = {
+			"1m": "hsl(25, 95%, 53%)",   // Orange for 1-minute
+			"5m": "hsl(217, 91%, 60%)",  // Blue for 5-minute  
+			"15m": "hsl(271, 81%, 56%)", // Purple for 15-minute
+		}
+
+		for (let data of chartData.systemStats) {
+			let newData = { created: data.created } as Record<string, number | string>
+			
+			// Add load average values if they exist
+			if (data.stats.l1 !== undefined) {
+				newData["1m"] = data.stats.l1
+			}
+			if (data.stats.l5 !== undefined) {
+				newData["5m"] = data.stats.l5
+			}
+			if (data.stats.l15 !== undefined) {
+				newData["15m"] = data.stats.l15
+			}
+			
+			newChartData.data.push(newData)
+		}
+		
+		newChartData.colors = colors
+		return newChartData
+	}, [chartData])
+
+	const loadKeys = ["1m", "5m", "15m"].filter(key => 
+		newChartData.data.some(data => data[key] !== undefined)
+	)
+
+	// console.log('rendered at', new Date())
+
+	return (
+		<div>
+			<ChartContainer
+				className={cn("h-full w-full absolute aspect-auto bg-card opacity-0 transition-opacity", {
+					"opacity-100": yAxisWidth,
+				})}
+			>
+				<LineChart accessibilityLayer data={newChartData.data} margin={chartMargin}>
+					<CartesianGrid vertical={false} />
+					<YAxis
+						direction="ltr"
+						orientation={chartData.orientation}
+						className="tracking-tighter"
+						domain={[0, "auto"]}
+						width={yAxisWidth}
+						tickFormatter={(value) => {
+							const val = toFixedWithoutTrailingZeros(value, 2)
+							return updateYAxisWidth(val)
+						}}
+						tickLine={false}
+						axisLine={false}
+					/>
+					{xAxis(chartData)}
+					<ChartTooltip
+						animationEasing="ease-out"
+						animationDuration={150}
+						// @ts-ignore
+						itemSorter={(a, b) => b.value - a.value}
+						content={
+							<ChartTooltipContent
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								contentFormatter={(item) => decimalString(item.value)}
+							/>
+						}
+					/>
+					{loadKeys.map((key) => (
+						<Line
+							key={key}
+							dataKey={key}
+							name={key === "1m" ? t`1 min` : key === "5m" ? t`5 min` : t`15 min`}
+							type="monotoneX"
+							dot={false}
+							strokeWidth={1.5}
+							stroke={newChartData.colors[key]}
+							isAnimationActive={false}
+						/>
+					))}
+					<ChartLegend content={<ChartLegendContent />} />
+				</LineChart>
+			</ChartContainer>
+		</div>
+	)
+}) 

--- a/beszel/site/src/components/charts/load-average-chart.tsx
+++ b/beszel/site/src/components/charts/load-average-chart.tsx
@@ -44,14 +44,14 @@ export default memo(function LoadAverageChart({ chartData }: { chartData: ChartD
 		for (let data of chartData.systemStats) {
 			let newData = { created: data.created } as Record<string, number | string>
 			
-			// Add load average values if they exist
-			if (data.stats.l1 !== undefined) {
+			// Add load average values if they exist and stats is not null
+			if (data.stats && data.stats.l1 !== undefined) {
 				newData["1m"] = data.stats.l1
 			}
-			if (data.stats.l5 !== undefined) {
+			if (data.stats && data.stats.l5 !== undefined) {
 				newData["5m"] = data.stats.l5
 			}
-			if (data.stats.l15 !== undefined) {
+			if (data.stats && data.stats.l15 !== undefined) {
 				newData["15m"] = data.stats.l15
 			}
 			

--- a/beszel/site/src/components/routes/system.tsx
+++ b/beszel/site/src/components/routes/system.tsx
@@ -47,6 +47,7 @@ const DiskChart = lazy(() => import("../charts/disk-chart"))
 const SwapChart = lazy(() => import("../charts/swap-chart"))
 const TemperatureChart = lazy(() => import("../charts/temperature-chart"))
 const GpuPowerChart = lazy(() => import("../charts/gpu-power-chart"))
+const LoadAverageChart = lazy(() => import("../charts/load-average-chart"))
 
 const cache = new Map<string, any>()
 
@@ -474,6 +475,18 @@ export default function SystemDetail({ name }: { name: string }) {
 					>
 						<AreaChartDefault chartData={chartData} chartName="CPU Usage" maxToggled={maxValues} unit="%" />
 					</ChartCard>
+
+					{/* Load Average chart */}
+					{(systemStats.at(-1)?.stats.l1 !== undefined || systemStats.at(-1)?.stats.l5 !== undefined || systemStats.at(-1)?.stats.l15 !== undefined) && (
+						<ChartCard
+							empty={dataEmpty}
+							grid={grid}
+							title={t`Load Average`}
+							description={t`System load averages over time`}
+						>
+							<LoadAverageChart chartData={chartData} />
+						</ChartCard>
+					)}
 
 					{containerFilterBar && (
 						<ChartCard

--- a/beszel/site/src/components/systems-table/systems-table.tsx
+++ b/beszel/site/src/components/systems-table/systems-table.tsx
@@ -238,59 +238,48 @@ export default function SystemsTable() {
 					const l1 = system.info?.l1;
 					const l5 = system.info?.l5;
 					const l15 = system.info?.l15;
-					
+					const cores = system.info?.c || 1;
+
 					// If no load average data, return null
 					if (!l1 && !l5 && !l15) return null;
-					
+
 					const loadAverages = [
-						{ name: "1m", value: l1, color: "bg-orange-500" },
-						{ name: "5m", value: l5, color: "bg-blue-500" },
-						{ name: "15m", value: l15, color: "bg-purple-500" }
+						{ name: "1m", value: l1 },
+						{ name: "5m", value: l5 },
+						{ name: "15m", value: l15 }
 					].filter(la => la.value !== undefined);
-					
+
 					if (!loadAverages.length) return null;
-					
-					// Get core count for proper load average interpretation
-					const cores = system.info?.c || 1;
-					
+
+					function getDotColor(value: number) {
+						const normalized = value / cores;
+						if (normalized < 0.7) return "bg-green-500";
+						if (normalized < 1.0) return "bg-orange-500";
+						return "bg-red-600";
+					}
+
 					return (
-						<div className="flex flex-col gap-1 w-full">
-							{loadAverages.map((la) => {
-								const value = la.value || 0;
-								const percent = calculateLoadAveragePercent(value, cores);
-								
-								return (
-									<TooltipProvider key={la.name}>
-										<Tooltip>
-											<TooltipTrigger asChild>
-												<div className="flex items-center w-full cursor-pointer">
-													<span className="min-w-[2.5em] text-xs">{decimalString(value, 2)}</span>
-													<span className="grow min-w-8 block bg-muted h-[0.7em] relative rounded-sm overflow-hidden">
-														<span
-															className={cn(
-																"absolute inset-0 w-full h-full origin-left transition-transform duration-200",
-																la.color,
-																`opacity-${Math.round(getLoadAverageOpacity(value, cores) * 100)}`
-															)}
-															style={{
-																transform: `scalex(${percent / 100})`,
-															}}
-														></span>
-													</span>
-												</div>
-											</TooltipTrigger>
-											<TooltipContent side="top">
-												<div className="text-center">
-													<div className="font-medium">{t`${la.name}`}</div>
-													<div className="text-sm text-muted-foreground">
-														{decimalString(value, 2)}
-													</div>
-												</div>
-											</TooltipContent>
-										</Tooltip>
-									</TooltipProvider>
-								);
-							})}
+						<div className="flex items-center gap-2 w-full">
+							{loadAverages.map((la, idx) => (
+								<TooltipProvider key={la.name}>
+									<Tooltip>
+										<TooltipTrigger asChild>
+											<span className="flex items-center cursor-pointer">
+												<span className={cn("inline-block w-2 h-2 rounded-full mr-1", getDotColor(la.value || 0))} />
+												<span className="tabular-nums">
+													{decimalString(la.value || 0, 2)}
+												</span>
+												{idx < loadAverages.length - 1 && <span className="mx-1 text-muted-foreground">/</span>}
+											</span>
+										</TooltipTrigger>
+										<TooltipContent side="top">
+											<div className="text-center">
+												<div className="font-medium">{t`${la.name}`}</div>
+											</div>
+										</TooltipContent>
+									</Tooltip>
+								</TooltipProvider>
+							))}
 						</div>
 					);
 				},

--- a/beszel/site/src/components/ui/collapsible.tsx
+++ b/beszel/site/src/components/ui/collapsible.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { ChevronDownIcon, HourglassIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Button } from "./button"
+
+interface CollapsibleProps {
+	title: string
+	children: React.ReactNode
+	description?: React.ReactNode
+	defaultOpen?: boolean
+	className?: string
+	icon?: React.ReactNode
+}
+
+export function Collapsible({ title, children, description, defaultOpen = false, className, icon }: CollapsibleProps) {
+	const [isOpen, setIsOpen] = React.useState(defaultOpen)
+
+	return (
+		<div className={cn("border rounded-lg", className)}>
+			<Button
+				variant="ghost"
+				className="w-full justify-between p-4 font-semibold"
+				onClick={() => setIsOpen(!isOpen)}
+			>
+				<div className="flex items-center gap-2">
+					{icon}
+					{title}
+				</div>
+				<ChevronDownIcon
+					className={cn("h-4 w-4 transition-transform duration-200", {
+						"rotate-180": isOpen,
+					})}
+				/>
+			</Button>
+			{description && (
+				<div className="px-4 pb-2 text-sm text-muted-foreground">
+					{description}
+				</div>
+			)}
+			{isOpen && (
+				<div className="px-4 pb-4">
+					<div className="grid gap-3">
+						{children}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+} 

--- a/beszel/site/src/lib/utils.ts
+++ b/beszel/site/src/lib/utils.ts
@@ -342,6 +342,16 @@ export const alertInfo: Record<string, AlertInfo> = {
 		icon: ThermometerIcon,
 		desc: () => t`Triggers when any sensor exceeds a threshold`,
 	},
+	LoadAvg1: {
+		name: () => t`Load Average 1m`,
+		unit: "",
+		icon: HourglassIcon,
+		max: 100,
+		min: 0.1,
+		start: 10,
+		step: 0.1,
+		desc: () => t`Triggers when 1 minute load average exceeds a threshold`,
+	},
 	LoadAvg5: {
 		name: () => t`Load Average 5m`,
 		unit: "",
@@ -380,3 +390,27 @@ export const getHubURL = () => BESZEL?.HUB_URL || window.location.origin
 
 /** Map of system IDs to their corresponding tokens (used to avoid fetching in add-system dialog) */
 export const tokenMap = new Map<SystemRecord["id"], FingerprintRecord["token"]>()
+
+/**
+ * Calculate load average percentage relative to CPU cores
+ * @param loadAverage - The load average value (1m, 5m, or 15m)
+ * @param cores - Number of CPU cores
+ * @returns Percentage (0-100) representing CPU utilization
+ */
+export const calculateLoadAveragePercent = (loadAverage: number, cores: number): number => {
+	if (!loadAverage || !cores) return 0
+	return Math.min((loadAverage / cores) * 100, 100)
+}
+
+/**
+ * Get load average opacity based on utilization relative to cores
+ * @param loadAverage - The load average value
+ * @param cores - Number of CPU cores
+ * @returns Opacity value (0.6, 0.8, or 1.0)
+ */
+export const getLoadAverageOpacity = (loadAverage: number, cores: number): number => {
+	if (!loadAverage || !cores) return 0.6
+	if (loadAverage < cores * 0.5) return 0.6
+	if (loadAverage < cores) return 0.8
+	return 1.0
+}

--- a/beszel/site/src/types.d.ts
+++ b/beszel/site/src/types.d.ts
@@ -44,6 +44,8 @@ export interface SystemInfo {
 	c: number
 	/** cpu model */
 	m: string
+	/** load average 1 minute */
+	l1?: number
 	/** load average 5 minutes */
 	l5?: number
 	/** load average 15 minutes */


### PR DESCRIPTION
### Summary
This PR enhances the recently added Load Averages feature by improving visibility, usability, and alert consolidation.

## What’s Changed

### System Table

- Added the 1-minute load average alongside the existing 5- and 15-minute values.
  - We use the core count to calculate the bar.
- Consolidated all three load averages into a single column, with a hover tooltip to reveal the 1m, 5m, and 15m figures.

<img width="500" height="197" alt="Load averages in system table with tooltip" src="https://github.com/user-attachments/assets/75de94cd-c9fc-4399-9da8-8352e65bdc31" />

### Historical Chart

- Introduced a chart to track load average trends over time, giving users deeper insight into system performance.

<img width="761" height="366" alt="Load average history chart" src="https://github.com/user-attachments/assets/b4bbff98-0955-4388-a3fa-a443406d9a69" />

### Alerts

- Included the 1-minute load average in alert notifications for quicker spike detection.
- Grouped all Load Average alerts into a single collapsible section to reduce dashboard clutter.

<img width="558" height="473" alt="Collapsible load average alerts" src="https://github.com/user-attachments/assets/d59001a6-1597-4231-bffd-08d72a59b674" />

Please review and let me know if any tweaks are needed!
