### PR TITLE
[BUG]: Generate new token after system creation

### DIFF
--- a/beszel/site/src/components/add-system.tsx
+++ b/beszel/site/src/components/add-system.tsx
@@ -97,7 +97,7 @@ export const SystemDialog = ({ setOpen, system }: { setOpen: (open: boolean) => 
 			tokenMap.set(system.id, token)
 			setToken(token)
 		})()
-	}, [system?.id])
+	}, [system?.id, nextSystemToken])
 
 	async function handleSubmit(e: SubmitEvent) {
 		e.preventDefault()


### PR DESCRIPTION
## 📃 Description

Fixing bug #1141 by adding nextSystemToken to the deps of the useEffect. Currently after system creation nextSystemToken is set to null, but the useEffect is not executed again and therefore no new token is generated.

## 🪵 Changelog

### 🔧 Fixed

- #1141
