### PR TITLE
feat: Added tooltips for navbar buttons to clear meaning of each one

### DIFF
--- a/internal/site/src/components/lang-toggle.tsx
+++ b/internal/site/src/components/lang-toggle.tsx
@@ -10,32 +10,32 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip"
 export function LangToggle() {
 	const { i18n } = useLingui()
 
+	const LangTrans = <Trans>Language</Trans>
+
 	return (
-		<Tooltip>
-			<TooltipTrigger>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
+		<DropdownMenu>
+			<DropdownMenuTrigger>
+				<Tooltip>
+					<TooltipTrigger asChild>
 						<Button variant={"ghost"} size="icon" className="hidden sm:flex">
 							<LanguagesIcon className="absolute h-[1.2rem] w-[1.2rem] light:opacity-85" />
-							<span className="sr-only">Language</span>
+							<span className="sr-only">{LangTrans}</span>
 						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent className="grid grid-cols-3">
-						{languages.map(([lang, label, e]) => (
-							<DropdownMenuItem
-								key={lang}
-								className={cn("px-2.5 flex gap-2.5 cursor-pointer", lang === i18n.locale && "bg-accent/70 font-medium")}
-								onClick={() => dynamicActivate(lang)}
-							>
-								<span>{e}</span> {label}
-							</DropdownMenuItem>
-						))}
-					</DropdownMenuContent>
-				</DropdownMenu>
-			</TooltipTrigger>
-			<TooltipContent>
-				<Trans>Switch language</Trans>
-			</TooltipContent>
-		</Tooltip>
+					</TooltipTrigger>
+					<TooltipContent>{LangTrans}</TooltipContent>
+				</Tooltip>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent className="grid grid-cols-3">
+				{languages.map(([lang, label, e]) => (
+					<DropdownMenuItem
+						key={lang}
+						className={cn("px-2.5 flex gap-2.5 cursor-pointer", lang === i18n.locale && "bg-accent/70 font-medium")}
+						onClick={() => dynamicActivate(lang)}
+					>
+						<span>{e}</span> {label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
 	)
 }

--- a/internal/site/src/components/mode-toggle.tsx
+++ b/internal/site/src/components/mode-toggle.tsx
@@ -3,6 +3,7 @@ import { MoonStarIcon, SunIcon } from "lucide-react"
 import { useTheme } from "@/components/theme-provider"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip"
+import { Trans } from "@lingui/react/macro"
 
 export function ModeToggle() {
 	const { theme, setTheme } = useTheme()
@@ -21,7 +22,7 @@ export function ModeToggle() {
 				</Button>
 			</TooltipTrigger>
 			<TooltipContent>
-				{theme === "dark" ? t`Switch to light mode` : t`Switch to dark mode`}
+				<Trans>Toggle theme</Trans>
 			</TooltipContent>
 		</Tooltip>
 	)

--- a/internal/site/src/components/navbar.tsx
+++ b/internal/site/src/components/navbar.tsx
@@ -49,6 +49,7 @@ export default function Navbar() {
 			</Link>
 			<SearchButton />
 
+			{/** biome-ignore lint/a11y/noStaticElementInteractions: ignore */}
 			<div className="flex items-center ms-auto" onMouseEnter={() => import("@/components/routes/settings/general")}>
 				<Tooltip>
 					<TooltipTrigger asChild>
@@ -61,7 +62,7 @@ export default function Navbar() {
 						</Link>
 					</TooltipTrigger>
 					<TooltipContent>
-						<Trans>Containers</Trans>
+						<Trans>All Containers</Trans>
 					</TooltipContent>
 				</Tooltip>
 				<Tooltip>
@@ -156,14 +157,14 @@ export default function Navbar() {
 	)
 }
 
+const Kbd = ({ children }: { children: React.ReactNode }) => (
+	<kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
+		{children}
+	</kbd>
+)
+
 function SearchButton() {
 	const [open, setOpen] = useState(false)
-
-	const Kbd = ({ children }: { children: React.ReactNode }) => (
-		<kbd className="pointer-events-none inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground opacity-100">
-			{children}
-		</kbd>
-	)
 
 	return (
 		<>

--- a/internal/site/src/components/routes/system/info-bar.tsx
+++ b/internal/site/src/components/routes/system/info-bar.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { FreeBsdIcon, TuxIcon, WebSocketIcon, WindowsIcon } from "@/components/ui/icons"
 import { Separator } from "@/components/ui/separator"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConnectionType, connectionTypeLabels, Os, SystemStatus } from "@/lib/enums"
 import { cn, formatBytes, getHostDisplayValue, secondsToString, toFixedFloat } from "@/lib/utils"
 import type { ChartData, SystemDetailsRecord, SystemRecord } from "@/types"
@@ -135,43 +135,41 @@ export default function InfoBar({
 				<div>
 					<h1 className="text-[1.6rem] font-semibold mb-1.5">{system.name}</h1>
 					<div className="flex flex-wrap items-center gap-3 gap-y-2 text-sm opacity-90">
-						<TooltipProvider>
-							<Tooltip>
-								<TooltipTrigger asChild>
-									<div className="capitalize flex gap-2 items-center">
-										<span className={cn("relative flex h-3 w-3")}>
-											{system.status === SystemStatus.Up && (
-												<span
-													className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
-													style={{ animationDuration: "1.5s" }}
-												></span>
-											)}
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<div className="capitalize flex gap-2 items-center">
+									<span className={cn("relative flex h-3 w-3")}>
+										{system.status === SystemStatus.Up && (
 											<span
-												className={cn("relative inline-flex rounded-full h-3 w-3", {
-													"bg-green-500": system.status === SystemStatus.Up,
-													"bg-red-500": system.status === SystemStatus.Down,
-													"bg-primary/40": system.status === SystemStatus.Paused,
-													"bg-yellow-500": system.status === SystemStatus.Pending,
-												})}
+												className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+												style={{ animationDuration: "1.5s" }}
 											></span>
-										</span>
-										{translatedStatus}
+										)}
+										<span
+											className={cn("relative inline-flex rounded-full h-3 w-3", {
+												"bg-green-500": system.status === SystemStatus.Up,
+												"bg-red-500": system.status === SystemStatus.Down,
+												"bg-primary/40": system.status === SystemStatus.Paused,
+												"bg-yellow-500": system.status === SystemStatus.Pending,
+											})}
+										></span>
+									</span>
+									{translatedStatus}
+								</div>
+							</TooltipTrigger>
+							{system.info.ct && (
+								<TooltipContent>
+									<div className="flex gap-1 items-center">
+										{system.info.ct === ConnectionType.WebSocket ? (
+											<WebSocketIcon className="size-4" />
+										) : (
+											<ChevronRightSquareIcon className="size-4" strokeWidth={2} />
+										)}
+										{connectionTypeLabels[system.info.ct as ConnectionType]}
 									</div>
-								</TooltipTrigger>
-								{system.info.ct && (
-									<TooltipContent>
-										<div className="flex gap-1 items-center">
-											{system.info.ct === ConnectionType.WebSocket ? (
-												<WebSocketIcon className="size-4" />
-											) : (
-												<ChevronRightSquareIcon className="size-4" strokeWidth={2} />
-											)}
-											{connectionTypeLabels[system.info.ct as ConnectionType]}
-										</div>
-									</TooltipContent>
-								)}
-							</Tooltip>
-						</TooltipProvider>
+								</TooltipContent>
+							)}
+						</Tooltip>
 
 						{systemInfo.map(({ value, label, Icon, hide }) => {
 							if (hide || !value) {
@@ -186,12 +184,10 @@ export default function InfoBar({
 								<div key={value} className="contents">
 									<Separator orientation="vertical" className="h-4 bg-primary/30" />
 									{label ? (
-										<TooltipProvider>
-											<Tooltip delayDuration={150}>
-												<TooltipTrigger asChild>{content}</TooltipTrigger>
-												<TooltipContent>{label}</TooltipContent>
-											</Tooltip>
-										</TooltipProvider>
+										<Tooltip delayDuration={100}>
+											<TooltipTrigger asChild>{content}</TooltipTrigger>
+											<TooltipContent>{label}</TooltipContent>
+										</Tooltip>
 									) : (
 										content
 									)}
@@ -202,26 +198,24 @@ export default function InfoBar({
 				</div>
 				<div className="xl:ms-auto flex items-center gap-2 max-sm:-mb-1">
 					<ChartTimeSelect className="w-full xl:w-40" agentVersion={chartData.agentVersion} />
-					<TooltipProvider delayDuration={100}>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button
-									aria-label={t`Toggle grid`}
-									variant="outline"
-									size="icon"
-									className="hidden xl:flex p-0 text-primary"
-									onClick={() => setGrid(!grid)}
-								>
-									{grid ? (
-										<LayoutGridIcon className="h-[1.2rem] w-[1.2rem] opacity-75" />
-									) : (
-										<Rows className="h-[1.3rem] w-[1.3rem] opacity-75" />
-									)}
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent>{t`Toggle grid`}</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								aria-label={t`Toggle grid`}
+								variant="outline"
+								size="icon"
+								className="hidden xl:flex p-0 text-primary"
+								onClick={() => setGrid(!grid)}
+							>
+								{grid ? (
+									<LayoutGridIcon className="h-[1.2rem] w-[1.2rem] opacity-75" />
+								) : (
+									<Rows className="h-[1.3rem] w-[1.3rem] opacity-75" />
+								)}
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>{t`Toggle grid`}</TooltipContent>
+					</Tooltip>
 				</div>
 			</div>
 		</Card>

--- a/internal/site/src/components/ui/input-copy.tsx
+++ b/internal/site/src/components/ui/input-copy.tsx
@@ -3,7 +3,7 @@ import { CopyIcon } from "lucide-react"
 import { copyToClipboard } from "@/lib/utils"
 import { Button } from "./button"
 import { Input } from "./input"
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip"
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip"
 
 export function InputCopy({ value, id, name }: { value: string; id: string; name: string }) {
 	return (
@@ -14,25 +14,23 @@ export function InputCopy({ value, id, name }: { value: string; id: string; name
 					"h-6 w-24 bg-linear-to-r rtl:bg-linear-to-l from-transparent to-background to-65% absolute top-2 end-1 pointer-events-none"
 				}
 			></div>
-			<TooltipProvider delayDuration={100} disableHoverableContent>
-				<Tooltip disableHoverableContent={true}>
-					<TooltipTrigger asChild>
-						<Button
-							type="button"
-							variant={"link"}
-							className="absolute end-0 top-0"
-							onClick={() => copyToClipboard(value)}
-						>
-							<CopyIcon className="size-4" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent>
-						<p>
-							<Trans>Click to copy</Trans>
-						</p>
-					</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+			<Tooltip disableHoverableContent={true}>
+				<TooltipTrigger asChild>
+					<Button
+						type="button"
+						variant={"link"}
+						className="absolute end-0 top-0"
+						onClick={() => copyToClipboard(value)}
+					>
+						<CopyIcon className="size-4" />
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>
+					<p>
+						<Trans>Click to copy</Trans>
+					</p>
+				</TooltipContent>
+			</Tooltip>
 		</div>
 	)
 }

--- a/internal/site/src/components/ui/tooltip.tsx
+++ b/internal/site/src/components/ui/tooltip.tsx
@@ -3,7 +3,7 @@ import type * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function TooltipProvider({ delayDuration = 0, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+function TooltipProvider({ delayDuration = 50, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
 	return <TooltipPrimitive.Provider data-slot="tooltip-provider" delayDuration={delayDuration} {...props} />
 }
 


### PR DESCRIPTION
## 📃 Description
Add tooltips to any clickable item that doesn't have text next to it.

Closes #1623

## 📖 Documentation

## 🪵 Changelog

### ➕ Added
Added tooltips for each navbar items to clear each purpose.

## 📷 Screenshots
<img width="1080" height="532" alt="Screenshot 2026-01-13 at 2 38 09 PM" src="https://github.com/user-attachments/assets/f4508f0b-b568-4e84-97d1-e4fd0f3fe60f" />