### PR TITLE
fix non unique fingerprint

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -233,7 +233,8 @@ func (a *Agent) getFingerprint() string {
 
 	// if no fingerprint is found, generate one
 	fingerprint, err := host.HostID()
-	if err != nil || fingerprint == "" {
+	// we ignore a commonly known "product_uuid" known not to be unique
+	if err != nil || fingerprint == "" || fingerprint == "03000200-0400-0500-0006-000700080009" {
 		fingerprint = a.systemDetails.Hostname + a.systemDetails.CpuModel
 	}
 


### PR DESCRIPTION
## 📃 Description

As [explained here](https://github.com/henrygd/beszel/issues/1277#issuecomment-3672596467) and [here](https://en.wikipedia.org/wiki/Universally_unique_identifier#cite_note-28), some motherboards have non-unique product_uuid's which leads to non-unique fingerprints.

## 📖 Documentation

n/a

## 🪵 Changelog

### 🔧 Fixed

- Unique fingerprints are now generated for motherboards with a product_uuid that is known to be broken/non-unique.
