### PR TITLE
feat(agent): Implement auto-discovery for extra mounted block volumes

### DIFF
--- a/agent/disk.go
+++ b/agent/disk.go
@@ -95,6 +95,121 @@ func isDockerSpecialMountpoint(mountpoint string) bool {
 	return false
 }
 
+// autoDiscoverExtraMountsDisabled returns true when DISABLE_AUTO_EXTRA_DISK is set
+// to opt out of scanning for additional mounted block volumes (default is enabled).
+func autoDiscoverExtraMountsDisabled() bool {
+	v, ok := utils.GetEnv("DISABLE_AUTO_EXTRA_DISK")
+	if !ok {
+		return false
+	}
+	v = strings.TrimSpace(strings.ToLower(v))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+// excludedAutoDiscoverFstypes are pseudo and remote filesystem types we never
+// auto-register as extra disks.
+var excludedAutoDiscoverFstypes = map[string]struct{}{
+	"tmpfs": {}, "devtmpfs": {}, "devpts": {}, "proc": {}, "sysfs": {},
+	"cgroup": {}, "cgroup2": {}, "overlay": {}, "autofs": {}, "fusectl": {},
+	"mqueue": {}, "bpf": {}, "tracefs": {}, "configfs": {}, "securityfs": {},
+	"hugetlbfs": {}, "debugfs": {}, "pstore": {}, "ramfs": {}, "fuse": {},
+	"rpc_pipefs": {}, "binfmt_misc": {}, "nsfs": {}, "squashfs": {}, "erofs": {},
+	"zfs_snapshot": {}, "none": {},
+	"nfs": {}, "nfs4": {}, "cifs": {}, "smb3": {}, "9p": {}, "ceph": {}, "glusterfs": {},
+}
+
+func isExcludedAutoDiscoverFstype(fstype string) bool {
+	fstype = strings.ToLower(strings.TrimSpace(fstype))
+	if fstype == "" {
+		return false
+	}
+	_, excluded := excludedAutoDiscoverFstypes[fstype]
+	return excluded
+}
+
+// isAutoDiscoverPseudoMountPath skips kernel and package-manager mount namespaces
+// that are not separate physical drives. /run intentionally is not skipped so that
+// USB volumes auto-mounted at /run/media/<user>/<label> still surface; non-disk
+// entries under /run are excluded by fstype.
+func isAutoDiscoverPseudoMountPath(mountpoint string) bool {
+	mountpoint = filepath.Clean(mountpoint)
+	if mountpoint == "/" {
+		return false
+	}
+	prefixes := []string{"/proc", "/sys", "/dev", "/snap"}
+	for _, p := range prefixes {
+		if mountpoint == p || strings.HasPrefix(mountpoint, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// partitionQualifiesForAutoExtra reports whether a discovered partition should be
+// tracked as an extra filesystem without EXTRA_FILESYSTEMS configuration.
+func partitionQualifiesForAutoExtra(p disk.PartitionStat, rootMountPoint string, isWindows bool) bool {
+	if p.Mountpoint == "" {
+		return false
+	}
+	if p.Mountpoint == rootMountPoint {
+		return false
+	}
+	if isDockerSpecialMountpoint(p.Mountpoint) {
+		return false
+	}
+	if strings.HasPrefix(p.Mountpoint, "/extra-filesystems") {
+		// Handled by addPartitionExtraFs / addExtraFilesystemFolders.
+		return false
+	}
+	if isAutoDiscoverPseudoMountPath(p.Mountpoint) {
+		return false
+	}
+	if isExcludedAutoDiscoverFstype(p.Fstype) {
+		return false
+	}
+	if isWindows {
+		return windowsMountLooksLikeDataVolume(p.Mountpoint, rootMountPoint)
+	}
+	fs := strings.ToLower(strings.TrimSpace(p.Fstype))
+	if fs == "zfs" {
+		return true
+	}
+	dev := strings.TrimSpace(p.Device)
+	if dev == "" {
+		return false
+	}
+	if strings.HasPrefix(dev, "/dev/loop") {
+		return false
+	}
+	return strings.HasPrefix(dev, "/dev/")
+}
+
+func windowsMountLooksLikeDataVolume(mountpoint, rootMountPoint string) bool {
+	// Root is typically "C:"; include other fixed drives (D:, E:, ...).
+	mp := strings.TrimSuffix(strings.TrimSpace(mountpoint), `\`)
+	root := strings.TrimSuffix(strings.TrimSpace(rootMountPoint), `\`)
+	if mp == "" || len(mp) < 2 || mp[1] != ':' {
+		return false
+	}
+	rootLetter := byte('C')
+	if len(root) >= 2 && root[1] == ':' {
+		rootLetter = root[0]
+	}
+	return mp[0] != rootLetter
+}
+
+// addAutoDiscoveredExtraMount registers conventional mounts (e.g. /mnt/data on
+// /dev/sdb1) so multiple physical volumes appear without EXTRA_FILESYSTEMS.
+func (d *diskDiscovery) addAutoDiscoveredExtraMount(p disk.PartitionStat) {
+	if autoDiscoverExtraMountsDisabled() {
+		return
+	}
+	if !partitionQualifiesForAutoExtra(p, d.rootMountPoint, d.ctx.isWindows) {
+		return
+	}
+	d.addFsStat(p.Device, p.Mountpoint, false, "")
+}
+
 // registerFilesystemStats resolves the tracked key and stats payload for a
 // filesystem before it is inserted into fsStats.
 func registerFilesystemStats(existing map[string]*system.FsStats, device, mountpoint string, root bool, customName string, ctx fsRegistrationContext) (string, *system.FsStats, bool) {
@@ -351,6 +466,7 @@ func (a *Agent) initializeDiskInfo() {
 			hasRoot = discovery.addPartitionRootFs(p.Device, p.Mountpoint)
 		}
 		discovery.addPartitionExtraFs(p)
+		discovery.addAutoDiscoveredExtraMount(p)
 	}
 
 	// Check all folders in /extra-filesystems and add them if not already present

--- a/agent/disk_test.go
+++ b/agent/disk_test.go
@@ -611,6 +611,154 @@ func TestAddPartitionExtraFs(t *testing.T) {
 	})
 }
 
+func TestPartitionQualifiesForAutoExtra(t *testing.T) {
+	root := "/"
+	t.Run("linux block mount", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/sdb1", Mountpoint: "/mnt/backup", Fstype: "ext4"}
+		assert.True(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips root mount", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/sda2", Mountpoint: "/", Fstype: "ext4"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips tmpfs", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "tmpfs", Mountpoint: "/run", Fstype: "tmpfs"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips nfs", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "192.168.1.1:/export", Mountpoint: "/mnt/nfs", Fstype: "nfs4"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips loop device", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/loop0", Mountpoint: "/snap/core/123", Fstype: "squashfs"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips pseudo mount path", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/sda1", Mountpoint: "/snap/foo/123", Fstype: "squashfs"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("skips extra-filesystems tree", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/sdc1", Mountpoint: "/extra-filesystems/data", Fstype: "ext4"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("zfs dataset without dev path", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "tank/data", Mountpoint: "/tank", Fstype: "zfs"}
+		assert.True(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("windows non-root drive", func(t *testing.T) {
+		p := disk.PartitionStat{Device: `\\.\HarddiskVolume2`, Mountpoint: `D:\`, Fstype: "ntfs"}
+		assert.True(t, partitionQualifiesForAutoExtra(p, `C:`, true))
+	})
+	t.Run("windows root drive", func(t *testing.T) {
+		p := disk.PartitionStat{Device: `\\.\HarddiskVolume1`, Mountpoint: `C:\`, Fstype: "ntfs"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, `C:`, true))
+	})
+	t.Run("usb mount at /run/media is allowed", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "/dev/sdc1", Mountpoint: "/run/media/user/usb", Fstype: "exfat"}
+		assert.True(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+	t.Run("rejects empty device", func(t *testing.T) {
+		p := disk.PartitionStat{Device: "", Mountpoint: "/mnt/data", Fstype: "ext4"}
+		assert.False(t, partitionQualifiesForAutoExtra(p, root, false))
+	})
+}
+
+func TestAddAutoDiscoveredExtraMount(t *testing.T) {
+	t.Run("registers conventional linux mount", func(t *testing.T) {
+		t.Setenv("DISABLE_AUTO_EXTRA_DISK", "")
+		agent := &Agent{fsStats: make(map[string]*system.FsStats)}
+		d := diskDiscovery{
+			agent:          agent,
+			rootMountPoint: "/",
+			ctx: fsRegistrationContext{
+				isWindows: false,
+				efPath:    "/extra-filesystems",
+				diskIoCounters: map[string]disk.IOCountersStat{
+					"sdb1": {Name: "sdb1"},
+				},
+			},
+		}
+		d.addAutoDiscoveredExtraMount(disk.PartitionStat{
+			Device: "/dev/sdb1", Mountpoint: "/mnt/backup", Fstype: "ext4",
+		})
+		stats, ok := agent.fsStats["sdb1"]
+		assert.True(t, ok)
+		assert.Equal(t, "/mnt/backup", stats.Mountpoint)
+		assert.False(t, stats.Root)
+	})
+
+	t.Run("respects DISABLE_AUTO_EXTRA_DISK", func(t *testing.T) {
+		t.Setenv("DISABLE_AUTO_EXTRA_DISK", "true")
+		agent := &Agent{fsStats: make(map[string]*system.FsStats)}
+		d := diskDiscovery{
+			agent:          agent,
+			rootMountPoint: "/",
+			ctx: fsRegistrationContext{
+				isWindows: false,
+				efPath:    "/extra-filesystems",
+				diskIoCounters: map[string]disk.IOCountersStat{
+					"sdb1": {Name: "sdb1"},
+				},
+			},
+		}
+		d.addAutoDiscoveredExtraMount(disk.PartitionStat{
+			Device: "/dev/sdb1", Mountpoint: "/mnt/backup", Fstype: "ext4",
+		})
+		assert.Empty(t, agent.fsStats)
+	})
+
+	t.Run("boot partition does not duplicate root I/O key", func(t *testing.T) {
+		t.Setenv("DISABLE_AUTO_EXTRA_DISK", "")
+		agent := &Agent{fsStats: map[string]*system.FsStats{
+			"sda": {Root: true, Mountpoint: "/"},
+		}}
+		d := diskDiscovery{
+			agent:          agent,
+			rootMountPoint: "/",
+			ctx: fsRegistrationContext{
+				isWindows: false,
+				efPath:    "/extra-filesystems",
+				diskIoCounters: map[string]disk.IOCountersStat{
+					"sda": {Name: "sda"},
+				},
+			},
+		}
+		d.addAutoDiscoveredExtraMount(disk.PartitionStat{
+			Device: "/dev/sda1", Mountpoint: "/boot", Fstype: "vfat",
+		})
+		assert.Len(t, agent.fsStats, 1)
+		_, hasBoot := agent.fsStats["sda1"]
+		assert.False(t, hasBoot)
+	})
+
+	t.Run("registers second physical disk independently", func(t *testing.T) {
+		t.Setenv("DISABLE_AUTO_EXTRA_DISK", "")
+		agent := &Agent{fsStats: map[string]*system.FsStats{
+			"sda": {Root: true, Mountpoint: "/"},
+		}}
+		d := diskDiscovery{
+			agent:          agent,
+			rootMountPoint: "/",
+			ctx: fsRegistrationContext{
+				isWindows: false,
+				efPath:    "/extra-filesystems",
+				diskIoCounters: map[string]disk.IOCountersStat{
+					"sda":  {Name: "sda"},
+					"sdb1": {Name: "sdb1"},
+				},
+			},
+		}
+		d.addAutoDiscoveredExtraMount(disk.PartitionStat{
+			Device: "/dev/sdb1", Mountpoint: "/mnt/data", Fstype: "ext4",
+		})
+		assert.Len(t, agent.fsStats, 2)
+		stats, ok := agent.fsStats["sdb1"]
+		assert.True(t, ok)
+		assert.False(t, stats.Root)
+		assert.Equal(t, "/mnt/data", stats.Mountpoint)
+	})
+}
+
 func TestFindIoDevice(t *testing.T) {
 	t.Run("matches by device name", func(t *testing.T) {
 		ioCounters := map[string]disk.IOCountersStat{


### PR DESCRIPTION
Added functionality to automatically register additional mounted block volumes based on specific criteria, including support for various filesystem types and conditions. Introduced tests to validate the behavior of the new auto-discovery feature, ensuring proper handling of conventional mounts, exclusions for certain filesystem types, and respect for the DISABLE_AUTO_EXTRA_DISK environment variable.

closes https://github.com/henrygd/beszel/issues/1928
closes https://github.com/henrygd/beszel/issues/1916

## 📃 Description

This literally just adds auto disk discovery

## 📖 Documentation

Add a link to the PR for [documentation](https://github.com/henrygd/beszel-docs) changes.

## 🪵 Changelog

### ➕ Added
This literally just adds auto disk discovery
