### PR TITLE
site: only hide GPU power graph if entire timescale is 0W

### DIFF
--- a/internal/site/src/components/routes/system.tsx
+++ b/internal/site/src/components/routes/system.tsx
@@ -402,7 +402,13 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 	const dataEmpty = !chartLoading && chartData.systemStats.length === 0
 	const lastGpuVals = Object.values(systemStats.at(-1)?.stats.g ?? {})
 	const hasGpuData = lastGpuVals.length > 0
-	const hasGpuPowerData = lastGpuVals.some((gpu) => gpu.p !== undefined || gpu.pp !== undefined)
+	const hasGpuPowerData = systemStats.some((record) => {
+		const gpus = record.stats?.g
+		if (!gpus) {
+			return false
+		}
+		return Object.values(gpus).some((gpu) => gpu.p !== undefined || gpu.pp !== undefined)
+	})
 	const hasGpuEnginesData = lastGpuVals.some((gpu) => gpu.e !== undefined)
 	const isLinux = !(details?.os ?? system.info?.os)
 	const isPodman = details?.podman ?? system.info?.p ?? false


### PR DESCRIPTION
### Description

Current logic hides the GPU power usage graph when a sample reports 0W. This means that useful history is hidden when a GPU enters RTD3 D3cold suspend and drops to 0W. This change _should_ leave the graph up unless the entire history of the current timescale on it is 0W.

Related to RTD3 NVML changes (#1522)

### Testing

I am crashing trying to npm run / build this on main and this branch so if you could test that would be much appreciated. 

```
$ npm --version
11.7.0
$ node --version
v25.2.1
$ npm run dev --host 0.0.0.0
npm warn "0.0.0.0" is being parsed as a normal command line argument.
npm warn Unknown cli config "--host". This will stop working in the next major version of npm.

> beszel@0.18.0-beta.2 dev
> vite --host 0.0.0.0

[1]    481847 bus error (core dumped)  npm run dev --host 0.0.0.0
```

### Screencast of old behavior

https://github.com/user-attachments/assets/dca17edc-3bb4-41b2-86ca-838ac3e9bb33



