### PR TITLE
fix(hub): stop launching system updaters after manager shutdown

### DIFF
--- a/internal/hub/systems/system_manager.go
+++ b/internal/hub/systems/system_manager.go
@@ -1,6 +1,7 @@
 package systems
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -45,6 +46,8 @@ type SystemManager struct {
 	systems       *store.Store[string, *System]         // Thread-safe store of active systems
 	sshConfig     *ssh.ClientConfig                     // SSH client configuration for system connections
 	smartFetchMap *expirymap.ExpiryMap[smartFetchState] // Stores last SMART fetch time/result; TTL is only for cleanup
+	ctx           context.Context                       // Cancelled when the manager is shutting down
+	cancel        context.CancelFunc                    // Cancels ctx
 }
 
 // hubLike defines the interface requirements for the hub dependency.
@@ -60,10 +63,13 @@ type hubLike interface {
 // NewSystemManager creates a new SystemManager instance with the provided hub.
 // The hub must implement the hubLike interface to provide database and alert functionality.
 func NewSystemManager(hub hubLike) *SystemManager {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &SystemManager{
 		systems:       store.New(map[string]*System{}),
 		hub:           hub,
 		smartFetchMap: expirymap.New[smartFetchState](time.Hour),
+		ctx:           ctx,
+		cancel:        cancel,
 	}
 }
 
@@ -103,7 +109,13 @@ func (sm *SystemManager) Initialize() error {
 		sleepTime := time.Duration(delta) * time.Millisecond
 
 		for _, system := range systems {
-			time.Sleep(sleepTime)
+			select {
+			case <-sm.ctx.Done():
+				// Abort if the manager has been shut down (e.g. test cleanup)
+				// to avoid starting updater goroutines against a torn-down hub. See #1950.
+				return
+			case <-time.After(sleepTime):
+			}
 			_ = sm.AddSystem(system)
 		}
 	}()
@@ -238,6 +250,11 @@ func (sm *SystemManager) onRecordAfterDeleteSuccess(e *core.RecordEvent) error {
 // It validates required fields, initializes the system context, and starts the update goroutine.
 // Returns error if a system with the same ID already exists.
 func (sm *SystemManager) AddSystem(sys *System) error {
+	if sm.ctx.Err() != nil {
+		// Manager is shutting down; do not start new updater goroutines
+		// against a hub that may be torn down. See #1950.
+		return sm.ctx.Err()
+	}
 	if sm.systems.Has(sys.Id) {
 		return errSystemExists
 	}

--- a/internal/hub/systems/system_test.go
+++ b/internal/hub/systems/system_test.go
@@ -3,9 +3,11 @@
 package systems
 
 import (
+	"context"
 	"testing"
 
 	"github.com/henrygd/beszel/internal/entities/system"
+	"github.com/pocketbase/pocketbase/tools/store"
 )
 
 func TestCombinedData_MigrateDeprecatedFields(t *testing.T) {
@@ -156,4 +158,21 @@ func TestCombinedData_MigrateDeprecatedFields(t *testing.T) {
 			t.Errorf("expected Info.Hostname to be reset, got '%s'", cd.Info.Hostname)
 		}
 	})
+}
+
+// TestAddSystemRefusedAfterShutdown verifies that AddSystem returns an error
+// once the manager has been shut down, so the staggered Initialize starter
+// cannot spawn updater goroutines against a torn-down hub. See #1950.
+func TestAddSystemRefusedAfterShutdown(t *testing.T) {
+	sm := &SystemManager{systems: store.New(map[string]*System{})}
+	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	sm.cancel()
+
+	err := sm.AddSystem(&System{Id: "sys", Host: "127.0.0.1"})
+	if err == nil {
+		t.Fatalf("AddSystem returned nil error after shutdown")
+	}
+	if sm.systems.Has("sys") {
+		t.Fatalf("system was added to store after shutdown")
+	}
 }

--- a/internal/hub/systems/systems_test_helpers.go
+++ b/internal/hub/systems/systems_test_helpers.go
@@ -111,6 +111,11 @@ func (sm *SystemManager) SetSystemStatusInDB(systemID string, status string) boo
 
 // TESTING ONLY: RemoveAllSystems removes all systems from the store
 func (sm *SystemManager) RemoveAllSystems() {
+	// Signal shutdown first so any in-flight Initialize staggered-start goroutine
+	// stops adding new systems against a hub that is about to be torn down. See #1950.
+	if sm.cancel != nil {
+		sm.cancel()
+	}
 	for _, system := range sm.systems.GetAll() {
 		sm.RemoveSystem(system.Id)
 	}


### PR DESCRIPTION
## Description

Fixes #1950.

The hub test suite intermittently panics on Apple Silicon during `go test ./internal/alerts/...` with a nil pointer dereference inside PocketBase's `RecordQuery`. The trace ends in `StartUpdater -> setDown -> getRecord -> FindRecordById`, with the goroutine created by `SystemManager.AddSystem`.

### Root cause

`SystemManager.Initialize` spawns a background goroutine that walks the systems loaded from the database and calls `AddSystem` for each one with a `time.Sleep` between calls (up to 2s per system). When a test's `defer hub.Cleanup()` runs while that loop is still sleeping, the loop is not aware of the shutdown:

1. `RemoveAllSystems` iterates `sm.systems.GetAll()` and cancels every system already added.
2. `TestApp.Cleanup` calls `ResetBootstrapState`, nilling the underlying DB.
3. The staggered loop wakes from its sleep, calls `AddSystem` for the next system, and starts a `StartUpdater` goroutine whose `sys.manager.hub` already has a nil DB. The first `update()` call inevitably fails (no real agent), `setDown -> getRecord -> FindRecordById` then panics inside `app.ConcurrentDB()`.

The window is much wider on Apple Silicon because of weaker memory ordering and slower TCP teardown, which is why x86_64 builds usually pass.

### Fix

Give `SystemManager` its own `context.Context` that is cancelled on shutdown:

- The staggered Initialize loop replaces `time.Sleep(sleepTime)` with a `select` on `sm.ctx.Done()` and returns early once shutdown is signalled.
- `AddSystem` refuses to add a system (and therefore does not spawn `StartUpdater`) once `sm.ctx` is cancelled.
- The test-only `RemoveAllSystems` helper cancels `sm.ctx` before tearing systems down, so by the time `TestApp.Cleanup` clears the DB the staggered loop is guaranteed not to start any new updaters.

No `recover()` is added; the production paths are unchanged on the happy path.

### Before / After

Before (from the issue, also reproducible locally on darwin/arm64):
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xb0]
goroutine N [running]:
github.com/pocketbase/pocketbase/core.(*BaseApp).RecordQuery(...)
github.com/henrygd/beszel/internal/hub/systems.(*System).getRecord(...)
github.com/henrygd/beszel/internal/hub/systems.(*System).setDown(...)
github.com/henrygd/beszel/internal/hub/systems.(*System).StartUpdater(...)
created by github.com/henrygd/beszel/internal/hub/systems.(*SystemManager).AddSystem
FAIL    github.com/henrygd/beszel/internal/alerts
```

After: `go test ./internal/alerts/... ./internal/hub/systems/...` is green across 5 consecutive runs on darwin/arm64.

## Changelog

### Fixed

- Hub system manager no longer starts `StartUpdater` goroutines against a hub that is being torn down, fixing a flaky panic in `internal/alerts` tests on Apple Silicon (#1950).