### PR TITLE
fix(auth): normalize email to lowercase for login and registration

### DIFF
--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -92,7 +92,7 @@ export function UserAuthForm({
 					return
 				}
 				const { password, passwordConfirm } = result.output
-				email = result.output.email
+				email = result.output.email.toLowerCase()
 				if (isFirstRun) {
 					// check that passwords match
 					if (password !== passwordConfirm) {

--- a/internal/site/src/components/login/forgot-pass-form.tsx
+++ b/internal/site/src/components/login/forgot-pass-form.tsx
@@ -28,7 +28,7 @@ export default function ForgotPassword() {
 			setIsLoading(true)
 			try {
 				// console.log(email)
-				await pb.collection("users").requestPasswordReset(email)
+				await pb.collection("users").requestPasswordReset(email.toLowerCase())
 				toast({
 					title: t`Password reset request received`,
 					description: t`Check ${email} for a reset link.`,

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -4,6 +4,7 @@ package users
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	"github.com/henrygd/beszel/internal/migrations"
 
@@ -83,7 +84,7 @@ func (um *UserManager) CreateFirstUser(e *core.RequestEvent) error {
 
 	collection, _ := um.app.FindCollectionByNameOrId("users")
 	user := core.NewRecord(collection)
-	user.SetEmail(data.Email)
+	user.SetEmail(strings.ToLower(data.Email))
 	user.SetPassword(data.Password)
 	user.Set("role", "admin")
 	user.Set("verified", true)
@@ -93,7 +94,7 @@ func (um *UserManager) CreateFirstUser(e *core.RequestEvent) error {
 	// create superuser using the email of the first user
 	collection, _ = um.app.FindCollectionByNameOrId(core.CollectionNameSuperusers)
 	adminUser := core.NewRecord(collection)
-	adminUser.SetEmail(data.Email)
+	adminUser.SetEmail(strings.ToLower(data.Email))
 	adminUser.SetPassword(data.Password)
 	if err := um.app.Save(adminUser); err != nil {
 		return e.JSON(http.StatusInternalServerError, map[string]string{"err": err.Error()})


### PR DESCRIPTION
Hi @henrygd! 👋

I noticed issue #1887 where users can't log in if they type their email with different casing than what they registered with. This is a pretty common PocketBase gotcha that can be frustrating for users.

This PR normalizes emails to lowercase in all the auth-related entry points:
- Frontend login/registration form (`auth-form.tsx`)
- Frontend password reset form (`forgot-pass-form.tsx`)
- Backend `create-first-user` endpoint (`internal/users/users.go`)

**Why this approach?**
PocketBase's `authWithPassword` does case-sensitive matching by default on the email field. Rather than modifying PocketBase internals, lowercasing at the application layer keeps the fix minimal and consistent across both the UI and API.

I tested the repro steps from the issue locally and confirmed that registering with `User@Example.com` and then logging in with `user@example.com` now works as expected 😊

Let me know if you'd prefer a different approach - happy to iterate! 🙏

Fixes #1887