### PR TITLE
[Bug] Restore "Add System" button on mobile. 

### DIFF
--- a/internal/site/src/components/add-system.tsx
+++ b/internal/site/src/components/add-system.tsx
@@ -49,10 +49,12 @@ export function AddSystemButton({ className }: { className?: string }) {
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>
 				<Button variant="outline" className={cn("flex gap-1 max-xs:h-[2.4rem]", className)}>
-					<PlusIcon className="h-4 w-4 -ms-1" />
-					<Trans>
-						Add <span className="hidden sm:inline">System</span>
-					</Trans>
+					<PlusIcon className="h-4 w-4 450:-ms-1" />
+					<span className="hidden 450:inline">
+						<Trans>
+							Add <span className="hidden sm:inline">System</span>
+						</Trans>
+					</span>
 				</Button>
 			</DialogTrigger>
 			{opened.current && <SystemDialog setOpen={setOpen} />}

--- a/internal/site/src/components/navbar.tsx
+++ b/internal/site/src/components/navbar.tsx
@@ -129,7 +129,7 @@ export default function Navbar() {
 						</DropdownMenuItem>
 					</DropdownMenuContent>
 				</DropdownMenu>
-				<AddSystemButton className="ms-2 hidden 450:flex" />
+				<AddSystemButton className="ms-2" />
 			</div>
 		</div>
 	)


### PR DESCRIPTION
## 📃 Description

The "Add System" button was removed for mobile. This PR adds it back as just an icon to save space.

fixes #1373 

## 🪵 Changelog

### ➕ Added

- "Add System" icon for mobile users

## 📷 Screenshots

![IMG_1242 (1)](https://github.com/user-attachments/assets/85ec5de0-e09e-41db-ae86-78e9d323f0e1)

