### PR TITLE
MD check sync action should not trigger a warning

### DIFF
--- a/agent/mdraid_linux.go
+++ b/agent/mdraid_linux.go
@@ -181,7 +181,7 @@ func mdraidSmartStatus(health mdraidHealth) string {
 		return "FAILED"
 	}
 	switch syncAction {
-	case "check", "repair":
+	case "repair":
 		return "WARNING"
 	}
 	switch state {


### PR DESCRIPTION
MD array checking is a routine check which should not trigger warnings and alerts.

## 📃 Description

When a consistency check is ran on a MD RAID array, this is currently interpreted as a warning in Beszel and triggers an alert. However, this is part of routine maintenance and often runs on a schedule (at least for Debian-based systems).

I have removed the case entry for `syncAction == "check"`, such that it should pass as healthy.

More information:
- https://manpages.debian.org/unstable/mdadm/md.4.en.html#SCRUBBING_AND_MISMATCHES
- https://www.spinics.net/lists/raid/msg61886.html

## 🪵 Changelog

### ✏️ Changed

- agent/mdraid_linux.go
