### PR TITLE
feat(agent): update Dockerfile for NVIDIA agent (#2002)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -52,6 +52,19 @@ jobs:
               type=semver,pattern={{major}}
               type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
 
+          # henrygd/beszel-agent-nvidia:slim
+          - image: henrygd/beszel-agent-nvidia
+            dockerfile: ./internal/dockerfile_agent_nvidia_slim
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+            registry: docker.io
+            username_secret: DOCKERHUB_USERNAME
+            password_secret: DOCKERHUB_TOKEN
+            tags: |
+              type=raw,value=slim
+              type=semver,pattern={{version}}-slim
+              type=semver,pattern={{major}}.{{minor}}-slim
+              type=semver,pattern={{major}}-slim
+
           # henrygd/beszel-agent-intel
           - image: henrygd/beszel-agent-intel
             dockerfile: ./internal/dockerfile_agent_intel
@@ -106,6 +119,19 @@ jobs:
               type=semver,pattern={{major}}.{{minor}}
               type=semver,pattern={{major}}
               type=raw,value={{sha}},enable=${{ github.ref_type != 'tag' }}
+
+          # ghcr.io/henrygd/beszel-agent-nvidia:slim
+          - image: ghcr.io/${{ github.repository }}/beszel-agent-nvidia
+            dockerfile: ./internal/dockerfile_agent_nvidia_slim
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password_secret: GITHUB_TOKEN
+            tags: |
+              type=raw,value=slim
+              type=semver,pattern={{version}}-slim
+              type=semver,pattern={{major}}.{{minor}}-slim
+              type=semver,pattern={{major}}-slim
 
           # ghcr.io/henrygd/beszel-agent-intel
           - image: ghcr.io/${{ github.repository }}/beszel-agent-intel

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -55,7 +55,7 @@ jobs:
           # henrygd/beszel-agent-nvidia:slim
           - image: henrygd/beszel-agent-nvidia
             dockerfile: ./internal/dockerfile_agent_nvidia_slim
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
+            platforms: linux/amd64,linux/arm64
             registry: docker.io
             username_secret: DOCKERHUB_USERNAME
             password_secret: DOCKERHUB_TOKEN
@@ -123,7 +123,7 @@ jobs:
           # ghcr.io/henrygd/beszel-agent-nvidia:slim
           - image: ghcr.io/${{ github.repository }}/beszel-agent-nvidia
             dockerfile: ./internal/dockerfile_agent_nvidia_slim
-            platforms: linux/amd64,linux/arm64,linux/arm/v7
+            platforms: linux/amd64,linux/arm64
             registry: ghcr.io
             username: ${{ github.actor }}
             password_secret: GITHUB_TOKEN

--- a/internal/dockerfile_agent_nvidia
+++ b/internal/dockerfile_agent_nvidia
@@ -9,35 +9,17 @@ RUN go mod download
 COPY . ./
 
 # Build
-ARG TARGETOS=linux
-ARG TARGETARCH
-ARG TARGETVARIANT
-
-RUN set -eux; \
-  if [ "$TARGETARCH" = "arm" ] && [ -n "$TARGETVARIANT" ]; then \
-    export GOARM="${TARGETVARIANT#v}"; \
-  fi; \
-  CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH \
-    go build -tags glibc -ldflags "-w -s" -o /agent ./internal/cmd/agent
+ARG TARGETOS TARGETARCH
+RUN CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags glibc -ldflags "-w -s" -o /agent ./internal/cmd/agent
 
 # --------------------------
 # Smartmontools builder stage
 # --------------------------
-FROM --platform=$TARGETPLATFORM debian:bookworm-slim AS smartmontools-builder
+FROM nvidia/cuda:12.2.2-base-ubuntu22.04 AS smartmontools-builder
 
-# Keep smartmontools 7.5 built from source to match the current NVIDIA agent image behavior.
-# A simpler Debian package based approach is also possible:
-#
-#   RUN apt-get update && apt-get install -y --no-install-recommends \
-#       smartmontools \
-#     && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y \
   wget \
-  ca-certificates \
   build-essential \
-  make \
-  g++ \
   && wget https://downloads.sourceforge.net/project/smartmontools/smartmontools/7.5/smartmontools-7.5.tar.gz \
   && tar zxvf smartmontools-7.5.tar.gz \
   && cd smartmontools-7.5 \
@@ -49,26 +31,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy smartmontools binary, data files, and required runtime libraries
-RUN set -eux; \
-  mkdir -p /out/rootfs/usr/share /out/rootfs/lib /out/rootfs/lib64 /out/rootfs/usr/lib; \
-  if [ -d /usr/share/smartmontools ]; then \
-    cp -a /usr/share/smartmontools /out/rootfs/usr/share/; \
-  fi; \
-  ldd /usr/sbin/smartctl \
-    | awk '{print $3}' \
-    | grep '^/' \
-    | xargs -r -I '{}' sh -c 'mkdir -p "/out/rootfs$(dirname "{}")"; cp -v "{}" "/out/rootfs{}"'; \
-  interp="$(ldd /usr/sbin/smartctl | awk "/ld-linux/ {print \$1}")"; \
-  if [ -n "$interp" ] && [ -e "$interp" ]; then \
-    mkdir -p "/out/rootfs$(dirname "$interp")"; \
-    cp -v "$interp" "/out/rootfs$interp"; \
-  fi
-
 # --------------------------
 # Final image: GPU-enabled agent with nvidia-smi
 # --------------------------
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12
+FROM nvidia/cuda:12.2.2-base-ubuntu22.04
 COPY --from=builder /agent /agent
 
 # AMD GPU name lookup (used by agent on hybrid laptops when /usr/share/libdrm/amdgpu.ids is read)
@@ -76,15 +42,8 @@ COPY --from=builder /app/agent/test-data/amdgpu.ids /usr/share/libdrm/amdgpu.ids
 
 # Copy smartmontools binaries and config files
 COPY --from=smartmontools-builder /usr/sbin/smartctl /usr/sbin/smartctl
-COPY --from=smartmontools-builder /out/rootfs/ /
-
-# nvidia-smi is intentionally not bundled.
-# Mount the host binary instead, for example:
-# - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
 
 # Ensure data persistence across container recreations
 VOLUME ["/var/lib/beszel-agent"]
-
-WORKDIR /var/lib/beszel-agent
 
 ENTRYPOINT ["/agent"]

--- a/internal/dockerfile_agent_nvidia
+++ b/internal/dockerfile_agent_nvidia
@@ -9,17 +9,35 @@ RUN go mod download
 COPY . ./
 
 # Build
-ARG TARGETOS TARGETARCH
-RUN CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags glibc -ldflags "-w -s" -o /agent ./internal/cmd/agent
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN set -eux; \
+  if [ "$TARGETARCH" = "arm" ] && [ -n "$TARGETVARIANT" ]; then \
+    export GOARM="${TARGETVARIANT#v}"; \
+  fi; \
+  CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -tags glibc -ldflags "-w -s" -o /agent ./internal/cmd/agent
 
 # --------------------------
 # Smartmontools builder stage
 # --------------------------
-FROM nvidia/cuda:12.2.2-base-ubuntu22.04 AS smartmontools-builder
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim AS smartmontools-builder
 
-RUN apt-get update && apt-get install -y \
+# Keep smartmontools 7.5 built from source to match the current NVIDIA agent image behavior.
+# A simpler Debian package based approach is also possible:
+#
+#   RUN apt-get update && apt-get install -y --no-install-recommends \
+#       smartmontools \
+#     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
   wget \
+  ca-certificates \
   build-essential \
+  make \
+  g++ \
   && wget https://downloads.sourceforge.net/project/smartmontools/smartmontools/7.5/smartmontools-7.5.tar.gz \
   && tar zxvf smartmontools-7.5.tar.gz \
   && cd smartmontools-7.5 \
@@ -31,10 +49,26 @@ RUN apt-get update && apt-get install -y \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/*
 
+# Copy smartmontools binary, data files, and required runtime libraries
+RUN set -eux; \
+  mkdir -p /out/rootfs/usr/share /out/rootfs/lib /out/rootfs/lib64 /out/rootfs/usr/lib; \
+  if [ -d /usr/share/smartmontools ]; then \
+    cp -a /usr/share/smartmontools /out/rootfs/usr/share/; \
+  fi; \
+  ldd /usr/sbin/smartctl \
+    | awk '{print $3}' \
+    | grep '^/' \
+    | xargs -r -I '{}' sh -c 'mkdir -p "/out/rootfs$(dirname "{}")"; cp -v "{}" "/out/rootfs{}"'; \
+  interp="$(ldd /usr/sbin/smartctl | awk "/ld-linux/ {print \$1}")"; \
+  if [ -n "$interp" ] && [ -e "$interp" ]; then \
+    mkdir -p "/out/rootfs$(dirname "$interp")"; \
+    cp -v "$interp" "/out/rootfs$interp"; \
+  fi
+
 # --------------------------
 # Final image: GPU-enabled agent with nvidia-smi
 # --------------------------
-FROM nvidia/cuda:12.2.2-base-ubuntu22.04
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12
 COPY --from=builder /agent /agent
 
 # AMD GPU name lookup (used by agent on hybrid laptops when /usr/share/libdrm/amdgpu.ids is read)
@@ -42,8 +76,15 @@ COPY --from=builder /app/agent/test-data/amdgpu.ids /usr/share/libdrm/amdgpu.ids
 
 # Copy smartmontools binaries and config files
 COPY --from=smartmontools-builder /usr/sbin/smartctl /usr/sbin/smartctl
+COPY --from=smartmontools-builder /out/rootfs/ /
+
+# nvidia-smi is intentionally not bundled.
+# Mount the host binary instead, for example:
+# - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
 
 # Ensure data persistence across container recreations
 VOLUME ["/var/lib/beszel-agent"]
+
+WORKDIR /var/lib/beszel-agent
 
 ENTRYPOINT ["/agent"]

--- a/internal/dockerfile_agent_nvidia_slim
+++ b/internal/dockerfile_agent_nvidia_slim
@@ -1,0 +1,90 @@
+FROM --platform=$BUILDPLATFORM golang:bookworm AS builder
+
+WORKDIR /app
+
+COPY ../go.mod ../go.sum ./
+RUN go mod download
+
+# Copy source files
+COPY . ./
+
+# Build
+ARG TARGETOS=linux
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN set -eux; \
+  if [ "$TARGETARCH" = "arm" ] && [ -n "$TARGETVARIANT" ]; then \
+    export GOARM="${TARGETVARIANT#v}"; \
+  fi; \
+  CGO_ENABLED=0 GOGC=75 GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    go build -tags glibc -ldflags "-w -s" -o /agent ./internal/cmd/agent
+
+# --------------------------
+# Smartmontools builder stage
+# --------------------------
+FROM --platform=$TARGETPLATFORM debian:bookworm-slim AS smartmontools-builder
+
+# Keep smartmontools 7.5 built from source to match the current NVIDIA agent image behavior.
+# A simpler Debian package based approach is also possible:
+#
+#   RUN apt-get update && apt-get install -y --no-install-recommends \
+#       smartmontools \
+#     && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  wget \
+  ca-certificates \
+  build-essential \
+  make \
+  g++ \
+  && wget https://downloads.sourceforge.net/project/smartmontools/smartmontools/7.5/smartmontools-7.5.tar.gz \
+  && tar zxvf smartmontools-7.5.tar.gz \
+  && cd smartmontools-7.5 \
+  && ./configure --prefix=/usr --sysconfdir=/etc \
+  && make \
+  && make install \
+  && rm -rf /smartmontools-7.5* \
+  && apt-get remove -y wget build-essential \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
+
+# Copy smartmontools binary, data files, and required runtime libraries
+RUN set -eux; \
+  mkdir -p /out/rootfs/usr/share /out/rootfs/lib /out/rootfs/lib64 /out/rootfs/usr/lib; \
+  if [ -d /usr/share/smartmontools ]; then \
+    cp -a /usr/share/smartmontools /out/rootfs/usr/share/; \
+  fi; \
+  ldd /usr/sbin/smartctl \
+    | awk '{print $3}' \
+    | grep '^/' \
+    | xargs -r -I '{}' sh -c 'mkdir -p "/out/rootfs$(dirname "{}")"; cp -v "{}" "/out/rootfs{}"'; \
+  interp="$(ldd /usr/sbin/smartctl | awk "/ld-linux/ {print \$1}")"; \
+  if [ -n "$interp" ] && [ -e "$interp" ]; then \
+    mkdir -p "/out/rootfs$(dirname "$interp")"; \
+    cp -v "$interp" "/out/rootfs$interp"; \
+  fi
+
+# --------------------------
+# Final image: lightweight multi-arch NVIDIA agent (slim)
+# --------------------------
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/base-debian12
+COPY --from=builder /agent /agent
+
+# AMD GPU name lookup (used by agent on hybrid laptops when /usr/share/libdrm/amdgpu.ids is read)
+COPY --from=builder /app/agent/test-data/amdgpu.ids /usr/share/libdrm/amdgpu.ids
+
+# Copy smartmontools binaries and config files
+COPY --from=smartmontools-builder /usr/sbin/smartctl /usr/sbin/smartctl
+COPY --from=smartmontools-builder /out/rootfs/ /
+
+# nvidia-smi is intentionally not bundled.
+# Mount the host binary instead, for example:
+# - /usr/bin/nvidia-smi:/usr/bin/nvidia-smi:ro
+
+# Ensure data persistence across container recreations
+VOLUME ["/var/lib/beszel-agent"]
+
+WORKDIR /var/lib/beszel-agent
+
+ENTRYPOINT ["/agent"]


### PR DESCRIPTION
## 📃 Description

Feature #2002 Optimized the `agent-nvidia` image for size and multi-arch support. By switching to a Distroless base and mounting nvidia-smi from the host, the image size is reduced by **75%**.

## 🪵 Changelog

### ➕ Added

- Multi-arch support: amd64, arm64, arm/v7.
- Dynamic library tracking for smartctl on Distroless.

### ✏️ Changed

- Base image: ubuntu-cuda → distroless/base-debian12.
- Reduced uncompressed size by ~270MB.

### 🗑️ Removed

- Bundled CUDA layers and shell (via Distroless).