### PR TITLE
[Bug] Add missing os.Chmod step to Hub update

### DIFF
--- a/beszel/internal/hub/update.go
+++ b/beszel/internal/hub/update.go
@@ -30,6 +30,14 @@ func Update(_ *cobra.Command, _ []string) {
 		return
 	}
 
+	// make sure the file is executable
+	exePath, err := os.Executable()
+	if err == nil {
+		if err := os.Chmod(exePath, 0755); err != nil {
+			fmt.Printf("Warning: failed to set executable permissions: %v\n", err)
+		}
+	}
+
 	// Try to restart the service if it's running
 	restartService()
 }


### PR DESCRIPTION
## 📃 Description

In the Hub update, the permissions weren’t set to 0755, which prevented the binary from being executable.

closes https://github.com/henrygd/beszel/issues/1091
