### PR TITLE
Fixing helm chart service/ingress

### DIFF
--- a/supplemental/kubernetes/beszel-hub/charts/templates/service.yaml
+++ b/supplemental/kubernetes/beszel-hub/charts/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "beszel.fullname" . }}-web
+  name: {{ include "beszel.fullname" . }}
   labels:
     {{- include "beszel.labels" . | nindent 4 }}
 {{- if .Values.service.annotations }}

--- a/supplemental/kubernetes/beszel-hub/charts/values.yaml
+++ b/supplemental/kubernetes/beszel-hub/charts/values.yaml
@@ -30,14 +30,10 @@ securityContext: {}
 
 service:
   enabled: true
-  type: LoadBalancer
-  loadBalancerIP: "10.0.10.251"
+  annotations: {}
+  type: ClusterIP
+  loadBalancerIP: ""
   port: 8090
-# -- Annotations for the DHCP service
-  annotations:
-    metallb.universe.tf/address-pool: pool
-    metallb.universe.tf/allow-shared-ip: beszel-hub-web
-  # -- Labels for the DHCP service
 
 ingress:
   enabled: false
@@ -96,7 +92,7 @@ persistentVolumeClaim:
   accessModes:
     - ReadWriteOnce
 
-  storageClass: "retain-local-path"
+  storageClass: ""
 
   # -- volume claim size
   size: "500Mi"


### PR DESCRIPTION
## 📃 Description

The helm chart doesn't work with an ingress as the service name hard coded `-web`, which can never match the ingress rule.

I've also made the default values less opinionated.

## 🪵 Changelog

### 🔧 Fixed

- The service name in the helm chart could never match the ingress rule.
- Removed opinionated values in helm chart

