### PR TITLE
Adding openwrt restart procedure after updating the agent automatically

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -705,13 +705,19 @@ stop_service() {
     killall beszel-agent
 }
 
+restart_service() {
+    stop
+    start
+}
+
 # Extra command to trigger agent update
-EXTRA_COMMANDS="update"
-EXTRA_HELP="        update          Update the Beszel agent"
+EXTRA_COMMANDS="update restart"
+EXTRA_HELP="        update          Update the Beszel agent
+        restart         Restart the Beszel agent"
 
 update() {
     if /opt/beszel-agent/beszel-agent update | grep -q "Successfully updated"; then
-        start_service
+        /etc/init.d/beszel-agent restart
     fi
 }
 


### PR DESCRIPTION
## 📃 Description

Adding openwrt restart procedure after updating the agent automatically

## 📖 Documentation

Add a link to the PR for [documentation](https://github.com/henrygd/beszel-docs) changes.

## 🪵 Changelog

### ➕ Added

restart section
```
restart_service() {
    stop
    start
}
```

### ✏️ Changed

Command that runs after agent update
Replaced:
`       start_service`
with:
`        /etc/init.d/beszel-agent restart`
