### PR TITLE
OpenWRT - graceful service stop, restart and respawn if crashes

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -757,18 +757,10 @@ start_service() {
     procd_set_param user beszel
     procd_set_param pidfile /var/run/beszel-agent.pid
     procd_set_param env PORT="$PORT" KEY="$KEY" TOKEN="$TOKEN" HUB_URL="$HUB_URL"
+    procd_set_param respawn
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_close_instance
-}
-
-stop_service() {
-    killall beszel-agent
-}
-
-restart_service() {
-    stop
-    start
 }
 
 # Extra command to trigger agent update


### PR DESCRIPTION
### 🔧 Fixed
- This message:
```
Restarting beszel-agent via procd…
Terminated
```
When you use USE_PROCD=1, procd automatically tracks and stops the process it started.
So normally, you don’t need to manually kill the process — procd does that cleanly on stop_service().
If you override stop_service() with killall, you’re:
Bypassing procd’s PID tracking
Potentially killing unrelated instances
Losing logging and restart behavior consistency

- Added respawn if crashes (default 5s, 5 attempts in 5min)