### PR TITLE
Clamp Linux battery capacity percentage

### DIFF
--- a/agent/battery/battery_linux.go
+++ b/agent/battery/battery_linux.go
@@ -102,6 +102,7 @@ func GetBatteryStats() (batteryPercent uint8, batteryState uint8, err error) {
 		if parseErr != nil {
 			continue
 		}
+		cap = min(max(cap, 0), 100)
 		totalPercent += cap
 		count++
 

--- a/agent/battery/battery_linux_test.go
+++ b/agent/battery/battery_linux_test.go
@@ -91,6 +91,16 @@ func TestGetBatteryStats_FullBattery(t *testing.T) {
 	assert.Equal(t, stateFull, state)
 }
 
+func TestGetBatteryStats_CapacityClamped(t *testing.T) {
+	_, addBattery := setupFakeSysfs(t)
+	addBattery("BAT0", "105", "Charging")
+
+	pct, state, err := GetBatteryStats()
+	assert.NoError(t, err)
+	assert.Equal(t, uint8(100), pct)
+	assert.Equal(t, stateCharging, state)
+}
+
 func TestGetBatteryStats_EmptyBattery(t *testing.T) {
 	_, addBattery := setupFakeSysfs(t)
 	addBattery("BAT0", "0", "Empty")


### PR DESCRIPTION
## Summary
- clamp Linux sysfs battery capacity values to the valid 0-100 range before reporting them
- add a regression test for a kernel/sysfs capacity value above 100

## Context
Some Linux systems can briefly report battery `capacity` values above 100 via `/sys/class/power_supply/*/capacity`. Beszel currently forwards that value directly, which can surface impossible percentages like 105% in integrations.

## Tests
- `go test -tags testing ./agent/battery`
- `go test ./agent/...`