### PR TITLE
fix: use nvme_total_capacity fallback for NVMe disk size

### DIFF
--- a/agent/smart.go
+++ b/agent/smart.go
@@ -1118,6 +1118,9 @@ func (sm *SmartManager) parseSmartForNvme(output []byte) (bool, int) {
 	smartData.SerialNumber = data.SerialNumber
 	smartData.FirmwareVersion = data.FirmwareVersion
 	smartData.Capacity = data.UserCapacity.Bytes
+	if smartData.Capacity == 0 {
+		smartData.Capacity = data.NVMeTotalCapacity
+	}
 	if smartData.Capacity == 0 && (runtime.GOOS == "darwin" || sm.darwinNvmeProvider != nil) {
 		smartData.Capacity = sm.lookupDarwinNvmeCapacity(data.SerialNumber)
 	}

--- a/internal/entities/smart/smart.go
+++ b/internal/entities/smart/smart.go
@@ -494,7 +494,7 @@ type SmartInfoForNvme struct {
 	FirmwareVersion string           `json:"firmware_version"`
 	// NVMePCIVendor                 NVMePCIVendor                 `json:"nvme_pci_vendor"`
 	// NVMeIEEEOUIIdentifier         uint32                        `json:"nvme_ieee_oui_identifier"`
-	// NVMeTotalCapacity             uint64                        `json:"nvme_total_capacity"`
+	NVMeTotalCapacity             uint64                        `json:"nvme_total_capacity"`
 	// NVMeUnallocatedCapacity       uint64                        `json:"nvme_unallocated_capacity"`
 	// NVMeControllerID              uint16                        `json:"nvme_controller_id"`
 	// NVMeVersion                   VersionStringInfo             `json:"nvme_version"`


### PR DESCRIPTION
## 📃 Description                                                                                                                                                                                                                                                                                                        

Some enterprise NVMe drives (e.g. Dell Ent NVMe CM7 U.2 RI 7.68TB) report capacity via `nvme_total_capacity` instead of `user_capacity.bytes` in smartctl JSON output. The NVMe SMART parser now falls back to `nvme_total_capacity` when `user_capacity.bytes` is zero.

In smartctl output, these drives have no `user_capacity` field:
                                                                                                                                                                                                                                                                                                                           
```json
{
  "json_format_version": [
    1,
    0
  ],
  "smartctl": {
    "version": [
      7,
      5
    ],
    "pre_release": false,
    "svn_revision": "5714",
    "platform_info": "x86_64-linux-6.8.0-106-generic",
    "build_info": "(local build)",
    "argv": [
      "smartctl",
      "-a",
      "--json=c",
      "/dev/nvme1"
    ],
    "exit_status": 0
  },
  "local_time": {
    "time_t": 1775572898,
    "asctime": "Tue Apr  7 14:41:38 2026 UTC"
  },
  "device": {
    "name": "/dev/nvme1",
    "info_name": "/dev/nvme1",
    "type": "nvme",
    "protocol": "NVMe"
  },
  "model_name": "Dell Ent NVMe CM7 U.2 RI 7.68TB",
  "serial_number": "9E20A0RE04A3",
  "firmware_version": "2.0.1",
  "nvme_pci_vendor": {
    "id": 7695,
    "subsystem_id": 4136
  },
  "nvme_ieee_oui_identifier": 9233294,
  "nvme_total_capacity": 7681501126656,
  "nvme_unallocated_capacity": 0,
  "nvme_controller_id": 1,
  "nvme_version": {
    "string": "2.0",
    "value": 131072
  },
  "nvme_number_of_namespaces": 64,
  "smart_support": {
    "available": true,
    "enabled": true
  },
  "nvme_firmware_update_capabilities": {
    "value": 23,
    "slots": 3,
    "first_slot_is_read_only": true,
    "activiation_without_reset": true,
    "multiple_update_detection": false,
    "other": 0
  },
  "nvme_optional_admin_commands": {
    "value": 606,
    "security_send_receive": false,
    "format_nvm": true,
    "firmware_download": true,
    "namespace_management": true,
    "self_test": true,
    "directives": false,
    "mi_send_receive": true,
    "virtualization_management": false,
    "doorbell_buffer_config": false,
    "get_lba_status": true,
    "command_and_feature_lockdown": false,
    "other": 0
  },
  "nvme_optional_nvm_commands": {
    "value": 255,
    "compare": true,
    "write_uncorrectable": true,
    "dataset_management": true,
    "write_zeroes": true,
    "save_select_feature_nonzero": true,
    "reservations": true,
    "timestamp": true,
    "verify": true,
    "copy": false,
    "other": 0
  },
  "nvme_log_page_attributes": {
    "value": 126,
    "smart_health_per_namespace": false,
    "commands_effects_log": true,
    "extended_get_log_page_cmd": true,
    "telemetry_log": true,
    "persistent_event_log": true,
    "supported_log_pages_log": true,
    "telemetry_data_area_4": true,
    "other": 0
  },
  "nvme_maximum_data_transfer_pages": 1024,
  "nvme_composite_temperature_threshold": {
    "warning": 77,
    "critical": 83
  },
  "temperature": {
    "op_limit_max": 77,
    "critical_limit_max": 83,
    "current": 27
  },
  "nvme_namespaces": [
    {
      "id": 4294967295,
      "features": {
        "value": 0,
        "thin_provisioning": false,
        "na_fields": false,
        "dealloc_or_unwritten_block_error": false,
        "uid_reuse": false,
        "np_fields": false,
        "other": 0
      }
    }
  ],
  "nvme_power_states": [
    {
      "non_operational_state": false,
      "relative_read_latency": 0,
      "relative_read_throughput": 0,
      "relative_write_latency": 0,
      "relative_write_throughput": 0,
      "entry_latency_us": 500000,
      "exit_latency_us": 500000,
      "max_power": {
        "value": 2500,
        "scale": 2,
        "units_per_watt": 100
      },
      "active_power": {
        "value": 2500,
        "scale": 2,
        "units_per_watt": 100
      }
    },
    {
      "non_operational_state": false,
      "relative_read_latency": 1,
      "relative_read_throughput": 1,
      "relative_write_latency": 1,
      "relative_write_throughput": 1,
      "entry_latency_us": 500000,
      "exit_latency_us": 500000,
      "max_power": {
        "value": 2000,
        "scale": 2,
        "units_per_watt": 100
      },
      "active_power": {
        "value": 2000,
        "scale": 2,
        "units_per_watt": 100
      }
    },
    {
      "non_operational_state": false,
      "relative_read_latency": 2,
      "relative_read_throughput": 2,
      "relative_write_latency": 2,
      "relative_write_throughput": 2,
      "entry_latency_us": 500000,
      "exit_latency_us": 500000,
      "max_power": {
        "value": 1800,
        "scale": 2,
        "units_per_watt": 100
      },
      "active_power": {
        "value": 1800,
        "scale": 2,
        "units_per_watt": 100
      }
    },
    {
      "non_operational_state": false,
      "relative_read_latency": 3,
      "relative_read_throughput": 3,
      "relative_write_latency": 3,
      "relative_write_throughput": 3,
      "entry_latency_us": 500000,
      "exit_latency_us": 500000,
      "max_power": {
        "value": 1400,
        "scale": 2,
        "units_per_watt": 100
      },
      "active_power": {
        "value": 1400,
        "scale": 2,
        "units_per_watt": 100
      }
    }
  ],
  "smart_status": {
    "passed": true,
    "nvme": {
      "value": 0
    }
  },
  "nvme_smart_health_information_log": {
    "nsid": -1,
    "critical_warning": 0,
    "temperature": 27,
    "available_spare": 100,
    "available_spare_threshold": 10,
    "percentage_used": 2,
    "data_units_read": 331438139,
    "data_units_written": 214346004,
    "host_reads": 4451259256,
    "host_writes": 4588635513,
    "controller_busy_time": 3144,
    "power_cycles": 38,
    "power_on_hours": 9292,
    "unsafe_shutdowns": 15,
    "media_errors": 0,
    "num_err_log_entries": 0,
    "warning_temp_time": 0,
    "critical_comp_time": 0
  },
  "spare_available": {
    "current_percent": 100,
    "threshold_percent": 10
  },
  "endurance_used": {
    "current_percent": 2
  },
  "power_cycle_count": 38,
  "power_on_time": {
    "hours": 9292
  },
  "nvme_error_information_log": {
    "size": 256,
    "read": 16,
    "unread": 0
  },
  "nvme_self_test_log": {
    "nsid": -1,
    "current_self_test_operation": {
      "value": 0,
      "string": "No self-test in progress"
    },
    "table": [
      {
        "self_test_code": {
          "value": 2,
          "string": "Extended"
        },
        "self_test_result": {
          "value": 0,
          "string": "Completed without error"
        },
        "power_on_hours": 8,
        "status_code_type": 0,
        "status_code": 0
      },
      {
        "self_test_code": {
          "value": 1,
          "string": "Short"
        },
        "self_test_result": {
          "value": 0,
          "string": "Completed without error"
        },
        "power_on_hours": 8,
        "status_code_type": 0,
        "status_code": 0
      }
    ]
  }
}
```

📖 Documentation

No documentation changes needed.

🪵 Changelog

➕ Added

- Enabled NVMeTotalCapacity field parsing in SmartInfoForNvme struct

✏️  Changed

- NVMe SMART parser now falls back to nvme_total_capacity when user_capacity.bytes is 0, before the existing Darwin lookupDarwinNvmeCapacity fallback

🔧 Fixed

- NVMe disk capacity showing as 0B for drives that report capacity at the controller level

🗑️  Removed

- N/A

📷 Screenshots

Before:
<img width="1587" height="580" alt="iShot_2026-04-07_22 11 14" src="https://github.com/user-attachments/assets/20904b94-99d1-4cf5-8847-1c6d31213b03" />

After:
<img width="1574" height="552" alt="iShot_2026-04-07_22 29 57" src="https://github.com/user-attachments/assets/c78fb46b-e4af-493c-8cef-540955568868" />

