### PR TITLE
Fix volume path in Docker run command

### DIFF
--- a/internal/site/src/components/install-dropdowns.tsx
+++ b/internal/site/src/components/install-dropdowns.tsx
@@ -43,7 +43,7 @@ export function copyDockerCompose(port = "45876", publicKey: string, token: stri
 
 export function copyDockerRun(port = "45876", publicKey: string, token: string) {
 	copyToClipboard(
-		`docker run -d --name beszel-agent --network host --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock:ro -v ./beszel_agent_data:/var/lib/beszel-agent -e KEY="${publicKey}" -e LISTEN=${port} -e TOKEN="${token}" -e HUB_URL="${getHubURL()}" henrygd/beszel-agent`
+		`docker run -d --name beszel-agent --network host --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock:ro -v beszel_agent_data:/var/lib/beszel-agent -e KEY="${publicKey}" -e LISTEN=${port} -e TOKEN="${token}" -e HUB_URL="${getHubURL()}" henrygd/beszel-agent`
 	)
 }
 


### PR DESCRIPTION
## 📃 Description

Fix invalid relative path `./beszel_agent_data` in the Docker run command generated by the UI. Docker does not accept relative paths as bind mount sources, causing the container to fail to start.

```bash
/opt/beszel-agent# docker run -d --name beszel-agent --network host --restart unless-stopped -v /var/run/docker.sock:/var/run/docker.sock:ro -v ./beszel_agent_data:/var/lib/beszel-agent -e KEY="KEY" -e LISTEN=45876 -e TOKEN="TOKEN" -e HUB_URL="https://localhost:8090" henrygd/beszel-agent
docker: Error response from daemon: create ./beszel_agent_data: "./beszel_agent_data" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.
```

### 🔧 Fixed

- Replace `./beszel_agent_data` with a named volume `beszel_agent_data` in the generated `docker run` command to fix Docker error: *includes invalid characters for a local volume name*