### PR TITLE
Add EXIT_ON_INITIAL_FAILURE environment variable

### DIFF
--- a/agent/connection_manager.go
+++ b/agent/connection_manager.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
+	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,15 +20,14 @@ import (
 // It handles both WebSocket and SSH connections, automatically switching between
 // them based on availability and managing reconnection attempts.
 type ConnectionManager struct {
-	agent                *Agent               // Reference to the parent agent
-	State                ConnectionState      // Current connection state
-	eventChan            chan ConnectionEvent // Channel for connection events
-	wsClient             *WebSocketClient     // WebSocket client for hub communication
-	serverOptions        ServerOptions        // Configuration for SSH server
-	wsTicker             *time.Ticker         // Ticker for WebSocket connection attempts
-	isConnecting         bool                 // Prevents multiple simultaneous reconnection attempts
-	exitOnInitialFailure bool                 // Exit instead of retrying if initial connection fails
-	ConnectionType       system.ConnectionType
+	agent          *Agent               // Reference to the parent agent
+	State          ConnectionState      // Current connection state
+	eventChan      chan ConnectionEvent // Channel for connection events
+	wsClient       *WebSocketClient     // WebSocket client for hub communication
+	serverOptions  ServerOptions        // Configuration for SSH server
+	wsTicker       *time.Ticker         // Ticker for WebSocket connection attempts
+	isConnecting   bool                 // Prevents multiple simultaneous reconnection attempts
+	ConnectionType system.ConnectionType
 }
 
 // ConnectionState represents the current connection state of the agent.
@@ -53,11 +55,9 @@ const wsTickerInterval = 10 * time.Second
 
 // newConnectionManager creates a new connection manager for the given agent.
 func newConnectionManager(agent *Agent) *ConnectionManager {
-	val, _ := utils.GetEnv("EXIT_ON_INITIAL_FAILURE")
 	cm := &ConnectionManager{
-		agent:                agent,
-		State:                Disconnected,
-		exitOnInitialFailure: val == "true" || val == "1",
+		agent: agent,
+		State: Disconnected,
 	}
 	return cm
 }
@@ -99,12 +99,7 @@ func (c *ConnectionManager) Start(serverOptions ServerOptions) error {
 	defer stopSignals()
 
 	c.startWsTicker()
-	if !c.connect() && c.exitOnInitialFailure {
-		c.stopWsTicker()
-		_ = c.agent.StopServer()
-		c.closeWebSocket()
-		return errors.New("initial connection failed")
-	}
+	c.connect()
 
 	// update health status immediately and every 90 seconds
 	_ = health.Update()
@@ -120,11 +115,34 @@ func (c *ConnectionManager) Start(serverOptions ServerOptions) error {
 			_ = health.Update()
 		case <-sigCtx.Done():
 			slog.Info("Shutting down", "cause", context.Cause(sigCtx))
-			_ = c.agent.StopServer()
-			c.closeWebSocket()
-			return health.CleanUp()
+			return c.stop()
 		}
 	}
+}
+
+// stop does not stop the connection manager itself, just any active connections. The manager will attempt to reconnect after stopping, so this should only be called immediately before shutting down the entire agent.
+//
+// If we need or want to expose a graceful Stop method in the future, do something like this to actually stop the manager:
+//
+//	func (c *ConnectionManager) Start(serverOptions ServerOptions) error {
+//		ctx, cancel := context.WithCancel(context.Background())
+//		c.cancel = cancel
+//
+//		for {
+//			select {
+//			case <-ctx.Done():
+//				return c.stop()
+//			}
+//		}
+//	}
+//
+//	func (c *ConnectionManager) Stop() {
+//		c.cancel()
+//	}
+func (c *ConnectionManager) stop() error {
+	_ = c.agent.StopServer()
+	c.closeWebSocket()
+	return health.CleanUp()
 }
 
 // handleEvent processes connection events and updates the connection state accordingly.
