### PR TITLE
Jetson tegrastats regex pre jetpack5

### DIFF
--- a/agent/gpu.go
+++ b/agent/gpu.go
@@ -137,7 +137,7 @@ func (gm *GPUManager) getJetsonParser() func(output []byte) bool {
 	// use closure to avoid recompiling the regex
 	ramPattern := regexp.MustCompile(`RAM (\d+)/(\d+)MB`)
 	gr3dPattern := regexp.MustCompile(`GR3D_FREQ (\d+)%`)
-	tempPattern := regexp.MustCompile(`tj|GPU@(\d+\.?\d*)C`)
+	tempPattern := regexp.MustCompile(`(?:tj|GPU)@(\d+\.?\d*)C`)
 	// Orin Nano / NX do not have GPU specific power monitor
 	// TODO: Maybe use VDD_IN for Nano / NX and add a total system power chart
 	powerPattern := regexp.MustCompile(`(GPU_SOC|CPU_GPU_CV)\s+(\d+)mW|VDD_SYS_GPU\s+(\d+)/\d+`)


### PR DESCRIPTION
## 📃 Description

Added regex catching groups for GPU temperature and power in pre jetpack 5.

Example Output:
`RAM 3276/7859MB (lfb 5x4MB) SWAP 1626/12122MB (cached 181MB) CPU [44%@1421,49%@2031,67%@2034,17%@1420,25%@1419,8%@1420] EMC_FREQ 1%@1866 GR3D_FREQ 0%@114 APE 150 MTS fg 1% bg 1% PLL@42.5C MCPU@42.5C PMIC@50C Tboard@38C GPU@39.5C BCPU@42.5C thermal@41.3C Tdiode@39.25C VDD_SYS_GPU 182/182 VDD_SYS_SOC 730/730 VDD_4V0_WIFI 0/0 VDD_IN 5297/5297 VDD_SYS_CPU 1917/1917 VDD_SYS_DDR 1241/1241`

Values wanted:
-`182` from `VDD_SYS_GPU 182/182`
-`39.5` from `GPU@39.5C`

### ✏️ Changed
In `getJetsonParser`:
-Added Second catching group for `powerPattern`, `VDD_SYS_GPU` without `mW`.
-Added `GPU` alternative for `tempPattern`.



