### PR TITLE
Set a dynamic upper domain on the YAxis for container chart

### DIFF
--- a/internal/site/src/components/charts/container-chart.tsx
+++ b/internal/site/src/components/charts/container-chart.tsx
@@ -124,6 +124,7 @@ export default memo(function ContainerChart({
 					<CartesianGrid vertical={false} />
 					<YAxis
 						direction="ltr"
+						domain={[0, 'dataMax']}
 						orientation={chartData.orientation}
 						className="tracking-tighter"
 						width={yAxisWidth}


### PR DESCRIPTION
<img width="716" height="318" alt="Screenshot 2025-11-13 at 18-08-53 Lenovo M720q _ Beszel" src="https://github.com/user-attachments/assets/4812efde-55f4-4092-9833-ba0b70a2c04e" />
<img width="716" height="318" alt="Screenshot 2025-11-13 at 18-08-45 Lenovo M720q _ Beszel" src="https://github.com/user-attachments/assets/8c5d0dd7-0b47-4360-aeaa-3746c86956f9" />
<img width="716" height="318" alt="Screenshot 2025-11-13 at 18-08-14 Lenovo M720q _ Beszel" src="https://github.com/user-attachments/assets/499d4953-4cf6-4d8c-89a9-2b5b6147b449" />
<img width="716" height="318" alt="Screenshot 2025-11-13 at 18-07-56 Lenovo M720q _ Beszel" src="https://github.com/user-attachments/assets/ab3e661e-af84-44c3-bb56-2dcfec8743ac" />

Recharts `YAxis` setting `domain={[0, 'dataMax']}` is correct for ensuring your Y-axis dynamically updates when metrics are lowering, while simultaneously keeping the axis floor at zero.

---

How `domain={[0, 'dataMax']}` works

This setting is widely used and provides a good balance of dynamism and stability for data visualization:

1.  **`0` (Fixed Minimum):** By setting the minimum value to `0`, you **anchor the baseline** of your chart. This is a crucial practice in data visualization as it prevents misleading visual drops that can occur when the Y-axis minimum is a non-zero value.
2.  **`'dataMax'` (Dynamic Maximum):** This keyword tells Recharts to calculate the **absolute maximum value** found in your current dataset and use that value as the Y-axis maximum.
    * When your metrics **lower**, the data maximum decreases. Recharts detects this change, re-calculates the scale, and redraws the `YAxis` ticks and the `CartesianGrid` horizontal lines accordingly.
    * When your metrics **increase**, the data maximum increases, and the axis automatically scales up.

### Why It's Effective for Lowering Metrics

As discussed, the `CartesianGrid` relies entirely on the ticks generated by the `YAxis`. When your data's highest value decreases (metrics are lowering), the `YAxis` uses the new, smaller `'dataMax'`, which results in:

* A smaller overall **domain** (e.g., from $[0, 100]$ to $[0, 50]$).
* Recalculated **ticks** (fewer or closer together).
* A dynamically updated **`CartesianGrid`** reflecting these new tick positions.