### PR TITLE
fix: [Bug]: Websockets not properly displayed

### DIFF
--- a/internal/hub/ws/ws.go
+++ b/internal/hub/ws/ws.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"errors"
+	"net/http"
 	"time"
 	"weak"
 
@@ -47,7 +48,11 @@ func GetUpgrader() *gws.Upgrader {
 		return upgrader
 	}
 	handler := &Handler{}
-	upgrader = gws.NewUpgrader(handler, &gws.ServerOption{})
+	upgrader = gws.NewUpgrader(handler, &gws.ServerOption{
+		ResponseHeader: http.Header{
+			"X-Accel-Buffering": []string{"no"},
+		},
+	})
 	return upgrader
 }
 


### PR DESCRIPTION
Fixes #1590

## Changes
- Add X-Accel-Buffering: no header to WebSocket upgrader response
- Prevents reverse proxies (especially Nginx) from buffering WebSocket connections