### PR TITLE
[Feature] improved support for `mips` and `mipsle` architectures

### DIFF
--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -38,6 +38,7 @@ builds:
       - mips64
       - riscv64
       - mipsle
+      - mips
       - ppc64le
     gomips:
       - hardfloat
@@ -52,6 +53,9 @@ builds:
         gomips: softfloat
       - goos: linux
         goarch: mipsle
+        gomips: hardfloat
+      - goos: linux
+        goarch: mips
         gomips: hardfloat
       - goos: windows
         goarch: arm

--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -398,7 +398,7 @@ fi
 echo "Downloading and installing the agent..."
 
 OS=$(uname -s | sed -e 'y/ABCDEFGHIJKLMNOPQRSTUVWXYZ/abcdefghijklmnopqrstuvwxyz/')
-ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/armv6l/arm/' -e 's/armv7l/arm/' -e 's/aarch64/arm64/' -e 's/mips/mipsle/')
+ARCH=$(uname -m | sed -e 's/x86_64/amd64/' -e 's/armv6l/arm/' -e 's/armv7l/arm/' -e 's/aarch64/arm64/')
 FILE_NAME="beszel-agent_${OS}_${ARCH}.tar.gz"
 
 # Determine version to install


### PR DESCRIPTION
## 📃 Description
This PR should improve the support for mostly older devices with mips (little- and big endian) CPUs often used with OpenWRT.
Until now `mips` based devices installed binaries for the `mipsle` architecture  (= `mips little endian` sometimes also referred to as `mipsel`) which isn't compatible with `mips` as it uses the opposite byte significance order.
Additionaly quite a lot of the mips/miplse embedded devices don't come with with hardware floating point capabilities, therefore I switched to software based floating point for the `mipsle` and newly added `mips` architecture.

resolves #1036

Successfully tested on [AVM 300E (mips)](https://openwrt.org/toh/hwdata/avm/avm_fritz_wlan_repeater_300e) and [D-Link COVR X1860 (mipsle)](https://openwrt.org/inbox/toh/d-link/x1860_a1)

## 🪵 Changelog

### ➕ Added

- support for `mips` architecture

### ✏️ Changed
/
### 🔧 Fixed

- switched `mipsle` to `softfloat` (#1036)
