### PR TITLE
fix(ui): revert CardTitle to text-2xl to fix tailwind-merge class override

### DIFF
--- a/internal/site/src/components/ui/card.tsx
+++ b/internal/site/src/components/ui/card.tsx
@@ -20,7 +20,7 @@ const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HT
 	({ className, ...props }, ref) => (
 		<h3
 			ref={ref}
-			className={cn("text-[1.4em] sm:text-2xl font-semibold leading-none tracking-tight", className)}
+			className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
 			{...props}
 		/>
 	)


### PR DESCRIPTION
## 📃 Description

`CardTitle` was changed to `text-[1.4em] sm:text-2xl` in a recent mobile improvement commit. This breaks `tailwind-merge`: when a consumer passes a size class like `text-base`, tailwind-merge removes `text-[1.4em]` but leaves `sm:text-2xl` untouched (responsive variants are treated as separate utilities). The `sm:text-2xl` then leaks through and overrides the intended size on desktop.

This is visible on the home screen server cards in grid view, where server names render at 24px instead of 16px, causing long names to overflow.

## 🪵 Changelog

### 🔧 Fixed

- `CardTitle` default font size reverted to `text-2xl` so consumer-provided size classes are properly resolved by tailwind-merge

## 📷 Screenshots                                                                                                                                                                                                                                                                                                                                       
### **Before** (broken, v0.18.5+)                                                                                                                                              
<img width="1545" height="843" alt="image" src="https://github.com/user-attachments/assets/fe5ae603-5098-475d-936e-71aa5ed9fe87" />
<img width="514" height="424" alt="image" src="https://github.com/user-attachments/assets/26b6a259-eb0f-4568-9398-083f5532c085" />


### **After** (fixed)
<img width="1538" height="837" alt="image" src="https://github.com/user-attachments/assets/7ba1475c-c2ae-4bce-a5e4-0b378989b86f" />
<img width="512" height="424" alt="image" src="https://github.com/user-attachments/assets/41355953-b78f-4aea-89be-a3f159e3f8f3" />
