### PR TITLE
Modify GPU usage section in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ The [quick start guide](https://beszel.dev/guide/getting-started) and other docu
 - **Network usage** - Host system and containers.
 - **Load average** - Host system.
 - **Temperature** - Host system sensors.
-- **GPU usage / temperature / power draw** - Nvidia and AMD only. Must use binary agent.
+- **GPU usage / power draw** - Nvidia, AMD, and Intel.
 - **Battery** - Host system battery charge.
 
 ## Help and discussion


### PR DESCRIPTION

- Synced section as currently written in https://beszel.dev/guide/what-is-beszel#supported-metrics 
- might want to consider re-using the markdown in future to prevent them deviating. Or personally, I would remove all documentation from README, and use README only for screenshots and "marketing" to funnel people to the docs site.