### PR TITLE
Charts: add max period up to 1 year

### DIFF
--- a/internal/records/records.go
+++ b/internal/records/records.go
@@ -545,11 +545,11 @@ func deleteOldSystemStats(app core.App) error {
 		retention  time.Duration
 	}
 	recordData := []RecordDeletionData{
-		{recordType: "1m", retention: time.Hour},             // 1 hour
-		{recordType: "10m", retention: 12 * time.Hour},       // 12 hours
-		{recordType: "20m", retention: 24 * time.Hour},       // 1 day
-		{recordType: "120m", retention: 7 * 24 * time.Hour},  // 7 days
-		{recordType: "480m", retention: 30 * 24 * time.Hour}, // 30 days
+		{recordType: "1m", retention: time.Hour},              // 1 hour
+		{recordType: "10m", retention: 12 * time.Hour},        // 12 hours
+		{recordType: "20m", retention: 24 * time.Hour},        // 1 day
+		{recordType: "120m", retention: 7 * 24 * time.Hour},   // 7 days
+		{recordType: "480m", retention: 365 * 24 * time.Hour}, // 1 year
 	}
 
 	now := time.Now().UTC()

--- a/internal/records/records_test.go
+++ b/internal/records/records_test.go
@@ -139,8 +139,8 @@ func TestDeleteOldSystemStats(t *testing.T) {
 		{"20m", 24 * time.Hour, false, 48 * time.Hour, "20m record older than 24 hours should be deleted"},
 		{"120m", 7 * 24 * time.Hour, true, 3 * 24 * time.Hour, "120m record within 7 days should be kept"},
 		{"120m", 7 * 24 * time.Hour, false, 10 * 24 * time.Hour, "120m record older than 7 days should be deleted"},
-		{"480m", 30 * 24 * time.Hour, true, 15 * 24 * time.Hour, "480m record within 30 days should be kept"},
-		{"480m", 30 * 24 * time.Hour, false, 45 * 24 * time.Hour, "480m record older than 30 days should be deleted"},
+		{"480m", 365 * 24 * time.Hour, true, 90 * 24 * time.Hour, "480m record within 1 year should be kept"},
+		{"480m", 365 * 24 * time.Hour, false, 400 * 24 * time.Hour, "480m record older than 1 year should be deleted"},
 	}
 
 	// Create test records for both system_stats and container_stats

--- a/internal/site/src/components/charts/chart-time-select.tsx
+++ b/internal/site/src/components/charts/chart-time-select.tsx
@@ -1,10 +1,10 @@
 import { useStore } from "@nanostores/react"
 import { HistoryIcon } from "lucide-react"
+import { memo, useEffect } from "react"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { $chartTime } from "@/lib/stores"
-import { chartTimeData, cn, compareSemVer, parseSemVer } from "@/lib/utils"
+import { $chartTime, $userSettings } from "@/lib/stores"
+import { cn, compareSemVer, getAvailableChartTimeEntries, getNearestAvailableChartTime, parseSemVer } from "@/lib/utils"
 import type { ChartTimes, SemVer } from "@/types"
