### PR TITLE
fix(agent): keep every EXTRA_FILESYSTEMS mount when device keys collide

### DIFF
--- a/agent/disk.go
+++ b/agent/disk.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -95,6 +96,25 @@ func isDockerSpecialMountpoint(mountpoint string) bool {
 	return false
 }
 
+// uniqueFsStatsKey derives a fsStats map key that does not collide with an
+// existing entry by starting from the mountpoint's basename and appending a
+// numeric suffix when necessary. Used when the device-derived key would
+// otherwise overwrite a different mount (e.g. autofs reporting "systemd-1"
+// for every automount target).
+func uniqueFsStatsKey(existing map[string]*system.FsStats, mountpoint string) string {
+	base := filepath.Base(mountpoint)
+	if base == "" || base == "/" || base == "." {
+		base = "fs"
+	}
+	key := base
+	for i := 2; ; i++ {
+		if _, exists := existing[key]; !exists {
+			return key
+		}
+		key = fmt.Sprintf("%s-%d", base, i)
+	}
+}
+
 // registerFilesystemStats resolves the tracked key and stats payload for a
 // filesystem before it is inserted into fsStats.
 func registerFilesystemStats(existing map[string]*system.FsStats, device, mountpoint string, root bool, customName string, ctx fsRegistrationContext) (string, *system.FsStats, bool) {
@@ -140,8 +160,16 @@ func registerFilesystemStats(existing map[string]*system.FsStats, device, mountp
 		}
 	}
 
-	if _, exists := existing[key]; exists {
-		return "", nil, false
+	if existingStats, exists := existing[key]; exists {
+		if existingStats.Mountpoint == mountpoint {
+			return "", nil, false
+		}
+		// Key collides on a different mountpoint. Pseudo-device setups like
+		// systemd-automount report the same device ("systemd-1") for every
+		// mount, which would otherwise drop every entry after the first
+		// (see #1931). Derive a unique key from the mountpoint so each mount
+		// survives.
+		key = uniqueFsStatsKey(existing, mountpoint)
 	}
 
 	fsStats := &system.FsStats{Root: root, Mountpoint: mountpoint}

--- a/agent/disk_test.go
+++ b/agent/disk_test.go
@@ -258,9 +258,9 @@ func TestBuildFsStatRegistration(t *testing.T) {
 		assert.Equal(t, `C:`, key)
 	})
 
-	t.Run("skips existing key", func(t *testing.T) {
+	t.Run("skips re-registration of the same mountpoint", func(t *testing.T) {
 		key, stats, ok := registerFilesystemStats(
-			map[string]*system.FsStats{"sda1": {Mountpoint: "/existing"}},
+			map[string]*system.FsStats{"sda1": {Mountpoint: "/mnt/data"}},
 			"/dev/sda1",
 			"/mnt/data",
 			false,
@@ -276,6 +276,52 @@ func TestBuildFsStatRegistration(t *testing.T) {
 		assert.False(t, ok)
 		assert.Empty(t, key)
 		assert.Nil(t, stats)
+	})
+
+	t.Run("keeps both mounts when a pseudo-device key collides (issue #1931)", func(t *testing.T) {
+		// systemd-automount reports every mount with device="systemd-1", so
+		// registering the second entry must not silently drop it.
+		existing := map[string]*system.FsStats{
+			"systemd-1": {Mountpoint: "/media/video"},
+		}
+		key, stats, ok := registerFilesystemStats(
+			existing,
+			"systemd-1",
+			"/media/backup",
+			false,
+			"Backup",
+			fsRegistrationContext{
+				isWindows:      false,
+				diskIoCounters: map[string]disk.IOCountersStat{},
+			},
+		)
+
+		assert.True(t, ok)
+		assert.NotEqual(t, "systemd-1", key, "key must differ from the colliding entry")
+		assert.Equal(t, "backup", key)
+		assert.Equal(t, "/media/backup", stats.Mountpoint)
+		assert.Equal(t, "Backup", stats.Name)
+	})
+
+	t.Run("derives a suffixed unique key when the mountpoint basename also collides", func(t *testing.T) {
+		existing := map[string]*system.FsStats{
+			"systemd-1": {Mountpoint: "/srv/backup"},
+			"backup":    {Mountpoint: "/media/backup"},
+		}
+		key, _, ok := registerFilesystemStats(
+			existing,
+			"systemd-1",
+			"/mnt/backup",
+			false,
+			"",
+			fsRegistrationContext{
+				isWindows:      false,
+				diskIoCounters: map[string]disk.IOCountersStat{},
+			},
+		)
+
+		assert.True(t, ok)
+		assert.Equal(t, "backup-2", key)
 	})
 }
 


### PR DESCRIPTION
## What

`EXTRA_FILESYSTEMS` now correctly registers every listed mount when multiple entries sit behind systemd-automount (or any other pseudo-device that reuses a single device identifier across mounts).

Fixes #1931.

## Why

`agent/disk.go`'s `registerFilesystemStats` dedupes by device-derived key. For most real devices that's correct — `/dev/sda1` can only be mounted in one place at a time. But `x-systemd.automount` reports every mount with the literal device `systemd-1`, so the fsStats key collides on the first entry and every subsequent mount is silently dropped (no log line, no error).

Reporter's config, which should register two disks, only surfaces one:

```
EXTRA_FILESYSTEMS=/media/video__Video,/media/backup__Backup
```

```
INFO Detected disk name=Video device=systemd-1 mount=/media/video io=systemd-1 root=false
DEBUG Extra FS data=map[Video:0x...]
```

Only `Video` ever makes it into `fsStats`; `Backup` is silently discarded because `fsStats["systemd-1"]` was already set.

## How

`registerFilesystemStats` now distinguishes two "existing key" cases:

1. **Same mountpoint already registered** — real duplicate. Still rejected with `ok=false` (the old behaviour).
2. **Different mountpoint under the same key** — pseudo-device collision. Fall back to a unique key derived from the mountpoint basename (`/media/backup` → `backup`), with a `-N` suffix if that basename also collides.

A small `uniqueFsStatsKey` helper encapsulates the basename/suffix logic.

## Before / After

For `EXTRA_FILESYSTEMS=/media/video__Video,/media/backup__Backup`:

| | v0.18.7 | After |
|---|---|---|
| fsStats keys | `{"systemd-1": Video}` | `{"systemd-1": Video, "backup": Backup}` |
| Mounts visible in UI | Video only | Video and Backup |

No change for any setup where the device key uniquely identifies the mount (i.e. every real block device). The new path only triggers on key collisions, so existing user-visible names stay stable.

## Test plan

- [x] `go build ./agent/...`
- [x] `gofmt -l agent/disk.go agent/disk_test.go` — clean
- [x] `go vet ./agent/...`
- [x] `go test -race ./agent/...` — all pass, including three tests covering the new paths:
  - updated "skips re-registration of the same mountpoint" (true duplicate case)
  - new "keeps both mounts when a pseudo-device key collides (issue #1931)"
  - new "derives a suffixed unique key when the mountpoint basename also collides"