### PR TITLE
[Feature] Let y axis for temperature not start at 0

### DIFF
--- a/internal/site/src/components/charts/temperature-chart.tsx
+++ b/internal/site/src/components/charts/temperature-chart.tsx
@@ -49,31 +49,6 @@ export default memo(function TemperatureChart({ chartData }: { chartData: ChartD
 
 	const colors = Object.keys(newChartData.colors)
 
-	/** Calculate temperature domain to focus on operating range */
-	const tempDomain = useMemo((): [number, number] | [number, "auto"] => {
-		if (newChartData.data.length === 0) {
-			return [0, "auto"] as [number, "auto"]
-		}
-		let minTemp = Infinity
-		let maxTemp = -Infinity
-		for (const data of newChartData.data) {
-			for (const key of colors) {
-				const temp = data[key] as number
-				if (typeof temp === "number" && !isNaN(temp)) {
-					minTemp = Math.min(minTemp, temp)
-					maxTemp = Math.max(maxTemp, temp)
-				}
-			}
-		}
-		if (minTemp === Infinity || maxTemp === -Infinity) {
-			return [0, "auto"] as [number, "auto"]
-		}
-		// Add 10% padding and round down/up to nice numbers
-		const range = maxTemp - minTemp
-		const padding = Math.max(range * 0.1, 5) // At least 5 degrees padding
-		return [Math.floor(minTemp - padding), Math.ceil(maxTemp + padding)]
-	}, [newChartData.data, colors])
-
 	// console.log('rendered at', new Date())
 
 	return (
@@ -89,7 +64,7 @@ export default memo(function TemperatureChart({ chartData }: { chartData: ChartD
 						direction="ltr"
 						orientation={chartData.orientation}
 						className="tracking-tighter"
-						domain={tempDomain}
+						domain={["auto", "auto"]}
 						width={yAxisWidth}
 						tickFormatter={(val) => {
 							const { value, unit } = formatTemperature(val, userSettings.unitTemp)


### PR DESCRIPTION
## 📃 Description

This PR adjust the temperature chart to not start at 0. Now the changes in temperature are better visible.  

Closes #1306 

<img width="790" height="356" alt="Scherm­afbeelding 2025-10-21 om 19 37 23" src="https://github.com/user-attachments/assets/9d56da11-c32b-4ddc-a694-e992947f86ca" />

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.
