### PR TITLE
fix systems table names wrapping

### DIFF
--- a/beszel/site/src/components/systems-table/systems-table.tsx
+++ b/beszel/site/src/components/systems-table/systems-table.tsx
@@ -176,7 +176,7 @@ export default function SystemsTable() {
 				cell: (info) => (
 					<span className="flex gap-2 items-center md:ps-1 md:pe-5">
 						<IndicatorDot system={info.row.original} />
-						<span className="font-medium text-sm">
+						<span className="font-medium text-sm text-nowrap">
 							{info.getValue() as string}
 						</span>
 					</span>


### PR DESCRIPTION
## 📃 Description

The copy button was moved in #1010 but caused text to break and wrap which looks a jarring.

This PR adds `whitespace: nowrap` to the system table names.

## 📷 Screenshots

before
<img width="200" height="132" alt="image" src="https://github.com/user-attachments/assets/789c595e-6330-41c1-bc96-fe7929b26371" />

after
<img width="238" height="104" alt="image" src="https://github.com/user-attachments/assets/aac3446d-6f31-4772-a486-81d73967b233" />

