### PR TITLE
Fix: Enable immediate exit on errors in install-agent.sh

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -230,6 +230,9 @@ detect_mips_endianness() {
   echo "mips"
 }
 
+# Ensure script exits immediately on errors
+set -eu
+
 # Default values
 PORT=45876
 UNINSTALL=false


### PR DESCRIPTION
## 📃 Description

Add error handling to ensure the script exits on errors.

Refs https://github.com/henrygd/beszel/issues/1971
