### PR TITLE
fix(cron): log CreateLongerRecords errors

### DIFF
--- a/internal/records/records.go
+++ b/internal/records/records.go
@@ -3,7 +3,7 @@ package records
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"math"
 	"time"
 
@@ -68,15 +68,18 @@ func (rm *RecordManager) CreateLongerRecords() {
 		},
 	}
 	// wrap the operations in a transaction
+	// Pocketbase cron does not handle errors, log them here.
 	rm.app.RunInTransaction(func(txApp core.App) error {
 		var err error
 		collections := [2]*core.Collection{}
 		collections[0], err = txApp.FindCachedCollectionByNameOrId("system_stats")
 		if err != nil {
+			slog.Error("Error finding cached collection using system stats:", "err", err)
 			return err
 		}
 		collections[1], err = txApp.FindCachedCollectionByNameOrId("container_stats")
 		if err != nil {
+			slog.Error("Error finding cached collection using container stats:", "err", err)
 			return err
 		}
 		var systems RecordIds
@@ -142,7 +145,7 @@ func (rm *RecordManager) CreateLongerRecords() {
 						longerRecord.Set("stats", rm.AverageContainerStats(db, recordIds))
 					}
 					if err := txApp.SaveNoValidate(longerRecord); err != nil {
-						log.Println("failed to save longer record", "err", err)
+						slog.Error("failed to save longer record", "err", err)
 					}
 				}
 			}

--- a/internal/records/records_deletion.go
+++ b/internal/records/records_deletion.go
@@ -12,6 +12,7 @@ import (
 
 // Delete old records
 func (rm *RecordManager) DeleteOldRecords() {
+	// Pocketbase cron does not handle errors, log them here.
 	rm.app.RunInTransaction(func(txApp core.App) error {
 		err := deleteOldSystemStats(txApp)
 		if err != nil {


### PR DESCRIPTION
This is a follow-up PR that does for `RecordManager.CreateLongerRecords()`what was done for `RecordManager.DeleteOldRecords()` in https://github.com/henrygd/beszel/pull/1909. A comment is added in both locations.