### PR TITLE
fix: use origin country flags for Spanish and Portuguese languages

### DIFF
--- a/internal/site/src/lib/languages.ts
+++ b/internal/site/src/lib/languages.ts
@@ -27,7 +27,7 @@ export default [
 	{
 		lang: "en",
 		label: "English",
-		e: "🇺🇸",
+		e: "🇬🇧",
 	},
 	{
 		lang: "es",


### PR DESCRIPTION
## 📃 Description

Changed flag emojis to use the country of origin for Spanish and Portuguese languages, following the pattern of other European languages (French→🇫🇷, German→🇩🇪, Italian→🇮🇹).

## 🪵 Changelog

### 🔧 Fixed

- Spanish now displays 🇪🇸 (Spain) instead of 🇲🇽 (Mexico)
- Portuguese now displays 🇵🇹 (Portugal) instead of 🇧🇷 (Brazil)