-import { memo } from "react"
 
 export default memo(function ChartTimeSelect({
 	className,
@@ -14,14 +14,24 @@ export default memo(function ChartTimeSelect({
 	agentVersion: SemVer
 }) {
 	const chartTime = useStore($chartTime)
+	const userSettings = useStore($userSettings)
+	const maxChartPeriod = userSettings.maxChartPeriod ?? "30d"
 
 	// remove chart times that are not supported by the system agent version
-	const availableChartTimes = Object.entries(chartTimeData).filter(([_, { minVersion }]) => {
+	const availableChartTimes = getAvailableChartTimeEntries(maxChartPeriod).filter(([_, { minVersion }]) => {
 		if (!minVersion) {
 			return true
 		}
 		return compareSemVer(agentVersion, parseSemVer(minVersion)) >= 0
 	})
+	const availableChartTimeValues = availableChartTimes.map(([value]) => value)
+
+	useEffect(() => {
+		const nextChartTime = getNearestAvailableChartTime(chartTime, availableChartTimeValues)
+		if (nextChartTime !== chartTime) {
+			$chartTime.set(nextChartTime)
+		}
+	}, [availableChartTimeValues, chartTime])
 
 	return (
 		<Select defaultValue="1h" value={chartTime} onValueChange={(value: ChartTimes) => $chartTime.set(value)}>

--- a/internal/site/src/components/routes/settings/general.tsx
+++ b/internal/site/src/components/routes/settings/general.tsx
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/correctness/useUniqueElementIds: component is only rendered once */
 import { Trans, useLingui } from "@lingui/react/macro"
 import { LanguagesIcon, LoaderCircleIcon, SaveIcon } from "lucide-react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useStore } from "@nanostores/react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -13,8 +13,8 @@ import { HourFormat, Unit } from "@/lib/enums"
 import { dynamicActivate } from "@/lib/i18n"
 import languages from "@/lib/languages"
 import { $userSettings } from "@/lib/stores"
-import { chartTimeData, currentHour12 } from "@/lib/utils"
-import type { UserSettings } from "@/types"
+import { chartMaxPeriodData, currentHour12, getAvailableChartTimeEntries, getNearestAvailableChartTime } from "@/lib/utils"
+import type { ChartMaxPeriod, ChartTimes, UserSettings } from "@/types"
 import { saveSettings } from "./layout"
 
 export default function SettingsProfilePage({ userSettings }: { userSettings: UserSettings }) {
@@ -22,6 +22,26 @@ export default function SettingsProfilePage({ userSettings }: { userSettings: Us
 	const { i18n } = useLingui()
 	const currentUserSettings = useStore($userSettings)
 	const layoutWidth = currentUserSettings.layoutWidth ?? 1500
+	const initialMaxChartPeriod = userSettings.maxChartPeriod ?? "30d"
+	const [chartTime, setChartTime] = useState<ChartTimes>(
+		getNearestAvailableChartTime(
+			userSettings.chartTime,
+			getAvailableChartTimeEntries(initialMaxChartPeriod).map(([availableChartTime]) => availableChartTime)
+		)
+	)
+	const [maxChartPeriod, setMaxChartPeriod] = useState<ChartMaxPeriod>(initialMaxChartPeriod)
+	const availableChartTimes = getAvailableChartTimeEntries(maxChartPeriod)
+
+	useEffect(() => {
+		const nextMaxChartPeriod = userSettings.maxChartPeriod ?? "30d"
+		setMaxChartPeriod(nextMaxChartPeriod)
+		setChartTime(
+			getNearestAvailableChartTime(
+				userSettings.chartTime,
+				getAvailableChartTimeEntries(nextMaxChartPeriod).map(([availableChartTime]) => availableChartTime)
+			)
+		)
+	}, [userSettings.chartTime, userSettings.maxChartPeriod])
 
 	async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
 		e.preventDefault()
@@ -30,6 +50,16 @@ export default function SettingsProfilePage({ userSettings }: { userSettings: Us
 		const data = Object.fromEntries(formData) as Partial<UserSettings>
 		await saveSettings(data)
 		setIsLoading(false)
+	}
+
+	function handleMaxChartPeriodChange(value: ChartMaxPeriod) {
+		setMaxChartPeriod(value)
+		setChartTime((currentChartTime) =>
+			getNearestAvailableChartTime(
+				currentChartTime,
+				getAvailableChartTimeEntries(value).map(([availableChartTime]) => availableChartTime)
+			)
+		)
 	}
 
 	return (
@@ -122,12 +152,12 @@ export default function SettingsProfilePage({ userSettings }: { userSettings: Us
 							<Label className="block" htmlFor="chartTime">
 								<Trans>Default time period</Trans>
 							</Label>
-							<Select name="chartTime" key={userSettings.chartTime} defaultValue={userSettings.chartTime}>
+							<Select name="chartTime" value={chartTime} onValueChange={(value: ChartTimes) => setChartTime(value)}>
 								<SelectTrigger id="chartTime">
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
-									{Object.entries(chartTimeData).map(([value, { label }]) => (
+									{availableChartTimes.map(([value, { label }]) => (
 										<SelectItem key={value} value={value}>
 											{label()}
 										</SelectItem>
@@ -151,6 +181,23 @@ export default function SettingsProfilePage({ userSettings }: { userSettings: Us
 									{Object.keys(HourFormat).map((value) => (
 										<SelectItem key={value} value={value}>
 											{value}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="grid gap-2">
+							<Label className="block" htmlFor="maxChartPeriod">
+								<Trans>Max Period</Trans>
+							</Label>
+							<Select name="maxChartPeriod" value={maxChartPeriod} onValueChange={handleMaxChartPeriodChange}>
+								<SelectTrigger id="maxChartPeriod">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{Object.entries(chartMaxPeriodData).map(([value, { label }]) => (
+										<SelectItem key={value} value={value}>
+											{label()}
 										</SelectItem>
 									))}
 								</SelectContent>

--- a/internal/site/src/components/routes/system.tsx
+++ b/internal/site/src/components/routes/system.tsx
@@ -36,6 +36,7 @@ import {
 	compareSemVer,
 	decimalString,
 	formatBytes,
+	getChartTimePointLimit,
 	listen,
 	parseSemVer,
 	toFixedFloat,
@@ -272,7 +273,7 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 			...getTimeData(chartTime, lastCreated),
 			agentVersion: parseSemVer(system?.info?.v),
 		}
-	}, [systemStats, containerData, direction])
+	}, [chartTime, containerData, direction, system?.info?.v, systemStats])
 
 	// Share chart config computation for all container charts
 	const containerChartConfigs = useContainerChartConfigs(containerData)
@@ -312,13 +313,14 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 			setChartLoading(false)
 
 			const { expectedInterval } = chartTimeData[chartTime]
+			const maxPoints = getChartTimePointLimit(chartTime)
 			// make new system stats
 			const ss_cache_key = `${system.id}_${chartTime}_system_stats`
 			let systemData = (cache.get(ss_cache_key) || []) as SystemStatsRecord[]
 			if (systemStats.status === "fulfilled" && systemStats.value.length) {
 				systemData = systemData.concat(addEmptyValues(systemData, systemStats.value, expectedInterval))
-				if (systemData.length > 120) {
-					systemData = systemData.slice(-100)
+				if (systemData.length > maxPoints) {
+					systemData = systemData.slice(-maxPoints)
 				}
 				cache.set(ss_cache_key, systemData)
 			}
@@ -328,8 +330,8 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 			let containerData = (cache.get(cs_cache_key) || []) as ContainerStatsRecord[]
 			if (containerStats.status === "fulfilled" && containerStats.value.length) {
 				containerData = containerData.concat(addEmptyValues(containerData, containerStats.value, expectedInterval))
-				if (containerData.length > 120) {
-					containerData = containerData.slice(-100)
+				if (containerData.length > maxPoints) {
+					containerData = containerData.slice(-maxPoints)
 				}
 				cache.set(cs_cache_key, containerData)
 			}

--- a/internal/site/src/lib/stores.ts
+++ b/internal/site/src/lib/stores.ts
@@ -25,8 +25,16 @@ export const $alerts = map<AlertMap>({})
 /** SSH public key */
 export const $publicKey = atom("")
 
+export const defaultUserSettings: UserSettings = {
+	chartTime: "1h",
+	maxChartPeriod: "30d",
+	emails: [pb.authStore.record?.email || ""],
+	unitNet: Unit.Bytes,
+	unitTemp: Unit.Celsius,
+}
+
 /** Chart time period */
-export const $chartTime = atom<ChartTimes>("1h")
+export const $chartTime = atom<ChartTimes>(defaultUserSettings.chartTime)
 
 /** Whether to display average or max chart values */
 export const $maxValues = atom(false)
@@ -43,14 +51,9 @@ export const $maxValues = atom(false)
 // })
 
 /** User settings */
-export const $userSettings = map<UserSettings>({
-	chartTime: "1h",
-	emails: [pb.authStore.record?.email || ""],
-	unitNet: Unit.Bytes,
-	unitTemp: Unit.Celsius,
-})
+export const $userSettings = map<UserSettings>(defaultUserSettings)
 // update chart time on change
-listenKeys($userSettings, ["chartTime"], ({ chartTime }) => $chartTime.set(chartTime))
+listenKeys($userSettings, ["chartTime"], ({ chartTime }) => $chartTime.set(chartTime || defaultUserSettings.chartTime))
 
 /** Container chart filter */
 export const $containerFilter = atom("")

--- a/internal/site/src/lib/utils.ts
+++ b/internal/site/src/lib/utils.ts
@@ -5,7 +5,7 @@ import { timeDay, timeHour, timeMinute } from "d3-time"
 import { useEffect, useState } from "react"
 import { twMerge } from "tailwind-merge"
 import { toast } from "@/components/ui/use-toast"
-import type { ChartTimeData, FingerprintRecord, SemVer, SystemRecord } from "@/types"
+import type { ChartMaxPeriod, ChartTimeData, ChartTimes, FingerprintRecord, SemVer, SystemRecord } from "@/types"
 import { HourFormat, Unit } from "./enums"
 import { $copyContent, $userSettings } from "./stores"
 
@@ -95,6 +95,13 @@ export const formatDay = (timestamp: string) => {
 	return dayFormatter.format(new Date(timestamp))
 }
 
+const monthFormatter = new Intl.DateTimeFormat(undefined, {
+	month: "short",
+})
+export const formatMonth = (timestamp: string) => {
+	return monthFormatter.format(new Date(timestamp))
+}
+
 export const updateFavicon = (() => {
 	let prevDownCount = 0
 	return (downCount = 0) => {
@@ -174,6 +181,70 @@ export const chartTimeData: ChartTimeData = {
 		format: (timestamp: string) => formatDay(timestamp),
 		getOffset: (endTime: Date) => timeDay.offset(endTime, -30),
 	},
+	"90d": {
+		type: "480m",
+		expectedInterval: 60_000 * 480,
+		label: () => t`90 days`,
+		ticks: 12,
+		format: (timestamp: string) => formatDay(timestamp),
+		getOffset: (endTime: Date) => timeDay.offset(endTime, -90),
+	},
+	"1y": {
+		type: "480m",
+		expectedInterval: 60_000 * 480,
+		label: () => t`1 year`,
+		ticks: 12,
+		format: (timestamp: string) => formatMonth(timestamp),
+		getOffset: (endTime: Date) => timeDay.offset(endTime, -365),
+	},
+}
+
+export const chartTimes: ChartTimes[] = ["1m", "1h", "12h", "24h", "1w", "30d", "90d", "1y"]
+
+export const chartMaxPeriodData: Record<ChartMaxPeriod, { label: () => string }> = {
+	"30d": {
+		label: () => t`30 days`,
+	},
+	"90d": {
+		label: () => t`90 days`,
+	},
+	"1y": {
+		label: () => t`1 year`,
+	},
+	all: {
+		label: () => t`All`,
+	},
+}
+
+export function getAvailableChartTimeEntries(maxChartPeriod: ChartMaxPeriod = "all") {
+	const maxIndex =
+		maxChartPeriod === "all" ? chartTimes.length - 1 : Math.max(chartTimes.indexOf(maxChartPeriod), chartTimes.indexOf("30d"))
+	return chartTimes
+		.filter((_, index) => index <= maxIndex)
+		.map((chartTime) => [chartTime, chartTimeData[chartTime]] as const)
+}
+
+export function getNearestAvailableChartTime(chartTime: ChartTimes, availableChartTimes: ChartTimes[]) {
+	if (!availableChartTimes.length || availableChartTimes.includes(chartTime)) {
+		return chartTime
+	}
+
+	const currentIndex = chartTimes.indexOf(chartTime)
+	let fallback = availableChartTimes[0]
+
+	for (const availableChartTime of availableChartTimes) {
+		if (chartTimes.indexOf(availableChartTime) <= currentIndex) {
+			fallback = availableChartTime
+		}
+	}
+
+	return fallback
+}
+
+export function getChartTimePointLimit(chartTime: ChartTimes) {
+	const endTime = new Date()
+	const startTime = chartTimeData[chartTime].getOffset(endTime)
+	return Math.ceil((endTime.getTime() - startTime.getTime()) / chartTimeData[chartTime].expectedInterval) + 6
 }
 
 /** Format number to x decimal places, without trailing zeros */

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -262,7 +262,9 @@ export interface ContainerRecord extends RecordModel {
 	updated: number
 }
 
-export type ChartTimes = "1m" | "1h" | "12h" | "24h" | "1w" | "30d"
+export type ChartTimes = "1m" | "1h" | "12h" | "24h" | "1w" | "30d" | "90d" | "1y"
+
+export type ChartMaxPeriod = "30d" | "90d" | "1y" | "all"
 
 export interface ChartTimeData {
 	[key: string]: {
@@ -278,6 +280,7 @@ export interface ChartTimeData {
 
 export interface UserSettings {
 	chartTime: ChartTimes
+	maxChartPeriod?: ChartMaxPeriod
 	emails?: string[]
 	webhooks?: string[]
 	unitTemp?: Unit

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -34,10 +34,12 @@ func (um *UserManager) InitializeUserSettings(e *core.RecordEvent) error {
 	record := e.Record
 	// intialize settings with defaults (zero values can be ignored)
 	settings := struct {
-		ChartTime string   `json:"chartTime"`
-		Emails    []string `json:"emails"`
+		ChartTime      string   `json:"chartTime"`
+		MaxChartPeriod string   `json:"maxChartPeriod"`
+		Emails         []string `json:"emails"`
 	}{
-		ChartTime: "1h",
+		ChartTime:      "1h",
+		MaxChartPeriod: "30d",
 	}
 	record.UnmarshalJSONField("settings", &settings)
 	// get user email from auth record

--- a/internal/users/users_test.go
+++ b/internal/users/users_test.go
@@ -1,0 +1,38 @@
+//go:build testing
+
+package users_test
+
+import (
+	"testing"
+
+	beszelTests "github.com/henrygd/beszel/internal/tests"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitializeUserSettingsDefaults(t *testing.T) {
+	hub, err := beszelTests.NewTestHub(t.TempDir())
+	require.NoError(t, err)
+	defer hub.Cleanup()
+
+	require.NoError(t, hub.StartHub())
+
+	user, err := beszelTests.CreateUser(hub, "test@example.com", "password")
+	require.NoError(t, err)
+
+	record, err := beszelTests.CreateRecord(hub, "user_settings", map[string]any{
+		"user": user.Id,
+	})
+	require.NoError(t, err)
+
+	settings := struct {
+		ChartTime      string   `json:"chartTime"`
+		MaxChartPeriod string   `json:"maxChartPeriod"`
+		Emails         []string `json:"emails"`
+	}{}
+	require.NoError(t, record.UnmarshalJSONField("settings", &settings))
+
+	require.Equal(t, "1h", settings.ChartTime)
+	require.Equal(t, "30d", settings.MaxChartPeriod)
+	require.Equal(t, []string{"test@example.com"}, settings.Emails)
+}


### PR DESCRIPTION
## Summary
- add 90 day and 1 year chart ranges
- add a Max Period setting that defaults to 30 days and caps the chart range selector
- retain 480m rollups for 1 year and add backend coverage for the new user setting default

## Testing
- go test -tags testing ./internal/users ./internal/records