### PR TITLE
Chore: Remove Debian package goreleaser workaround

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -158,9 +158,7 @@ nfpms:
         - debconf
       scripts:
         templates: ./supplemental/debian/templates
-        # Currently broken due to a bug in goreleaser
-        # https://github.com/goreleaser/goreleaser/issues/5487
-        #config: ./supplemental/debian/config.sh
+        config: ./supplemental/debian/config.sh
 
 scoops:
   - ids: [beszel-agent]

--- a/supplemental/debian/postinstall.sh
+++ b/supplemental/debian/postinstall.sh
@@ -9,13 +9,6 @@ SERVICE_USER=beszel
 
 . /usr/share/debconf/confmodule
 
-# This would normally be in the config control file, however this is currently
-# broken in goreleaser. Temporarily do it here.
-# https://github.com/goreleaser/goreleaser/issues/5487
-db_version 2.0
-db_input high beszel-agent/key || true
-db_go
-
 # Create group and user
 if ! getent group "$SERVICE_USER" >/dev/null; then
 	echo "Creating $SERVICE_USER group"


### PR DESCRIPTION
## 📃 Description

The goreleaser bug  has been fixed in v2.7.0, so the workaround is no longer needed.

Did a test build and being ask for the SSH key during the install. 

Closes #702 


## 🪵 Changelog

### ✏️ Changed

- Remove debconf workaround from postinstall.sh that was needed due to goreleaser bug
- Re-enable config.sh script in .goreleaser.yml
