### PR TITLE
feat: add tooltip to system name in systems table

### DIFF
--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -129,20 +129,27 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 				const { name, id } = info.row.original
 				const longestName = useStore($longestSystemNameLen)
 				return (
-					<>
-						<span className="flex gap-2 items-center font-medium text-sm text-nowrap md:ps-1">
-							<IndicatorDot system={info.row.original} />
-							{/* NOTE: change to 1 ch if switching to monospace font */}
-							<span className="truncate" style={{ width: `${longestName / 1.1}ch` }}>
-								{name}
-							</span>
-						</span>
-						<Link
-							href={getPagePath($router, "system", { id })}
-							className="inset-0 absolute size-full"
-							aria-label={name}
-						></Link>
-					</>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<div className="relative">
+								<span className="flex gap-2 items-center font-medium text-sm text-nowrap md:ps-1">
+									<IndicatorDot system={info.row.original} />
+									{/* NOTE: change to 1 ch if switching to monospace font */}
+									<span className="truncate" style={{ width: `${longestName / 1.1}ch` }}>
+										{name}
+									</span>
+								</span>
+								<Link
+									href={getPagePath($router, "system", { id })}
+									className="inset-0 absolute size-full"
+									aria-label={name}
+								></Link>
+							</div>
+						</TooltipTrigger>
+						<TooltipContent>
+							<p>{name}</p>
+						</TooltipContent>
+					</Tooltip>
 				)
 			},
 			header: sortableHeader,


### PR DESCRIPTION
## 📃 Description

#1622 Add tooltip to system name in systems table for better accessiility

## 🪵 Changelog

### ➕ Added

- Added tooltip on system hostname for better user experience

## 📷 Screenshots
<img width="702" height="467" alt="Screenshot 2026-01-14 at 11 00 42 AM" src="https://github.com/user-attachments/assets/3aaae22b-5f7e-464e-acef-1fee8811a55e" />
