### PR TITLE
Change usermod to addgroup for docker access

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -540,7 +540,7 @@ if is_alpine; then
   # Add the user to the docker group to allow access to the Docker socket if group docker exists
   if getent group docker; then
     echo "Adding beszel to docker group"
-    usermod -aG docker beszel
+    addgroup beszel docker
   fi
   
 elif is_openwrt; then


### PR DESCRIPTION
## 📃 Description

On Alpine Linux, the correct command to add a user to an existing group is addgroup <username> <groupname> rather than usermod -aG. The usermod command is part of the shadow package which is not installed by default on Alpine.

## 📖 Documentation

N/A

## 🪵 Changelog

### ➕ Added

N/A

### ✏️ Changed

N/A

### 🔧 Fixed

- Fixed usermod: not found error on Alpine Linux when adding beszel user to docker group

### 🗑️ Removed

N/A

## 📷 Screenshots

N/A
