### PR TITLE
Fix #1214: Add VOLUME ["/beszel_data"] to preserve config across container recreations

### DIFF
--- a/internal/dockerfile_agent
+++ b/internal/dockerfile_agent
@@ -23,4 +23,7 @@ COPY --from=builder /agent /agent
 # this is so we don't need to create the /tmp directory in the scratch container
 COPY --from=builder /tmp /tmp
 
+# Ensure data persistence across container recreations
+VOLUME ["/beszel_data"]
+
 ENTRYPOINT ["/agent"]

--- a/internal/dockerfile_agent_intel
+++ b/internal/dockerfile_agent_intel
@@ -22,4 +22,7 @@ COPY --from=builder /agent /agent
 
 RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing igt-gpu-tools
 
+# Ensure data persistence across container recreations
+VOLUME ["/beszel_data"]
+
 ENTRYPOINT ["/agent"]

--- a/internal/dockerfile_agent_nvidia
+++ b/internal/dockerfile_agent_nvidia
@@ -24,4 +24,7 @@ COPY --from=builder /agent /agent
 # this is so we don't need to create the /tmp directory in the scratch container
 COPY --from=builder /tmp /tmp
 
+# Ensure data persistence across container recreations
+VOLUME ["/beszel_data"]
+
 ENTRYPOINT ["/agent"]

--- a/internal/dockerfile_hub
+++ b/internal/dockerfile_hub
@@ -25,6 +25,9 @@ FROM scratch
 COPY --from=builder /beszel /
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+# Ensure data persistence across container recreations
+VOLUME ["/beszel_data"]
+
 EXPOSE 8090
 
 ENTRYPOINT [ "/beszel" ]


### PR DESCRIPTION
## Description

This PR addresses issue #1214 by adding built-in data persistence to Beszel's agent containers.

Many users deploy Beszel with automated container update tools like Watchtower. If they forget (or don't know) to mount a volume for `/beszel_data`, all configuration is lost every time the container is automatically replaced — leading to unexpected resets and a poor user experience.

To prevent this, i add the following line to all agent Dockerfiles:

```dockerfile
VOLUME ["/beszel_data"]