### PR TITLE
feat: add AMD RX 7600 device ID mapping

### DIFF
--- a/agent/gpu_amd_linux.go
+++ b/agent/gpu_amd_linux.go
@@ -172,6 +172,8 @@ var getRadeonNames = sync.OnceValue(func() map[string]string {
 
 		"744c": "RX 7900",
 
+		"7480": "RX 7600",
+
 		"1681": "680M",
 
 		"7448": "PRO W7900",


### PR DESCRIPTION
## 📃 Description

Added AMD Radeon RX 7600 device ID (7480) to the GPU lookup table for proper detection on Linux systems.

## 🪵 Changelog

### ➕ Added

- AMD Radeon RX 7600 device ID (7480) mapping in `agent/gpu_amd_linux.go`