### PR TITLE
[Feature] Add crossorigin attribute to manifest link

### DIFF
--- a/internal/site/index.html
+++ b/internal/site/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="manifest" href="./static/manifest.json" />
+		<link rel="manifest" href="./static/manifest.json" crossorigin="use-credentials" />
 		<link rel="icon" type="image/svg+xml" href="./static/icon.svg" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0,maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 		<meta name="robots" content="noindex, nofollow" />


### PR DESCRIPTION
## 📃 Description

This PR adds the crossorigin="use-credentials" attribute to the web app manifest link in the HTML head. This enables the manifest file to be fetched with credentials (cookies, authorization headers, etc.) when loaded from a different origin, which is required for proper CORS handling in cross-origin scenarios.

### ➕ Added

- added crossorigin="use-credentials" attribute to the <link rel="manifest"> tag
