### PR TITLE
nvml: add rtd3 memory workaround, fix slog imports

### DIFF
--- a/agent/gpu.go
+++ b/agent/gpu.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/henrygd/beszel/internal/entities/system"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 const (

--- a/agent/gpu_nvml.go
+++ b/agent/gpu_nvml.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ebitengine/purego"
 	"github.com/henrygd/beszel/internal/entities/system"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // NVML constants and types

--- a/agent/gpu_nvml_linux.go
+++ b/agent/gpu_nvml_linux.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/ebitengine/purego"
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 func openLibrary(name string) (uintptr, error) {

--- a/agent/handlers.go
+++ b/agent/handlers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/henrygd/beszel/internal/common"
 	"github.com/henrygd/beszel/internal/entities/smart"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // HandlerContext provides context for request handlers

--- a/agent/smart.go
+++ b/agent/smart.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/henrygd/beszel/internal/entities/smart"
 
-	"golang.org/x/exp/slog"
+	"log/slog"
 )
 
 // SmartManager manages data collection for SMART devices


### PR DESCRIPTION
Only call MemoryInfo NVML APIs if the GPU is actually being used by checking `> 0% usage`. Fixes RTD3 since the MemoryInfo NVML APIs seem to refresh the 21 second suspend window.

Also fixed slog imports since the difference packages have different global log instances therefore breaking logging.