### PR TITLE
fix(hub): use rfcEmail validator to allow IDN/Punycode email addresses

### DIFF
--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -17,7 +17,7 @@ import { toast } from "../ui/use-toast"
 import { OtpInputForm } from "./otp-forms"
 
 const honeypot = v.literal("")
-const emailSchema = v.pipe(v.string(), v.email(t`Invalid email address.`))
+const emailSchema = v.pipe(v.string(), v.rfcEmail(t`Invalid email address.`))
 const passwordSchema = v.pipe(
 	v.string(),
 	v.minLength(8, t`Password must be at least 8 characters.`),

--- a/internal/site/src/components/routes/settings/notifications.tsx
+++ b/internal/site/src/components/routes/settings/notifications.tsx
@@ -24,7 +24,7 @@ interface ShoutrrrUrlCardProps {
 }
 
 const NotificationSchema = v.object({
-	emails: v.array(v.pipe(v.string(), v.email())),
+	emails: v.array(v.pipe(v.string(), v.rfcEmail())),
 	webhooks: v.array(v.pipe(v.string(), v.url())),
 })
 


### PR DESCRIPTION
## Problem

Email addresses with internationalized domain names (IDN) fail validation even when the address is valid. For example:

- `user@münchen.de` → normalized as `user@xn--mnchen-3ya.de` (Punycode)
- Any domain with `--` in a label (like `xn--...`) is rejected

This is caused by valibot's `email()` action using a regex that rejects labels containing `--`, which is required by Punycode encoding.

## Root cause

`v.email()` uses this regex:
```
/^[\w+-]+(?:\.[\w+-]+)*@[\da-z]+(?:[.-][\da-z]+)*\.[a-z]{2,}$/iu
```

The `[\da-z]+(?:[.-][\da-z]+)*` pattern for the domain part only allows alternating alphanumeric segments separated by `.` or `-` — it can't match consecutive hyphens like `xn--`.

## Fix

Replace `v.email()` with `v.rfcEmail()` in both validation locations. The RFC-compliant validator uses a pattern derived from RFC 5322 that correctly handles IDN/Punycode domain labels.

**Before:**
```ts
const emailSchema = v.pipe(v.string(), v.email(t`Invalid email address.`))
emails: v.array(v.pipe(v.string(), v.email())),
```

**After:**
```ts
const emailSchema = v.pipe(v.string(), v.rfcEmail(t`Invalid email address.`))
emails: v.array(v.pipe(v.string(), v.rfcEmail())),
```

Both `email()` and `rfcEmail()` are available in valibot v1.3.1 (the version pinned in `package.json`).

Fixes #1934