### PR TITLE
fix: the login email is now case insensitive

### DIFF
--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -92,7 +92,7 @@ export function UserAuthForm({
 					return
 				}
 				const { password, passwordConfirm } = result.output
-				email = result.output.email
+				email = result.output.email.toLowerCase()
 				if (isFirstRun) {
 					// check that passwords match
 					if (password !== passwordConfirm) {

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -4,6 +4,7 @@ package users
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/henrygd/beszel/internal/migrations"
 
@@ -83,7 +84,7 @@ func (um *UserManager) CreateFirstUser(e *core.RequestEvent) error {
 
 	collection, _ := um.app.FindCollectionByNameOrId("users")
 	user := core.NewRecord(collection)
-	user.SetEmail(data.Email)
+	user.SetEmail(strings.ToLower(data.Email))
 	user.SetPassword(data.Password)
 	user.Set("role", "admin")
 	user.Set("verified", true)
@@ -93,7 +94,7 @@ func (um *UserManager) CreateFirstUser(e *core.RequestEvent) error {
 	// create superuser using the email of the first user
 	collection, _ = um.app.FindCollectionByNameOrId(core.CollectionNameSuperusers)
 	adminUser := core.NewRecord(collection)
-	adminUser.SetEmail(data.Email)
+	adminUser.SetEmail(strings.ToLower(data.Email))
 	adminUser.SetPassword(data.Password)
 	if err := um.app.Save(adminUser); err != nil {
 		return e.JSON(http.StatusInternalServerError, map[string]string{"err": err.Error()})


### PR DESCRIPTION
## 📃 Description
Email addresses are case-insensitive by nature, but login was failing when users typed their email in a different case than what was registered (e.g. registering with ABC@log.com but typing abc@log.com at login).

### 🔧 Fixed
This fix normalizes the email to lowercase at both the frontend form and the backend user creation endpoint before any auth or storage operation happens.
fixes #1887 

##Changes
Frontend: lowercase email before passing it to login and register calls
Backend: lowercase email before saving new user and superuser records in CreateFirstUser
