### PR TITLE
Use British flag for English, and use Portuguese flag for Portuguese

### DIFF
--- a/beszel/site/src/lib/languages.ts
+++ b/beszel/site/src/lib/languages.ts
@@ -87,7 +87,7 @@ export default [
 	{
 		lang: "pt",
 		label: "Português",
-		e: "🇧🇷",
+		e: "🇵🇹",
 	},
 	{
 		lang: "tr",


### PR DESCRIPTION
## 📃 Description

English is clearly not from the US, English is from England, in the United Kingdom. It makes more sense to put the flag of the United Kingdom there.

Same with Portuguese, the language comes from Portugal, so the Portuguese flag should be used.

## 🪵 Changelog

### ✏️ Changed

- US flag -> British flag
- Brazilian flag -> Portuguese flag
