### PR TITLE
feat: allow precise value entry for alerts via text input

### DIFF
--- a/internal/site/src/components/alerts/alert-button.tsx
+++ b/internal/site/src/components/alerts/alert-button.tsx
@@ -26,7 +26,7 @@ export default memo(function AlertsButton({ system }: { system: SystemRecord }) 
 						/>
 					</Button>
 				</SheetTrigger>
-				<SheetContent className="max-h-full overflow-auto w-150 !max-w-full p-4 sm:p-6">
+				<SheetContent className="max-h-full overflow-auto w-160 !max-w-full p-4 sm:p-6">
 					{opened && <AlertDialogContent system={system} />}
 				</SheetContent>
 			</Sheet>

--- a/internal/site/src/lib/alerts.ts
+++ b/internal/site/src/lib/alerts.ts
@@ -40,7 +40,7 @@ export const alertInfo: Record<string, AlertInfo> = {
 		unit: " MB/s",
 		icon: EthernetIcon,
 		desc: () => t`Triggers when combined up/down exceeds a threshold`,
-		max: 125,
+		max: 250,
 	},
 	GPU: {
 		name: () => t`GPU Usage`,


### PR DESCRIPTION
## 📃 Description

The Alerts slider can be tricky to use when trying to select the exact value. This PR adds a text input so users can enter the desired value precisely.

Closes #1621

## 🪵 Changelog

### ➕ Added

- Text Input next to the slider.

## 📷 Screenshots

<img width="1174" height="322" alt="image" src="https://github.com/user-attachments/assets/308380ce-ca02-48b0-b161-9fb0c256333b" />
