### PR TITLE
fix: correct DST offset handling in daily quiet hours

### DIFF
--- a/internal/site/src/components/routes/settings/quiet-hours.tsx
+++ b/internal/site/src/components/routes/settings/quiet-hours.tsx
@@ -134,10 +134,10 @@ export function QuietHours() {
 			const startMinutes = startDate.getUTCHours() * 60 + startDate.getUTCMinutes()
 			const endMinutes = endDate.getUTCHours() * 60 + endDate.getUTCMinutes()
 
-			// Convert UTC to local time offset
-			const offset = now.getTimezoneOffset()
-			const localStartMinutes = (startMinutes - offset + 1440) % 1440
-			const localEndMinutes = (endMinutes - offset + 1440) % 1440
+			// Convert UTC to local time using the stored date's offset, not the current date's offset
+			// This avoids DST mismatch when records were saved in a different DST period
+			const localStartMinutes = (startMinutes - startDate.getTimezoneOffset() + 1440) % 1440
+			const localEndMinutes = (endMinutes - endDate.getTimezoneOffset() + 1440) % 1440
 
 			// Handle cases where window spans midnight
 			if (localStartMinutes <= localEndMinutes) {
@@ -347,12 +347,13 @@ function QuietHoursDialog({
 
 			if (windowType === "daily") {
 				// For daily windows, convert local time to UTC
-				// Create a date with the time in local timezone, then convert to UTC
-				const startDate = new Date(`2000-01-01T${startTime}:00`)
+				// Use today's date so the current DST offset is applied (not a fixed historical date)
+				const today = new Date().toISOString().split("T")[0]
+				const startDate = new Date(`${today}T${startTime}:00`)
 				startValue = startDate.toISOString()
 
 				if (endTime) {
-					const endDate = new Date(`2000-01-01T${endTime}:00`)
+					const endDate = new Date(`${today}T${endTime}:00`)
 					endValue = endDate.toISOString()
 				}
 			} else {


### PR DESCRIPTION
## 📃 Description

Daily quiet hours windows were showing "Inactive" and failing to suppress notifications for users in DST-observing timezones (e.g. US Eastern).

There were two related bugs:

Encoding bug (handleSubmit): Times were encoded using the hardcoded date 2000-01-01, which always falls in winter. For US Eastern users currently in EDT (UTC−4), creating new Date('2000-01-01T19:00:00') applied the winter EST offset (UTC−5) instead — storing 00:00 UTC instead of the correct 23:00 UTC. This caused a 1-hour discrepancy for anyone in a DST period.

Decoding bug (getWindowState): The function converted stored UTC times back to local time using now.getTimezoneOffset() (the current DST offset). But since the times were encoded with a different (winter) offset, the decoded local time was off by 1 hour — causing the window to appear Inactive even when the user was within the configured timeframe.

Fixes #1825

## 🪵 Changelog

### ✏️ Changed

- Replace 2000-01-01 with today's date when creating the UTC ISO string for daily windows, so the correct current DST offset is used.
- Use startDate.getTimezoneOffset() / endDate.getTimezoneOffset() (the stored date's offset) instead of now.getTimezoneOffset(), ensuring the UTC→local conversion is consistent with how the time was originally encoded.

