### PR TITLE
fix: When there is no client, LoaderCircle will always transfer

### DIFF
--- a/internal/site/src/components/containers-table/containers-table.tsx
+++ b/internal/site/src/components/containers-table/containers-table.tsx
@@ -55,8 +55,11 @@ export default function ContainersTable({ systemId }: { systemId?: string }) {
 					filter: systemId ? pb.filter("system={:system}", { system: systemId }) : undefined,
 				})
 				.then(
-					({ items }) =>
-						items.length &&
+					({ items }) => {
+						if (items.length === 0) {
+							setData([]);
+							return;
+						}
 						setData((curItems) => {
 							const lastUpdated = Math.max(items[0].updated, items.at(-1)?.updated ?? 0)
 							const containerIds = new Set()
@@ -74,6 +77,7 @@ export default function ContainersTable({ systemId }: { systemId?: string }) {
 							}
 							return newItems
 						})
+					}
 				)
 		}
 
@@ -333,12 +337,12 @@ function ContainerSheet({
 		setLogsDisplay("")
 		setInfoDisplay("")
 		if (!container) return
-		;(async () => {
-			const [logsHtml, infoHtml] = await Promise.all([getLogsHtml(container), getInfoHtml(container)])
-			setLogsDisplay(logsHtml)
-			setInfoDisplay(infoHtml)
-			setTimeout(scrollLogsToBottom, 20)
-		})()
+			;(async () => {
+				const [logsHtml, infoHtml] = await Promise.all([getLogsHtml(container), getInfoHtml(container)])
+				setLogsDisplay(logsHtml)
+				setInfoDisplay(infoHtml)
+				setTimeout(scrollLogsToBottom, 20)
+			})()
 	}, [container])
 
 	return (


### PR DESCRIPTION
## 📃 Description

Bug：When there are no Systems (or the PB items list is empty), the All Containers page would stay in a permanent loading state (the LoaderCircle spinner never goes away).

<img width="2262" height="690" alt="image" src="https://github.com/user-attachments/assets/d01a7b05-839e-4209-9643-e2b5e16423a3" />
<img width="2256" height="678" alt="image" src="https://github.com/user-attachments/assets/c8cb345d-1c7c-493b-9731-4b527ce2ca48" />

## 📖 Reason

**Root cause**: the code only called setData(...) when items.length > 0 (using items.length && setData(...)), so when items was empty the data state remained undefined and the UI treated that as “still loading”.

### 🔧 Fixed

When pb.collection(...).getList(...) returns an empty items, call setData([]) so data reflects “loaded but no items”.

## 📷 Screenshots

After fixed：

<img width="2279" height="672" alt="image" src="https://github.com/user-attachments/assets/d7567876-d012-4be1-aee5-c2ea9ef34675" />
