### PR TITLE
Add apple-touch-icon link to index.html

### DIFF
--- a/internal/site/index.html
+++ b/internal/site/index.html
@@ -4,7 +4,7 @@
 		<meta charset="UTF-8" />
 		<link rel="manifest" href="./static/manifest.json" crossorigin="use-credentials" />
 		<link rel="icon" type="image/svg+xml" href="./static/icon.svg" />
-		<link rel="apple-touch-icon" type="image/svg+xml" href="./static/icon.svg" />
+		<link rel="apple-touch-icon" href="./static/icon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0,maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 		<meta name="robots" content="noindex, nofollow" />
 		<title>Beszel</title>


### PR DESCRIPTION

## 📃 Description

When adding Beszel to iOS Safari homepage favorites, the favicon doesn't show up. This PR adds a `apple-touch-icon` link to the current favicon.

## 🪵 Changelog

### 🔧 Fixed

- Favicon in iOS Safari homepage favorites not showing up #1506
