### PR TITLE
feat(docker): add healthcheck to hub docker-compose example

### DIFF
--- a/supplemental/docker/hub/docker-compose.yml
+++ b/supplemental/docker/hub/docker-compose.yml
@@ -7,3 +7,9 @@ services:
       - '8090:8090'
     volumes:
       - ./beszel_data:/beszel_data
+    healthcheck:
+      test: ["CMD", "/beszel", "health", "--url", "http://127.0.0.1:8090"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/supplemental/docker/same-system/docker-compose.yml
+++ b/supplemental/docker/same-system/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       - ./beszel_data:/beszel_data
     extra_hosts:
       - 'host.docker.internal:host-gateway'
+    healthcheck:
+      test: ["CMD", "/beszel", "health", "--url", "http://127.0.0.1:8090"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   beszel-agent:
     image: 'henrygd/beszel-agent' #Add -nvidia for nvidia gpus


### PR DESCRIPTION
## What

Adds a `healthcheck` directive to `supplemental/docker/hub/docker-compose.yml`.

## Why

The hub image is distroless — no shell, no `wget`, no `curl` — so the typical healthcheck patterns fail silently. The binary already exposes a `health` subcommand that performs an HTTP self-check, making it a natural fit for `HEALTHCHECK`.

Without this, containers running the distroless hub image show as "running" indefinitely even when wedged, with no orchestrator-level liveness signal and no automatic restart policy trigger.

## Verification

Tested on `henrygd/beszel:0.18.7`:

```bash
$ docker exec beszel /beszel health --url http://127.0.0.1:8090
ok
$ echo $?
0
```

Closes #1963