### PR TITLE
fix: update smartctlArgs call to use hasExistingData flag

### DIFF
--- a/agent/smart.go
+++ b/agent/smart.go
@@ -435,7 +435,7 @@ func (sm *SmartManager) CollectSmart(deviceInfo *DeviceInfo) error {
 	defer cancel()
 
 	// Try with -n standby first if we have existing data
-	args := sm.smartctlArgs(deviceInfo, true)
+	args := sm.smartctlArgs(deviceInfo, hasExistingData)
 	cmd := exec.CommandContext(ctx, sm.binPath, args...)
 	output, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
## 📃 Description

Fixes SMART data collection failure for certain devices (particularly SATA drives behind SCSI controllers) by preventing the `-n standby` flag from being used during initial data collection.

### Problem
The beszel agent was failing to collect SMART data from some devices with the error:
```
INFO no valid SMART data found device=/dev/sdd
```

This affected SATA drives (like Kingston A400 SSDs) connected through HBA controllers (e.g., H200 in IT mode) that are detected as SCSI devices by `smartctl --scan`.

### Root Cause
The agent was using `smartctl -a --json=c -n standby /dev/sdd` **even during initial data collection** when no cached data existed. The `-n standby` flag can cause smartctl to:
- Return exit code 2 if the device is in standby/low-power mode
- Skip data collection to avoid spinning up sleeping drives

While this is the correct behavior when cached data already exists (to avoid unnecessary disk wake-ups), it prevents **initial data collection** for devices that are in standby mode or slow to respond.

### Solution
Changed line 435 in `smart.go` from:
```go
args := sm.smartctlArgs(deviceInfo, true)
```
to:
```go
args := sm.smartctlArgs(deviceInfo, hasExistingData)
```

This ensures:
- **First query**: Runs WITHOUT `-n standby` → forces data collection even if drive is in standby
- **Subsequent queries**: Runs WITH `-n standby` if data exists → prevents unnecessary drive wake-ups

The retry logic on line 446-453 already handles standby mode correctly for subsequent refreshes.

## 📖 Documentation

N/A - Internal behavior change, no user-facing documentation needed.

## 🪵 Changelog

### ➕ Added

N/A

### ✏️ Changed

Modified `CollectSmart()` method to only use standby mode flag (`-n standby`) when cached SMART data already exists for the device.

```go
// smart.go:435
// Try with -n standby first if we have existing data
args := sm.smartctlArgs(deviceInfo, hasExistingData) // Changed from 'true'
```

### 🔧 Fixed

- SMART data collection for SATA drives connected through SCSI HBA controllers (e.g., Kingston A400 SSD on H200 IT Mode)
- Initial data collection for devices in standby/low-power mode
- Devices that `smartctl --scan` reports as SCSI but are actually SATA (SAT - SCSI-to-ATA Translation)

### 🗑️ Removed

N/A

## 📷 Screenshots

**Before fix:**
```
2026/01/14 11:04:53 INFO no valid SMART data found device=/dev/sdd
```

**After fix:**
Device successfully detected and SMART data collected, visible in beszel dashboard.

---

**Testing Notes:**
- Tested on Kingston SA400S37120G SSD connected via LSI H200 HBA in IT mode
- Device is detected by `smartctl --scan` as type "scsi" but contains SAT (SATA) data
- First query now successfully collects data; subsequent queries properly use standby mode
- No regression on other drive types (NVMe, regular SATA, SAS drives all continue working)
