### PR TITLE
Add temperature data for freebsd

### DIFF
--- a/agent/sensors_default.go
+++ b/agent/sensors_default.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !freebsd
 
 package agent
 

--- a/agent/sensors_freebsd.go
+++ b/agent/sensors_freebsd.go
@@ -1,0 +1,45 @@
+//go:build freebsd
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/shirou/gopsutil/v4/sensors"
+	"golang.org/x/sys/unix"
+)
+
+var getSensorTemps getTempsFn = freebsdGetTemps
+
+// freebsdGetTemps reads hardware temperatures from FreeBSD sysctls.
+// CPU temps come from dev.cpu.N.temperature (coretemp/amdtemp drivers).
+// System temps come from hw.acpi.thermal.tzN.temperature (ACPI thermal zones).
+// Values are in deciKelvin; conversion: °C = val/10 - 273.15.
+func freebsdGetTemps(_ context.Context) ([]sensors.TemperatureStat, error) {
+	var temps []sensors.TemperatureStat
+
+	for i := range 64 {
+		val, err := unix.SysctlUint32(fmt.Sprintf("dev.cpu.%d.temperature", i))
+		if err != nil {
+			break
+		}
+		temps = append(temps, sensors.TemperatureStat{
+			SensorKey:   fmt.Sprintf("cpu%d", i),
+			Temperature: float64(val)/10.0 - 273.15,
+		})
+	}
+
+	for i := range 16 {
+		val, err := unix.SysctlUint32(fmt.Sprintf("hw.acpi.thermal.tz%d.temperature", i))
+		if err != nil {
+			break
+		}
+		temps = append(temps, sensors.TemperatureStat{
+			SensorKey:   fmt.Sprintf("tz%d", i),
+			Temperature: float64(val)/10.0 - 273.15,
+		})
+	}
+
+	return temps, nil
+}


### PR DESCRIPTION
## 📃 Description

Freebsd temps are currently not supported by gopsutil (https://github.com/henrygd/beszel/issues/1601). This change adds specific freebsd flow to just grab the temps directly using the unix library. Useful for when you want to run Beszel on an opnsense router. Thanks for creating this project! 

## 📷 Screenshots

<img width="1804" height="502" alt="screenshot-2026-04-30_08-36-00" src="https://github.com/user-attachments/assets/7332b775-cd15-408b-a984-51f031549a10" />
<img width="1840" height="423" alt="screenshot-2026-04-30_08-37-32" src="https://github.com/user-attachments/assets/34dfb650-3162-4032-888a-3f11ba1d66a1" />

