### PR TITLE
Use older cuda image for increased compatibility

### DIFF
--- a/beszel/dockerfile_agent_nvidia
+++ b/beszel/dockerfile_agent_nvidia
@@ -15,7 +15,7 @@ RUN CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags "-
 # --------------------------
 # Final image: GPU-enabled agent with nvidia-smi
 # --------------------------
-FROM nvidia/cuda:12.9.1-base-ubuntu22.04
+FROM nvidia/cuda:12.2.2-base-ubuntu22.04
 COPY --from=builder /agent /agent
 
 ENTRYPOINT ["/agent"]


### PR DESCRIPTION
## 📃 Description

This changes the docker cuda image from `12.9.1` to `12.2.2` for increased compatibility.
For example, if you install [the `nvidia-driver` package from the debian trixie repos](https://packages.debian.org/en/trixie/nvidia-driver) from their repo [as recommended](https://wiki.debian.org/NvidiaGraphicsDrivers) you get cuda `12.4` and this error.

```
nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.9, please update your driver to a newer version, or use an earlier cuda container: unknown
```

I'm implementing the second suggestion here. [`cuda:12.2.2-base-ubuntu22.04` is supported](https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/supported-tags.md#cuda-1222) and as far as I know (please correct me if I'm wrong) this has no disadvantages for this project.

## 🪵 Changelog
### ✏️ Changed
- Replace the docker cuda image from `12.9.1` to `12.2.2` for increased compatibility