@@ -182,8 +200,7 @@ func (c *ConnectionManager) handleStateChange(newState ConnectionState) {
 
 // connect handles the connection logic with proper delays and priority.
 // It attempts WebSocket connection first, falling back to SSH server if needed.
-// Returns true if a WebSocket connection was initiated, false if it failed.
-func (c *ConnectionManager) connect() bool {
+func (c *ConnectionManager) connect() {
 	c.isConnecting = true
 	defer func() {
 		c.isConnecting = false
@@ -195,12 +212,17 @@ func (c *ConnectionManager) connect() bool {
 
 	// Try WebSocket first, if it fails, start SSH server
 	err := c.startWebSocketConnection()
-	if err != nil && c.State == Disconnected {
-		c.startSSHServer()
-		c.startWsTicker()
-		return false
+	if err != nil {
+		if shouldExitOnErr(err) {
+			time.Sleep(2 * time.Second) // prevent tight restart loop
+			_ = c.stop()
+			os.Exit(1)
+		}
+		if c.State == Disconnected {
+			c.startSSHServer()
+			c.startWsTicker()
+		}
 	}
-	return true
 }
 
 // startWebSocketConnection attempts to establish a WebSocket connection to the hub.
@@ -235,4 +257,15 @@ func (c *ConnectionManager) closeWebSocket() {
 	if c.wsClient != nil {
 		c.wsClient.Close()
 	}
+}
+
+// shouldExitOnErr checks if the error is a DNS resolution failure and if the
+// EXIT_ON_DNS_ERR env var is set. https://github.com/henrygd/beszel/issues/1924.
+func shouldExitOnErr(err error) bool {
+	if val, _ := utils.GetEnv("EXIT_ON_DNS_ERR"); val == "true" {
+		if opErr, ok := errors.AsType[*net.OpError](err); ok {
+			return strings.Contains(opErr.Err.Error(), "lookup")
+		}
+	}
+	return false
 }

--- a/agent/connection_manager.go
+++ b/agent/connection_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/henrygd/beszel/agent/health"
+	"github.com/henrygd/beszel/agent/utils"
 	"github.com/henrygd/beszel/internal/entities/system"
 )
 
@@ -16,14 +17,15 @@ import (
 // It handles both WebSocket and SSH connections, automatically switching between
 // them based on availability and managing reconnection attempts.
 type ConnectionManager struct {
-	agent          *Agent               // Reference to the parent agent
-	State          ConnectionState      // Current connection state
-	eventChan      chan ConnectionEvent // Channel for connection events
-	wsClient       *WebSocketClient     // WebSocket client for hub communication
-	serverOptions  ServerOptions        // Configuration for SSH server
-	wsTicker       *time.Ticker         // Ticker for WebSocket connection attempts
-	isConnecting   bool                 // Prevents multiple simultaneous reconnection attempts
-	ConnectionType system.ConnectionType
+	agent                *Agent               // Reference to the parent agent
+	State                ConnectionState      // Current connection state
+	eventChan            chan ConnectionEvent // Channel for connection events
+	wsClient             *WebSocketClient     // WebSocket client for hub communication
+	serverOptions        ServerOptions        // Configuration for SSH server
+	wsTicker             *time.Ticker         // Ticker for WebSocket connection attempts
+	isConnecting         bool                 // Prevents multiple simultaneous reconnection attempts
+	exitOnInitialFailure bool                 // Exit instead of retrying if initial connection fails
+	ConnectionType       system.ConnectionType
 }
 
 // ConnectionState represents the current connection state of the agent.
@@ -51,9 +53,11 @@ const wsTickerInterval = 10 * time.Second
 
 // newConnectionManager creates a new connection manager for the given agent.
 func newConnectionManager(agent *Agent) *ConnectionManager {
+	val, _ := utils.GetEnv("EXIT_ON_INITIAL_FAILURE")
 	cm := &ConnectionManager{
-		agent: agent,
-		State: Disconnected,
+		agent:                agent,
+		State:                Disconnected,
+		exitOnInitialFailure: val == "true" || val == "1",
 	}
 	return cm
 }
@@ -95,7 +99,12 @@ func (c *ConnectionManager) Start(serverOptions ServerOptions) error {
 	defer stopSignals()
 
 	c.startWsTicker()
-	c.connect()
+	if !c.connect() && c.exitOnInitialFailure {
+		c.stopWsTicker()
+		_ = c.agent.StopServer()
+		c.closeWebSocket()
+		return errors.New("initial connection failed")
+	}
 
 	// update health status immediately and every 90 seconds
 	_ = health.Update()
@@ -173,7 +182,8 @@ func (c *ConnectionManager) handleStateChange(newState ConnectionState) {
 
 // connect handles the connection logic with proper delays and priority.
 // It attempts WebSocket connection first, falling back to SSH server if needed.
-func (c *ConnectionManager) connect() {
+// Returns true if a WebSocket connection was initiated, false if it failed.
+func (c *ConnectionManager) connect() bool {
 	c.isConnecting = true
 	defer func() {
 		c.isConnecting = false
@@ -188,7 +198,9 @@ func (c *ConnectionManager) connect() {
 	if err != nil && c.State == Disconnected {
 		c.startSSHServer()
 		c.startWsTicker()
+		return false
 	}
+	return true
 }
 
 // startWebSocketConnection attempts to establish a WebSocket connection to the hub.

--- a/agent/connection_manager.go
+++ b/agent/connection_manager.go
@@ -260,9 +260,9 @@ func (c *ConnectionManager) closeWebSocket() {
 }
 
 // shouldExitOnErr checks if the error is a DNS resolution failure and if the
-// EXIT_ON_DNS_ERR env var is set. https://github.com/henrygd/beszel/issues/1924.
+// EXIT_ON_DNS_ERROR env var is set. https://github.com/henrygd/beszel/issues/1924.
 func shouldExitOnErr(err error) bool {
-	if val, _ := utils.GetEnv("EXIT_ON_DNS_ERR"); val == "true" {
+	if val, _ := utils.GetEnv("EXIT_ON_DNS_ERROR"); val == "true" {
 		if opErr, ok := errors.AsType[*net.OpError](err); ok {
 			return strings.Contains(opErr.Err.Error(), "lookup")
 		}

--- a/agent/connection_manager_test.go
+++ b/agent/connection_manager_test.go
@@ -298,3 +298,15 @@ func TestConnectionManager_ConnectFlow(t *testing.T) {
 		cm.connect()
 	}, "Connect should not panic without WebSocket client")
 }
+
+// TestConnectionManager_ExitOnInitialFailure tests that Start returns an error
+// when exitOnInitialFailure is set and the initial connection fails.
+func TestConnectionManager_ExitOnInitialFailure(t *testing.T) {
+	agent := createTestAgent(t)
+	cm := agent.connectionManager
+	serverOptions := createTestServerOptions(t)
+	cm.exitOnInitialFailure = true
+
+	err := cm.Start(serverOptions)
+	assert.EqualError(t, err, "initial connection failed")
+}

--- a/agent/connection_manager_test.go
+++ b/agent/connection_manager_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"crypto/ed25519"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -299,14 +300,64 @@ func TestConnectionManager_ConnectFlow(t *testing.T) {
 	}, "Connect should not panic without WebSocket client")
 }
 
-// TestConnectionManager_ExitOnInitialFailure tests that Start returns an error
-// when exitOnInitialFailure is set and the initial connection fails.
-func TestConnectionManager_ExitOnInitialFailure(t *testing.T) {
-	agent := createTestAgent(t)
-	cm := agent.connectionManager
-	serverOptions := createTestServerOptions(t)
-	cm.exitOnInitialFailure = true
+func TestShouldExitOnErr(t *testing.T) {
+	createDialErr := func(msg string) error {
+		return &net.OpError{
+			Op:  "dial",
+			Net: "tcp",
+			Err: errors.New(msg),
+		}
+	}
 
-	err := cm.Start(serverOptions)
-	assert.EqualError(t, err, "initial connection failed")
+	tests := []struct {
+		name     string
+		err      error
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "no env var",
+			err:      createDialErr("lookup lkahsdfasdf: no such host"),
+			envValue: "",
+			expected: false,
+		},
+		{
+			name:     "env var false",
+			err:      createDialErr("lookup lkahsdfasdf: no such host"),
+			envValue: "false",
+			expected: false,
+		},
+		{
+			name:     "env var true, matching error",
+			err:      createDialErr("lookup lkahsdfasdf: no such host"),
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var true, matching error with extra context",
+			err:      createDialErr("lookup beszel.server.lan on [::1]:53: read udp [::1]:44557->[::1]:53: read: connection refused"),
+			envValue: "true",
+			expected: true,
+		},
+		{
+			name:     "env var true, non-matching error",
+			err:      errors.New("connection refused"),
+			envValue: "true",
+			expected: false,
+		},
+		{
+			name:     "env var true, dial but not lookup",
+			err:      createDialErr("connection timeout"),
+			envValue: "true",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("EXIT_ON_DNS_ERR", tt.envValue)
+			result := shouldExitOnErr(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/agent/connection_manager_test.go
+++ b/agent/connection_manager_test.go
@@ -355,7 +355,7 @@ func TestShouldExitOnErr(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("EXIT_ON_DNS_ERR", tt.envValue)
+			t.Setenv("EXIT_ON_DNS_ERROR", tt.envValue)
 			result := shouldExitOnErr(tt.err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -16,10 +16,11 @@ import (
 
 // cli options
 type cmdOptions struct {
-	key    string // key is the public key(s) for SSH authentication.
-	listen string // listen is the address or port to listen on.
-	hubURL string // hubURL is the URL of the Beszel hub.
-	token  string // token is the token to use for authentication.
+	key                  string // key is the public key(s) for SSH authentication.
+	listen               string // listen is the address or port to listen on.
+	hubURL               string // hubURL is the URL of the Beszel hub.
+	token                string // token is the token to use for authentication.
+	exitOnInitialFailure bool   // exitOnInitialFailure exits if the initial connection fails.
 }
 
 // parse parses the command line flags and populates the config struct.
@@ -52,6 +53,7 @@ func (opts *cmdOptions) parse() bool {
 	chinaMirrors := pflag.BoolP("china-mirrors", "c", false, "Use mirror for update (gh.beszel.dev) instead of GitHub")
 	version := pflag.BoolP("version", "v", false, "Show version information")
 	help := pflag.BoolP("help", "h", false, "Show this help message")
+	pflag.BoolVar(&opts.exitOnInitialFailure, "exit-on-initial-failure", false, "Exit if initial connection fails (useful with restart policies)")
 
 	// Convert old single-dash long flags to double-dash for backward compatibility
 	flagsToConvert := []string{"key", "listen", "url", "token"}
@@ -105,6 +107,9 @@ func (opts *cmdOptions) parse() bool {
 	}
 	if opts.token != "" {
 		os.Setenv("TOKEN", opts.token)
+	}
+	if opts.exitOnInitialFailure {
+		os.Setenv("EXIT_ON_INITIAL_FAILURE", "true")
 	}
 	return false
 }

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -16,11 +16,10 @@ import (
 
 // cli options
 type cmdOptions struct {
-	key                  string // key is the public key(s) for SSH authentication.
-	listen               string // listen is the address or port to listen on.
-	hubURL               string // hubURL is the URL of the Beszel hub.
-	token                string // token is the token to use for authentication.
-	exitOnInitialFailure bool   // exitOnInitialFailure exits if the initial connection fails.
+	key    string // key is the public key(s) for SSH authentication.
+	listen string // listen is the address or port to listen on.
+	hubURL string // hubURL is the URL of the Beszel hub.
+	token  string // token is the token to use for authentication.
 }
 
 // parse parses the command line flags and populates the config struct.
@@ -53,7 +52,6 @@ func (opts *cmdOptions) parse() bool {
 	chinaMirrors := pflag.BoolP("china-mirrors", "c", false, "Use mirror for update (gh.beszel.dev) instead of GitHub")
 	version := pflag.BoolP("version", "v", false, "Show version information")
 	help := pflag.BoolP("help", "h", false, "Show this help message")
-	pflag.BoolVar(&opts.exitOnInitialFailure, "exit-on-initial-failure", false, "Exit if initial connection fails (useful with restart policies)")
 
 	// Convert old single-dash long flags to double-dash for backward compatibility
 	flagsToConvert := []string{"key", "listen", "url", "token"}
@@ -107,9 +105,6 @@ func (opts *cmdOptions) parse() bool {
 	}
 	if opts.token != "" {
 		os.Setenv("TOKEN", opts.token)
-	}
-	if opts.exitOnInitialFailure {
-		os.Setenv("EXIT_ON_INITIAL_FAILURE", "true")
 	}
 	return false
 }

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -200,6 +200,6 @@ func main() {
 	}
 
 	if err := a.Start(serverConfig); err != nil {
-		log.Fatal("Failed to start server: ", err)
+		log.Fatal("Failed to start: ", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1924

Follow-up to #1341. On system startup, DNS might not be ready when the agent tries to connect, so the initial attempt fails but then it just retries forever.

## Changes

Added `EXIT_ON_INITIAL_FAILURE` environment variable. Set it to `true` or `1` and the agent will exit immediately on first connection failure instead of retrying. Lets init systems like systemd restart the agent, giving DNS time to come online.

Added tests.

## Screenshots (if applicable)

N/A