### PR TITLE
bug: ignore alt key combinations

### DIFF
--- a/internal/site/src/components/routes/system.tsx
+++ b/internal/site/src/components/routes/system.tsx
@@ -363,7 +363,8 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 				e.target instanceof HTMLTextAreaElement ||
 				e.shiftKey ||
 				e.ctrlKey ||
-				e.metaKey
+				e.metaKey ||
+				e.altKey
 			) {
 				return
 			}


### PR DESCRIPTION
## 📃 Description

Ignore `Alt + Arrow` key combinations in the system keyboard navigation handler. Prevents conflict with browser's native history navigation (Alt+Left = back, Alt+Right = forward)

Fixes #1583

## 🪵 Changelog

### ➕ Added

- Add `e.altKey` to navigation handler
