### PR TITLE
agent: Allow agent to connect to hub via SOCKS5 proxy

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/lxzan/gws"
 	"golang.org/x/crypto/ssh"
- 	"golang.org/x/net/proxy"
+	"golang.org/x/net/proxy"
 )
 
 const (
@@ -105,6 +105,11 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 	}
 	client.hubURL.Path = path.Join(client.hubURL.Path, "api/beszel/agent-connect")
 
+	// make sure BESZEL_AGENT_ALL_PROXY works (GWS only checks ALL_PROXY)
+	if val := os.Getenv("BESZEL_AGENT_ALL_PROXY"); val != "" {
+		os.Setenv("ALL_PROXY", val)
+	}
+
 	client.options = &gws.ClientOption{
 		Addr:      client.hubURL.String(),
 		TlsConfig: &tls.Config{InsecureSkipVerify: true},
@@ -113,7 +118,7 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 			"X-Token":    []string{client.token},
 			"X-Beszel":   []string{beszel.Version},
 		},
-        NewDialer: func() (gws.Dialer, error) {
+		NewDialer: func() (gws.Dialer, error) {
 			return proxy.FromEnvironment(), nil
 		},
 	}

--- a/agent/client.go
+++ b/agent/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fxamacker/cbor/v2"
 	"github.com/lxzan/gws"
 	"golang.org/x/crypto/ssh"
+ 	"golang.org/x/net/proxy"
 )
 
 const (
@@ -111,6 +112,9 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 			"User-Agent": []string{getUserAgent()},
 			"X-Token":    []string{client.token},
 			"X-Beszel":   []string{beszel.Version},
+		},
+        NewDialer: func() (gws.Dialer, error) {
+			return proxy.FromEnvironment(), nil
 		},
 	}
 	return client.options


### PR DESCRIPTION
## 📃 Description

Some machines may not have a public IP and need to connect to the internet via a proxy.
Ideally both HTTP and SOCKS proxies should be supported, but SOCKS would be enough.

The Agent uses https://github.com/lxzan/gws to establish a WebSocket connection to the Hub.

GWS already supports basic proxy support via `golang.org/x/net/proxy`, as seen in their example:
https://github.com/lxzan/gws?tab=readme-ov-file#proxy

This change will allow to define the `ALL_PROXY` or `all_proxy` env var, which will create the Dialer that proxies the WebSocket request.
If both `ALL_PROXY` and `all_proxy` are missing or they do not have a valid scheme (only `socks5` and `socks5h` are allowed at the moment), a direct connection will be used.

Example use:
```bash
ALL_PROXY="socks5://127.0.0.1:1080"
ALL_PROXY="socks5://username:password@127.0.0.1:1080"
```

## 📖 Documentation

https://github.com/henrygd/beszel-docs/pull/57

## 🪵 Changelog

### ➕ Added

- Agent `ALL_PROXY` environment variable