### PR TITLE
Font ligatures create unwanted artifacts in random ids

### DIFF
--- a/internal/site/src/index.css
+++ b/internal/site/src/index.css
@@ -142,6 +142,7 @@
 
 	body {
 		@apply bg-background text-foreground;
+		font-variant-ligatures: no-contextual;
 	}
 
 	button {


### PR DESCRIPTION
## 📃 Description

When monitoring resources (i.e. containers) that are named using random id schemes, the current font setup will sometimes turn certain sequences into ligatures (e.g. `x` is interpreted as multiplication when in between two numbers). This creates visual noise that is slightly confusing.

Let me know if adding this globally is unwanted and the rule should be applied selectively only (if at all).

## 📖 Documentation

n/a

## 🪵 Changelog

Disabled font-ligatures for all text content.

## 📷 Screenshots

Before:

<img width="279" height="355" alt="image" src="https://github.com/user-attachments/assets/58c7db7b-1816-428b-8fa5-6ee5b1ff604f" />

After:

<img width="279" height="355" alt="image" src="https://github.com/user-attachments/assets/3a694530-fa1a-4c11-a1fc-1775330ab281" />
