### PR TITLE
Add offline caching to the agent

### DIFF
--- a/agent/agent_offline_cache.go
+++ b/agent/agent_offline_cache.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"sync"
+
+	"github.com/henrygd/beszel/internal/entities/system"
+)
+
+type systemOfflineCache struct {
+	sync.Mutex
+	cache []*system.CombinedData
+}
+
+func NewSystemOfflineCache() *systemOfflineCache {
+	return &systemOfflineCache{
+		cache: make([]*system.CombinedData, 0),
+	}
+}
+
+// GetAll retrieves all cached combined data and clears the cache.
+func (c *systemOfflineCache) GetAll() (result []*system.CombinedData) {
+	c.Lock()
+	defer c.Unlock()
+
+	result = append(result, c.cache...)
+	c.cache = c.cache[:0]
+
+	return result
+}
+
+// Add appends a new combined data snapshot to the cache.
+func (c *systemOfflineCache) Add(data system.CombinedData) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.cache = append(c.cache, &data)
+}

--- a/agent/client.go
+++ b/agent/client.go
@@ -269,7 +269,7 @@ func (client *WebSocketClient) sendResponse(data any, requestID *uint32) error {
 
 		// Set the appropriate typed field based on data type
 		switch v := data.(type) {
-		case *system.CombinedData:
+		case []*system.CombinedData:
 			response.SystemData = v
 		case *common.FingerprintResponse:
 			response.Fingerprint = v

--- a/agent/handlers.go
+++ b/agent/handlers.go
@@ -94,8 +94,10 @@ func (h *GetDataHandler) Handle(hctx *HandlerContext) error {
 	var options common.DataRequestOptions
 	_ = cbor.Unmarshal(hctx.Request.Data, &options)
 
-	sysStats := hctx.Agent.gatherStats(options.CacheTimeMs)
-	return hctx.SendResponse(sysStats, hctx.RequestID)
+	data := hctx.Agent.offlineCache.GetAll()
+	data = append(data, hctx.Agent.gatherStats(options.CacheTimeMs))
+
+	return hctx.SendResponse(data, hctx.RequestID)
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/agent/server.go
+++ b/agent/server.go
@@ -168,7 +168,7 @@ func (a *Agent) handleSSHRequest(w io.Writer, req *common.HubRequest[cbor.RawMes
 	sshResponder := func(data any, requestID *uint32) error {
 		response := common.AgentResponse{Id: requestID}
 		switch v := data.(type) {
-		case *system.CombinedData:
+		case []*system.CombinedData:
 			response.SystemData = v
 		case string:
 			response.String = &v

--- a/internal/alerts/alerts_system.go
+++ b/internal/alerts/alerts_system.go
@@ -108,29 +108,29 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 	}
 
 	systemStats := []struct {
-		Stats   []byte         `db:"stats"`
-		Created types.DateTime `db:"created"`
+		Stats     []byte         `db:"stats"`
+		Timestamp types.DateTime `db:"timestamp"`
 	}{}
 
 	err = am.hub.DB().
-		Select("stats", "created").
+		Select("stats", "timestamp").
 		From("system_stats").
 		Where(dbx.NewExp(
-			"system={:system} AND type='1m' AND created > {:created}",
+			"system={:system} AND type='1m' AND timestamp > {:timestamp}",
 			dbx.Params{
 				"system": systemRecord.Id,
 				// subtract some time to give us a bit of buffer
-				"created": oldestTime.Add(-time.Second * 90),
+				"timestamp": oldestTime.Add(-time.Second * 90),
 			},
 		)).
-		OrderBy("created").
+		OrderBy("timestamp").
 		All(&systemStats)
 	if err != nil || len(systemStats) == 0 {
 		return err
 	}
 
 	// get oldest record creation time from first record in the slice
-	oldestRecordTime := systemStats[0].Created.Time()
+	oldestRecordTime := systemStats[0].Timestamp.Time()
 	// log.Println("oldestRecordTime", oldestRecordTime.String())
 
 	// Filter validAlerts to keep only those with time newer than oldestRecord
@@ -153,7 +153,7 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 	for i := range systemStats {
 		stat := systemStats[i]
 		// subtract 10 seconds to give a small time buffer
-		systemStatsCreation := stat.Created.Time().Add(-time.Second * 10)
+		systemStatsCreation := stat.Timestamp.Time().Add(-time.Second * 10)
 		if err := json.Unmarshal(stat.Stats, &stats); err != nil {
 			return err
 		}

--- a/internal/common/common-ws.go
+++ b/internal/common/common-ws.go
@@ -34,7 +34,7 @@ type HubRequest[T any] struct {
 // AgentResponse defines the structure for responses sent from agent to hub.
 type AgentResponse struct {
 	Id          *uint32                    `cbor:"0,keyasint,omitempty"`
-	SystemData  *system.CombinedData       `cbor:"1,keyasint,omitempty,omitzero"`
+	SystemData  []*system.CombinedData     `cbor:"1,keyasint,omitempty,omitzero"`
 	Fingerprint *FingerprintResponse       `cbor:"2,keyasint,omitempty,omitzero"`
 	Error       string                     `cbor:"3,keyasint,omitempty,omitzero"`
 	String      *string                    `cbor:"4,keyasint,omitempty,omitzero"`

--- a/internal/entities/system/system.go
+++ b/internal/entities/system/system.go
@@ -156,4 +156,5 @@ type CombinedData struct {
 	Info            Info               `json:"info" cbor:"1,keyasint"`
 	Containers      []*container.Stats `json:"container" cbor:"2,keyasint"`
 	SystemdServices []*systemd.Service `json:"systemd,omitempty" cbor:"3,keyasint,omitempty"`
+	Timestamp       *time.Time         `json:"ts,omitempty" cbor:"4,keyasint,omitempty"`
 }

--- a/internal/hub/systems/system_manager.go
+++ b/internal/hub/systems/system_manager.go
@@ -208,7 +208,8 @@ func (sm *SystemManager) onRecordAfterUpdateSuccess(e *core.RecordEvent) error {
 
 	// Trigger system alerts when system comes online
 	if newStatus == up {
-		if err := sm.hub.HandleSystemAlerts(e.Record, system.data); err != nil {
+		// TODO: update this to handle multiple data records
+		if err := sm.hub.HandleSystemAlerts(e.Record, system.data[0]); err != nil {
 			e.App.Logger().Error("Error handling system alerts", "err", err)
 		}
 	}
@@ -243,7 +244,6 @@ func (sm *SystemManager) AddSystem(sys *System) error {
 	// Initialize system for monitoring
 	sys.manager = sm
 	sys.ctx, sys.cancel = sys.getContext()
-	sys.data = &system.CombinedData{}
 	sm.systems.Set(sys.Id, sys)
 
 	// Start monitoring in background

--- a/internal/hub/systems/systems_test_helpers.go
+++ b/internal/hub/systems/systems_test_helpers.go
@@ -61,7 +61,7 @@ func (sm *SystemManager) GetAllSystemIDs() []string {
 // TESTING ONLY: GetSystemData returns the combined data for a system with the given ID
 // Returns nil if the system doesn't exist
 // This method is intended for testing
-func (sm *SystemManager) GetSystemData(systemID string) *entities.CombinedData {
+func (sm *SystemManager) GetSystemData(systemID string) []*entities.CombinedData {
 	sys, ok := sm.systems.GetOk(systemID)
 	if !ok {
 		return nil

--- a/internal/hub/ws/handlers.go
+++ b/internal/hub/ws/handlers.go
@@ -32,7 +32,7 @@ func (h *BaseHandler) HandleLegacy(rawData []byte) error {
 
 // systemDataHandler implements ResponseHandler for system data requests
 type systemDataHandler struct {
-	data *system.CombinedData
+	data *[]*system.CombinedData
 }
 
 func (h *systemDataHandler) HandleLegacy(rawData []byte) error {
@@ -40,14 +40,12 @@ func (h *systemDataHandler) HandleLegacy(rawData []byte) error {
 }
 
 func (h *systemDataHandler) Handle(agentResponse common.AgentResponse) error {
-	if agentResponse.SystemData != nil {
-		*h.data = *agentResponse.SystemData
-	}
+	*h.data = append(*h.data, agentResponse.SystemData...)
 	return nil
 }
 
 // RequestSystemData requests system metrics from the agent and unmarshals the response.
-func (ws *WsConn) RequestSystemData(ctx context.Context, data *system.CombinedData, options common.DataRequestOptions) error {
+func (ws *WsConn) RequestSystemData(ctx context.Context, data *[]*system.CombinedData, options common.DataRequestOptions) error {
 	if !ws.IsConnected() {
 		return gws.ErrConnClosed
 	}

--- a/internal/migrations/1761659006_add_time.go
+++ b/internal/migrations/1761659006_add_time.go
@@ -1,0 +1,69 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	var collectionNames = []string{"system_stats", "container_stats"}
+
+	m.Register(func(app core.App) error {
+		return app.RunInTransaction(func(txApp core.App) error {
+			updateCollection := func(collectionName string) error {
+				fmt.Println("Updating collection:", collectionName)
+				collection, err := txApp.FindCollectionByNameOrId(collectionName)
+				if err != nil {
+					return err
+				}
+
+				collection.Fields.Add(&core.DateField{
+					Name:     "timestamp",
+					Required: true,
+				})
+
+				err = txApp.Save(collection)
+				if err != nil {
+					return err
+				}
+
+				query := fmt.Sprintf("UPDATE %s SET timestamp = created", collectionName)
+				fmt.Println("Running query:", query)
+				_, err = txApp.DB().NewQuery(query).Execute()
+				return err
+			}
+
+			for _, collectionName := range collectionNames {
+				err := updateCollection(collectionName)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}, func(app core.App) error {
+		return app.RunInTransaction(func(txApp core.App) error {
+			revertCollection := func(collectionName string) error {
+				fmt.Println("Reverting collection:", collectionName)
+				collection, err := txApp.FindCollectionByNameOrId(collectionName)
+				if err != nil {
+					return err
+				}
+				collection.Fields.RemoveByName("timestamp")
+				return txApp.Save(collection)
+			}
+
+			for _, collectionName := range collectionNames {
+				err := revertCollection(collectionName)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	})
+}

--- a/internal/site/src/components/alerts-history-columns.tsx
+++ b/internal/site/src/components/alerts-history-columns.tsx
@@ -100,8 +100,8 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 		},
 	},
 	{
-		accessorKey: "created",
-		accessorFn: (record) => formatShortDate(record.created),
+		accessorKey: "timestamp",
+		accessorFn: (record) => formatShortDate(record.timestamp),
 		enableSorting: true,
 		invertSorting: true,
 		header: ({ column }) => (
@@ -110,7 +110,7 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 			</Button>
 		),
 		cell: ({ getValue, row }) => (
-			<span className="ps-1 tabular-nums tracking-tight" title={`${row.original.created} UTC`}>
+			<span className="ps-1 tabular-nums tracking-tight" title={`${row.original.timestamp} UTC`}>
 				{getValue() as string}
 			</span>
 		),
@@ -141,12 +141,12 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 		invertSorting: true,
 		enableSorting: true,
 		sortingFn: (rowA, rowB) => {
-			const aCreated = new Date(rowA.original.created)
-			const bCreated = new Date(rowB.original.created)
+			const aTimestamp = new Date(rowA.original.timestamp)
+			const bTimestamp = new Date(rowB.original.timestamp)
 			const aResolved = rowA.original.resolved ? new Date(rowA.original.resolved) : null
 			const bResolved = rowB.original.resolved ? new Date(rowB.original.resolved) : null
-			const aDuration = aResolved ? aResolved.getTime() - aCreated.getTime() : null
-			const bDuration = bResolved ? bResolved.getTime() - bCreated.getTime() : null
+			const aDuration = aResolved ? aResolved.getTime() - aTimestamp.getTime() : null
+			const bDuration = bResolved ? bResolved.getTime() - bTimestamp.getTime() : null
 			if (!aDuration && bDuration) return -1
 			if (aDuration && !bDuration) return 1
 			return (aDuration || 0) - (bDuration || 0)
@@ -157,7 +157,7 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 			</Button>
 		),
 		cell: ({ row }) => {
-			const duration = formatDuration(row.original.created, row.original.resolved)
+			const duration = formatDuration(row.original.timestamp, row.original.resolved)
 			if (!duration) {
 				return null
 			}

--- a/internal/site/src/components/charts/area-chart.tsx
+++ b/internal/site/src/components/charts/area-chart.tsx
@@ -95,7 +95,7 @@ export default function AreaChartDefault({
 							itemSorter={itemSorter}
 							content={
 								<ChartTooltipContent
-									labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+									labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 									contentFormatter={contentFormatter}
 									showTotal={showTotal}
 								/>

--- a/internal/site/src/components/charts/container-chart.tsx
+++ b/internal/site/src/components/charts/container-chart.tsx
@@ -137,7 +137,7 @@ export default memo(function ContainerChart({
 						animationEasing="ease-out"
 						animationDuration={150}
 						truncate={true}
-						labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+						labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 						// @ts-expect-error
 						itemSorter={(a, b) => b.value - a.value}
 						content={<ChartTooltipContent filter={filter} contentFormatter={toolTipFormatter} showTotal={true} />}

--- a/internal/site/src/components/charts/disk-chart.tsx
+++ b/internal/site/src/components/charts/disk-chart.tsx
@@ -58,7 +58,7 @@ export default memo(function DiskChart({
 						animationDuration={150}
 						content={
 							<ChartTooltipContent
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={({ value }) => {
 									const { value: convertedValue, unit } = formatBytes(value * 1024, false, Unit.Bytes, true)
 									return decimalString(convertedValue) + " " + unit

--- a/internal/site/src/components/charts/gpu-power-chart.tsx
+++ b/internal/site/src/components/charts/gpu-power-chart.tsx
@@ -28,7 +28,7 @@ export default memo(function GpuPowerChart({ chartData }: { chartData: ChartData
 
 		for (const stats of chartData.systemStats) {
 			const gpus = stats.stats?.g ?? {}
-			const data = { created: stats.created } as Record<string, GPUData | string>
+			const data = { timestamp: stats.timestamp } as Record<string, GPUData | string>
 			for (const id in gpus) {
 				const gpu = gpus[id] as GPUData
 				data[gpu.n] = gpu
@@ -91,7 +91,7 @@ export default memo(function GpuPowerChart({ chartData }: { chartData: ChartData
 						itemSorter={(a, b) => b.value - a.value}
 						content={
 							<ChartTooltipContent
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={(item) => `${decimalString(item.value)}W`}
 								// indicator="line"
 							/>

--- a/internal/site/src/components/charts/line-chart.tsx
+++ b/internal/site/src/components/charts/line-chart.tsx
@@ -78,7 +78,7 @@ export default function LineChartDefault({
 							itemSorter={itemSorter}
 							content={
 								<ChartTooltipContent
-									labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+									labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 									contentFormatter={contentFormatter}
 								/>
 							}

--- a/internal/site/src/components/charts/load-average-chart.tsx
+++ b/internal/site/src/components/charts/load-average-chart.tsx
@@ -61,7 +61,7 @@ export default memo(function LoadAverageChart({ chartData }: { chartData: ChartD
 						animationDuration={150}
 						content={
 							<ChartTooltipContent
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={(item) => decimalString(item.value)}
 							/>
 						}

--- a/internal/site/src/components/charts/mem-chart.tsx
+++ b/internal/site/src/components/charts/mem-chart.tsx
@@ -55,7 +55,7 @@ export default memo(function MemChart({ chartData, showMax }: { chartData: Chart
 							<ChartTooltipContent
 								// @ts-expect-error
 								itemSorter={(a, b) => a.order - b.order}
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={({ value }) => {
 									// mem values are supplied as GB
 									const { value: convertedValue, unit } = formatBytes(value * 1024, false, Unit.Bytes, true)

--- a/internal/site/src/components/charts/swap-chart.tsx
+++ b/internal/site/src/components/charts/swap-chart.tsx
@@ -44,7 +44,7 @@ export default memo(function SwapChart({ chartData }: { chartData: ChartData }) 
 						animationDuration={150}
 						content={
 							<ChartTooltipContent
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={({ value }) => {
 									// mem values are supplied as GB
 									const { value: convertedValue, unit } = formatBytes(value * 1024, false, userSettings.unitDisk, true)

--- a/internal/site/src/components/charts/temperature-chart.tsx
+++ b/internal/site/src/components/charts/temperature-chart.tsx
@@ -31,7 +31,7 @@ export default memo(function TemperatureChart({ chartData }: { chartData: ChartD
 		}
 		const tempSums = {} as Record<string, number>
 		for (const data of chartData.systemStats) {
-			const newData = { created: data.created } as Record<string, number | string>
+			const newData = { timestamp: data.timestamp } as Record<string, number | string>
 			const keys = Object.keys(data.stats?.t ?? {})
 			for (let i = 0; i < keys.length; i++) {
 				const key = keys[i]
@@ -81,7 +81,7 @@ export default memo(function TemperatureChart({ chartData }: { chartData: ChartD
 						itemSorter={(a, b) => b.value - a.value}
 						content={
 							<ChartTooltipContent
-								labelFormatter={(_, data) => formatShortDate(data[0].payload.created)}
+								labelFormatter={(_, data) => formatShortDate(data[0].payload.timestamp)}
 								contentFormatter={(item) => {
 									const { value, unit } = formatTemperature(item.value, userSettings.unitTemp)
 									return decimalString(value) + " " + unit

--- a/internal/site/src/components/routes/settings/alerts-history-data-table.tsx
+++ b/internal/site/src/components/routes/settings/alerts-history-data-table.tsx
@@ -78,13 +78,13 @@ export default function AlertsHistoryDataTable() {
 		let unsubscribe: (() => void) | undefined
 		const pbOptions = {
 			expand: "system",
-			fields: "id,name,value,state,created,resolved,expand.system.name",
+			fields: "id,name,value,state,timestamp,resolved,expand.system.name",
 		}
 		// Initial load
 		pb.collection<AlertsHistoryRecord>("alerts_history")
 			.getList(0, 200, {
 				...pbOptions,
-				sort: "-created",
+				sort: "-timestamp",
 			})
 			.then(({ items }) => setData(items))
 
@@ -156,12 +156,12 @@ export default function AlertsHistoryDataTable() {
 		globalFilterFn: (row, _columnId, filterValue) => {
 			const system = row.original.expand?.system?.name ?? ""
 			const name = row.getValue("name") ?? ""
-			const created = row.getValue("created") ?? ""
+			const timestamp = row.getValue("timestamp") ?? ""
 			const search = String(filterValue).toLowerCase()
 			return (
 				system.toLowerCase().includes(search) ||
 				(name as string).toLowerCase().includes(search) ||
-				(created as string).toLowerCase().includes(search)
+				(timestamp as string).toLowerCase().includes(search)
 			)
 		},
 	})
@@ -202,9 +202,9 @@ export default function AlertsHistoryDataTable() {
 			name: (record) => alertInfo[record.name]?.name() || record.name,
 			value: (record) => record.value + (alertInfo[record.name]?.unit ?? ""),
 			state: (record) => (record.resolved ? t`Resolved` : t`Active`),
-			created: (record) => formatShortDate(record.created),
+			timestamp: (record) => formatShortDate(record.timestamp),
 			resolved: (record) => (record.resolved ? formatShortDate(record.resolved) : ""),
-			duration: (record) => (record.resolved ? formatDuration(record.created, record.resolved) : ""),
+			duration: (record) => (record.resolved ? formatDuration(record.timestamp, record.resolved) : ""),
 		}
 		const csvRows = [Object.keys(cells).join(",")]
 		for (const row of selectedRows) {

--- a/internal/site/src/components/ui/chart.tsx
+++ b/internal/site/src/components/ui/chart.tsx
@@ -431,7 +431,7 @@ const xAxis = ({ domain, ticks, chartTime }: ChartData) => {
 	}
 	cachedAxis = (
 		<RechartsPrimitive.XAxis
-			dataKey="created"
+			dataKey="timestamp"
 			domain={domain}
 			ticks={ticks}
 			allowDataOverflow

--- a/internal/site/src/lib/utils.ts
+++ b/internal/site/src/lib/utils.ts
@@ -329,15 +329,15 @@ export const tokenMap = new Map<SystemRecord["id"], FingerprintRecord["token"]>(
 
 /** Calculate duration between two dates and format as human-readable string */
 export function formatDuration(
-	createdDate: string | null | undefined,
+	timestampDate: string | null | undefined,
 	resolvedDate: string | null | undefined
 ): string {
-	const created = createdDate ? new Date(createdDate) : null
+	const timestamp = timestampDate ? new Date(timestampDate) : null
 	const resolved = resolvedDate ? new Date(resolvedDate) : null
 
-	if (!created || !resolved) return ""
+	if (!timestamp || !resolved) return ""
 
-	const diffMs = resolved.getTime() - created.getTime()
+	const diffMs = resolved.getTime() - timestamp.getTime()
 	if (diffMs < 0) return ""
 
 	const totalSeconds = Math.floor(diffMs / 1000)

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -202,7 +202,7 @@ export interface ExtraFsStats {
 export interface ContainerStatsRecord extends RecordModel {
 	system: string
 	stats: ContainerStats[]
-	created: string | number
+	timestamp: string | number
 }
 
 interface ContainerStats {
@@ -221,7 +221,7 @@ interface ContainerStats {
 export interface SystemStatsRecord extends RecordModel {
 	system: string
 	stats: SystemStats
-	created: string | number
+	timestamp: string | number
 }
 
 export interface AlertRecord extends RecordModel {
@@ -240,7 +240,7 @@ export interface AlertsHistoryRecord extends RecordModel {
 	system: string
 	name: string
 	val: number
-	created: string
+	timestamp: string
 	resolved?: string | null
 }
 
@@ -299,9 +299,9 @@ export interface UserSettings {
 }
 
 type ChartDataContainer = {
-	created: number | null
+	timestamp: number | null
 } & {
-	[key: string]: key extends "created" ? never : ContainerStats
+	[key: string]: key extends "timestamp" ? never : ContainerStats
 }
 
 export interface SemVer {


### PR DESCRIPTION
## 📃 Description

This pull request adds offline caching capabilities to the agent as discussed in https://github.com/henrygd/beszel/issues/1262. The goal is to keep gathering statistics while the agent cannot reach the hub. Once the connection is restored the backlog is committed to the hub.

Currently there is a basic cache implemented for the agent. What still needs to be done before this can be merged:

- [ ] Add support to the hub for processing multiple statistics at once without breaking compatibility with older clients.
- [ ] Check if alerts need to be changed to timestamp as well.
- [ ] Add graph to the hub for showing connection status over time. To indicate which measurements were live and which were cached.
- [ ] Add tests.

Closes https://github.com/henrygd/beszel/issues/1262

## 🪵 Changelog

### ➕ Added

- Offline cache to the agent
- `Timestamp` field to the `CombinedData` struct
- `Timestamp` field to the database instead of using the `created` field. This allows the data to be backfilled.

### ✏️ Changed

- `AgentResponse` `SystemData` field is now an array of `[]*system.CombinedData`. This is a breaking change for older agents.
