### PR TITLE
fix: allow system titles to expand

### DIFF
--- a/beszel/site/src/components/systems-table/systems-table-columns.tsx
+++ b/beszel/site/src/components/systems-table/systems-table-columns.tsx
@@ -68,7 +68,6 @@ export default function SystemsTableColumns(viewMode: "table" | "grid"): ColumnD
 	}
 	return [
 		{
-			minSize: 0,
 			accessorKey: "name",
 			id: "system",
 			name: () => t`System`,

--- a/beszel/site/src/components/systems-table/systems-table-columns.tsx
+++ b/beszel/site/src/components/systems-table/systems-table-columns.tsx
@@ -68,7 +68,6 @@ export default function SystemsTableColumns(viewMode: "table" | "grid"): ColumnD
 	}
 	return [
 		{
-			size: 200,
 			minSize: 0,
 			accessorKey: "name",
 			id: "system",


### PR DESCRIPTION
## 📃 Description

It appears that the system titles column is maxed at 200px wide. This causes longer system titles to be word wrapped onto 2 columns (see picture). These titles that wrap are not very long and should still fit on one line to make the column readable.

<img width="1362" height="256" alt="image" src="https://github.com/user-attachments/assets/5c420e7c-fcff-4d18-835e-d5b7f4d3f74c" />


## 📖 Documentation

N/A

## 🪵 Changelog


### 🔧 Fixed

- word wrapping on system title column

## 📸 Screenshots

After changes:
<img width="1393" height="257" alt="image" src="https://github.com/user-attachments/assets/0c59b0a8-6f1f-412e-bf31-c8d3f6353119" />

