### PR TITLE
feat: add dismiss alert function

### DIFF
--- a/internal/alerts/alerts_status.go
+++ b/internal/alerts/alerts_status.go
@@ -134,6 +134,10 @@ func (am *AlertManager) handleSystemUp(systemName string, alertRecords []*core.R
 			}
 			continue
 		}
+		// Skip alerts that were already resolved/dismissed while the system was down.
+		if !alertRecord.GetBool("triggered") {
+			continue
+		}
 		// No alert scheduled for this record, send "up" alert
 		if err := am.sendStatusAlert("up", systemName, alertRecord); err != nil {
 			am.hub.Logger().Error("Failed to send alert", "err", err)

--- a/internal/site/src/components/active-alerts.tsx
+++ b/internal/site/src/components/active-alerts.tsx
@@ -1,90 +1,123 @@
-import { alertInfo } from "@/lib/alerts"
-import { $alerts, $allSystemsById } from "@/lib/stores"
-import type { AlertRecord } from "@/types"
+import { t } from "@lingui/core/macro"
 import { Plural, Trans } from "@lingui/react/macro"
 import { useStore } from "@nanostores/react"
 import { getPagePath } from "@nanostores/router"
-import { useMemo } from "react"
+import { type MouseEvent, useMemo, useState } from "react"
+import { alertInfo } from "@/lib/alerts"
+import { pb } from "@/lib/api"
+import { $alerts, $allSystemsById } from "@/lib/stores"
+import type { AlertRecord } from "@/types"
 import { $router, Link } from "./router"
-import { Alert, AlertTitle, AlertDescription } from "./ui/alert"
-import { Card, CardHeader, CardTitle, CardContent } from "./ui/card"
+import { Alert, AlertDescription, AlertTitle } from "./ui/alert"
+import { Button } from "./ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card"
+import { toast } from "./ui/use-toast"
 
 export const ActiveAlerts = () => {
 	const alerts = useStore($alerts)
 	const systems = useStore($allSystemsById)
+	const [dismissing, setDismissing] = useState<Record<string, boolean>>({})
 
-	const { activeAlerts, alertsKey } = useMemo(() => {
+	const activeAlerts = useMemo(() => {
 		const activeAlerts: AlertRecord[] = []
-		// key to prevent re-rendering if alerts change but active alerts didn't
-		const alertsKey: string[] = []
 
 		for (const systemId of Object.keys(alerts)) {
 			for (const alert of alerts[systemId].values()) {
 				if (alert.triggered && alert.name in alertInfo) {
 					activeAlerts.push(alert)
-					alertsKey.push(`${alert.system}${alert.value}${alert.min}`)
 				}
 			}
 		}
 
-		return { activeAlerts, alertsKey }
+		return activeAlerts
 	}, [alerts])
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: alertsKey is inclusive
-	return useMemo(() => {
-		if (activeAlerts.length === 0) {
-			return null
+	const dismissAlert = async (event: MouseEvent<HTMLButtonElement>, alert: AlertRecord) => {
+		event.preventDefault()
+		event.stopPropagation()
+		if (dismissing[alert.id]) {
+			return
 		}
-		return (
-			<Card>
-				<CardHeader className="pb-4 px-2 sm:px-6 max-sm:pt-5 max-sm:pb-1">
-					<div className="px-2 sm:px-1">
-						<CardTitle>
-							<Trans>Active Alerts</Trans>
-						</CardTitle>
-					</div>
-				</CardHeader>
-				<CardContent className="max-sm:p-2">
-					{activeAlerts.length > 0 && (
-						<div className="grid sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3">
-							{activeAlerts.map((alert) => {
-								const info = alertInfo[alert.name as keyof typeof alertInfo]
-								return (
-									<Alert
-										key={alert.id}
-										className="hover:-translate-y-px duration-200 bg-transparent border-foreground/10 hover:shadow-md shadow-black/5"
-									>
-										<info.icon className="h-4 w-4" />
-										<AlertTitle>
-											{systems[alert.system]?.name} {info.name()}
-										</AlertTitle>
-										<AlertDescription>
-											{alert.name === "Status" ? (
-												<Trans>Connection is down</Trans>
-											) : info.invert ? (
-												<Trans>
-													Below {alert.value}
-													{info.unit} in last <Plural value={alert.min} one="# minute" other="# minutes" />
-												</Trans>
-											) : (
-												<Trans>
-													Exceeds {alert.value}
-													{info.unit} in last <Plural value={alert.min} one="# minute" other="# minutes" />
-												</Trans>
-											)}
-										</AlertDescription>
-										<Link
-											href={getPagePath($router, "system", { id: systems[alert.system]?.id })}
-											className="absolute inset-0 w-full h-full"
-											aria-label="View system"
-										></Link>
-									</Alert>
-								)
-							})}
-						</div>
-					)}
-				</CardContent>
-			</Card>
-		)
-	}, [alertsKey.join("")])
+
+		setDismissing((current) => ({ ...current, [alert.id]: true }))
+		try {
+			await pb.collection<AlertRecord>("alerts").update(alert.id, { triggered: false })
+		} catch (error) {
+			console.error(error)
+			toast({
+				title: t`Failed to update alert`,
+				description: t`Please check logs for more details.`,
+				variant: "destructive",
+			})
+		} finally {
+			setDismissing((current) => {
+				const next = { ...current }
+				delete next[alert.id]
+				return next
+			})
+		}
+	}
+
+	if (activeAlerts.length === 0) {
+		return null
+	}
+
+	return (
+		<Card>
+			<CardHeader className="pb-4 px-2 sm:px-6 max-sm:pt-5 max-sm:pb-1">
+				<div className="px-2 sm:px-1">
+					<CardTitle>
+						<Trans>Active Alerts</Trans>
+					</CardTitle>
+				</div>
+			</CardHeader>
+			<CardContent className="max-sm:p-2">
+				<div className="grid sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3">
+					{activeAlerts.map((alert) => {
+						const info = alertInfo[alert.name as keyof typeof alertInfo]
+						return (
+							<Alert
+								key={alert.id}
+								className="hover:-translate-y-px duration-200 bg-transparent border-foreground/10 hover:shadow-md shadow-black/5"
+							>
+								<info.icon className="h-4 w-4" />
+								<AlertTitle>
+									{systems[alert.system]?.name} {info.name()}
+								</AlertTitle>
+								<AlertDescription>
+									{alert.name === "Status" ? (
+										<Trans>Connection is down</Trans>
+									) : info.invert ? (
+										<Trans>
+											Below {alert.value}
+											{info.unit} in last <Plural value={alert.min} one="# minute" other="# minutes" />
+										</Trans>
+									) : (
+										<Trans>
+											Exceeds {alert.value}
+											{info.unit} in last <Plural value={alert.min} one="# minute" other="# minutes" />
+										</Trans>
+									)}
+								</AlertDescription>
+								<Button
+									type="button"
+									variant="ghost"
+									className="absolute right-2 top-2 z-10 h-auto rounded-sm !ps-1.5 px-1 py-0.5 xs:text-xs leading-none font-normal text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+									onClick={(event) => dismissAlert(event, alert)}
+									disabled={!!dismissing[alert.id]}
+								>
+									<Trans>Dismiss</Trans>
+								</Button>
+								<Link
+									href={getPagePath($router, "system", { id: systems[alert.system]?.id })}
+									className="absolute inset-0 w-full h-full"
+									aria-label="View system"
+								></Link>
+							</Alert>
+						)
+					})}
+				</div>
+			</CardContent>
+		</Card>
+	)
 }


### PR DESCRIPTION
## 📃 Description
Closes #1483 based on the disposition in the comments of the issue.

Adds the ability to dismiss alerts.

Note that this does not include any "snooze" functionality; this is particularly visible when developing with alert time set to 1 minute, as if you dismiss at 57 seconds into the profiling period, the alert will return again 3 seconds later.  A later solution could be to add a "snooze" period, either automatic or configured, or somehow reset the timer for the profiling period for that specific alert type.

## 🪵 Changelog

### ➕ Added

- feat: add dismiss alert function

## 📷 Screenshots

<img width="873" height="175" alt="image" src="https://github.com/user-attachments/assets/03b3febc-49d9-4923-8bd0-8cdd80b0308c" />
<img width="953" height="208" alt="image" src="https://github.com/user-attachments/assets/9f52dea3-c7e9-498a-94f7-1a8782ca0b69" />
<img width="429" height="647" alt="image" src="https://github.com/user-attachments/assets/504de328-3075-44b6-aac2-771271469ced" />

