### PR TITLE
systems: synthesize error when getRecord returns nil record

### DIFF
--- a/internal/hub/systems/system.go
+++ b/internal/hub/systems/system.go
@@ -348,6 +348,9 @@ func (sys *System) getRecord(app core.App) (*core.Record, error) {
 	record, err := app.FindRecordById("systems", sys.Id)
 	if err != nil || record == nil {
 		_ = sys.manager.RemoveSystem(sys.Id)
+		if err == nil {
+			err = fmt.Errorf("system record %s not found", sys.Id)
+		}
 		return nil, err
 	}
 	return record, nil


### PR DESCRIPTION
Closes #1950. `FindRecordById` can return (nil, nil) when the record is gone; the caller used to receive (nil, nil), then dereferenced the nil record downstream and panicked.