### PR TITLE
[FIX] fix brew, winget, scoop release workflow

### DIFF
--- a/beszel/.goreleaser.yml
+++ b/beszel/.goreleaser.yml
@@ -135,7 +135,7 @@ scoops:
     homepage: "https://beszel.dev"
     description: "Agent for Beszel, a lightweight server monitoring platform."
     license: MIT
-    skip_upload: "{{ if .Env.IS_FORK }}true{{ else }}auto{{ end }}"
+    skip_upload: '{{ if eq (tolower .Env.IS_FORK) "true" }}true{{ else }}auto{{ end }}'
 
 # # Needs choco installed, so doesn't build on linux / default gh workflow :(
 # chocolateys:
@@ -169,7 +169,7 @@ brews:
     homepage: "https://beszel.dev"
     description: "Agent for Beszel, a lightweight server monitoring platform."
     license: MIT
-    skip_upload: "{{ if .Env.IS_FORK }}true{{ else }}auto{{ end }}"
+    skip_upload: '{{ if eq (tolower .Env.IS_FORK) "true" }}true{{ else }}auto{{ end }}'
     extra_install: |
       (bin/"beszel-agent-launcher").write <<~EOS
         #!/bin/bash
@@ -201,7 +201,7 @@ winget:
     release_notes_url: "https://github.com/henrygd/beszel/releases/tag/v{{ .Version }}"
     publisher_support_url: "https://github.com/henrygd/beszel/issues"
     short_description: "Agent for Beszel, a lightweight server monitoring platform."
-    skip_upload: "{{ if .Env.IS_FORK }}true{{ else }}auto{{ end }}"
+    skip_upload: '{{ if eq (tolower .Env.IS_FORK) "true" }}true{{ else }}auto{{ end }}'
     description: |
       Beszel is a lightweight server monitoring platform that includes Docker
       statistics, historical data, and alert functions. It has a friendly web


### PR DESCRIPTION

## 📃 Description

Goreleaser performs truthy evaluation on templates. As `.Env.IS_FORK` is a string, the env variable containing a non empty-string already evaluated to true which causes the external asset releases to always be skipped.

resolves #1144


## 🪵 Changelog
- fixed official release workflow for winget, scoop, homebrew

### 🔧 Fixed

- external releases of winget, scoop, homebrew for the official repository

## 📷 Screenshots

- test in my fork without any code modification:  
https://github.com/a-mnich/beszel/actions/runs/17503917759/job/49723165161
<img width="1463" height="375" alt="image" src="https://github.com/user-attachments/assets/cc850dbb-a71c-4068-915e-465ad44b5d87" />

- test in my fork with `IS_FORK: ${{ github.repository_owner != 'a-mnich' }}` - (simulation of a release in the offical repository):   https://github.com/a-mnich/beszel/actions/runs/17503935051/job/49723218947
An error is expected here as I don't have access to the winget and brew repositories.
<img width="1736" height="412" alt="image" src="https://github.com/user-attachments/assets/61a93579-ecb1-4936-b2f9-55510d0dcc7e" />
