### PR TITLE
Fixed OpenWRT agent restarter logic

### DIFF
--- a/agent/update.go
+++ b/agent/update.go
@@ -41,11 +41,11 @@ type openWRTRestarter struct{ cmd string }
 
 func (w *openWRTRestarter) Restart() error {
 	// https://openwrt.org/docs/guide-user/base-system/managing_services?s[]=service
-	if err := exec.Command("service", "beszel-agent", "running").Run(); err != nil {
+	if err := exec.Command("/etc/init.d/beszel-agent", "running").Run(); err != nil {
 		return nil
 	}
 	ghupdate.ColorPrint(ghupdate.ColorYellow, "Restarting beszel-agent via procd…")
-	return exec.Command("service", "beszel-agent", "restart").Run()
+	return exec.Command("/etc/init.d/beszel-agent", "restart").Run()
 }
 
 type freeBSDRestarter struct{ cmd string }
@@ -59,15 +59,15 @@ func (f *freeBSDRestarter) Restart() error {
 }
 
 func detectRestarter() restarter {
-    if path, err := exec.LookPath("procd"); err == nil {
-        return &openWRTRestarter{cmd: path}
-    }
 	if path, err := exec.LookPath("systemctl"); err == nil {
 		return &systemdRestarter{cmd: path}
 	}
 	if path, err := exec.LookPath("rc-service"); err == nil {
 		return &openRCRestarter{cmd: path}
 	}
+    if path, err := exec.LookPath("procd"); err == nil {
+        return &openWRTRestarter{cmd: path}
+    }
 	if path, err := exec.LookPath("service"); err == nil {
 		if runtime.GOOS == "freebsd" {
 			return &freeBSDRestarter{cmd: path}


### PR DESCRIPTION
### 🔧 Fixed

Fixes for:
```
No supported init system detected; please restart manually if needed.
```

- Direct `procd` detection for OpenWrt
- Correct order of command which is `service beszel-agent restart`