### PR TITLE
feat(ui): replace color-only status dots with icons (WCAG 2.2 SC 1.4.1)

### DIFF
--- a/internal/site/src/components/containers-table/containers-table-columns.tsx
+++ b/internal/site/src/components/containers-table/containers-table-columns.tsx
@@ -132,9 +132,9 @@ export const containerChartCols: ColumnDef<ContainerRecord>[] = [
 			const healthStatus = ContainerHealthLabels[healthValue] || "Unknown"
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-4 me-1.5 text-green-500" />}
-					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-4 me-1.5 text-red-500" />}
-					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-4 me-1.5 text-yellow-500" />}
+					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-4 me-1.5 text-[#356144] dark:text-green-500" />}
+					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-4 me-1.5 text-[#913e42] dark:text-red-500" />}
+					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-4 me-1.5 text-[#976f00] dark:text-yellow-500" />}
 					{healthValue === ContainerHealth.None && <CircleMinusIcon className="size-4 me-1.5 text-zinc-500" />}
 					{healthStatus}
 				</Badge>

--- a/internal/site/src/components/containers-table/containers-table-columns.tsx
+++ b/internal/site/src/components/containers-table/containers-table-columns.tsx
@@ -132,10 +132,10 @@ export const containerChartCols: ColumnDef<ContainerRecord>[] = [
 			const healthStatus = ContainerHealthLabels[healthValue] || "Unknown"
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-3 me-1.5 text-green-500" />}
-					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-3 me-1.5 text-red-500" />}
-					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-3 me-1.5 text-yellow-500" />}
-					{healthValue === ContainerHealth.None && <CircleMinusIcon className="size-3 me-1.5 text-zinc-500" />}
+					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-4 me-1.5 text-green-500" />}
+					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-4 me-1.5 text-red-500" />}
+					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-4 me-1.5 text-yellow-500" />}
+					{healthValue === ContainerHealth.None && <CircleMinusIcon className="size-4 me-1.5 text-zinc-500" />}
 					{healthStatus}
 				</Badge>
 			)

--- a/internal/site/src/components/containers-table/containers-table-columns.tsx
+++ b/internal/site/src/components/containers-table/containers-table-columns.tsx
@@ -4,6 +4,10 @@ import { cn, decimalString, formatBytes, hourWithSeconds } from "@/lib/utils"
 import type { ContainerRecord } from "@/types"
 import { ContainerHealth, ContainerHealthLabels } from "@/lib/enums"
 import {
+	CircleCheckIcon,
+	CircleDashedIcon,
+	CircleMinusIcon,
+	CircleXIcon,
 	ClockIcon,
 	ContainerIcon,
 	CpuIcon,
@@ -128,14 +132,10 @@ export const containerChartCols: ColumnDef<ContainerRecord>[] = [
 			const healthStatus = ContainerHealthLabels[healthValue] || "Unknown"
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					<span
-						className={cn("size-2 me-1.5 rounded-full", {
-							"bg-green-500": healthValue === ContainerHealth.Healthy,
-							"bg-red-500": healthValue === ContainerHealth.Unhealthy,
-							"bg-yellow-500": healthValue === ContainerHealth.Starting,
-							"bg-zinc-500": healthValue === ContainerHealth.None,
-						})}
-					></span>
+					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-3 me-1.5 text-green-500" />}
+					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-3 me-1.5 text-red-500" />}
+					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-3 me-1.5 text-yellow-500" />}
+					{healthValue === ContainerHealth.None && <CircleMinusIcon className="size-3 me-1.5 text-zinc-500" />}
 					{healthStatus}
 				</Badge>
 			)

--- a/internal/site/src/components/containers-table/containers-table-columns.tsx
+++ b/internal/site/src/components/containers-table/containers-table-columns.tsx
@@ -132,10 +132,10 @@ export const containerChartCols: ColumnDef<ContainerRecord>[] = [
 			const healthStatus = ContainerHealthLabels[healthValue] || "Unknown"
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon className="size-4 me-1.5 text-[#356144] dark:text-green-500" />}
-					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon className="size-4 me-1.5 text-[#913e42] dark:text-red-500" />}
-					{healthValue === ContainerHealth.Starting && <CircleDashedIcon className="size-4 me-1.5 text-[#976f00] dark:text-yellow-500" />}
-					{healthValue === ContainerHealth.None && <CircleMinusIcon className="size-4 me-1.5 text-zinc-500" />}
+					{healthValue === ContainerHealth.Healthy && <CircleCheckIcon aria-hidden="true" className="size-4 me-1.5 text-[#356144] dark:text-green-500" />}
+					{healthValue === ContainerHealth.Unhealthy && <CircleXIcon aria-hidden="true" className="size-4 me-1.5 text-[#913e42] dark:text-red-500" />}
+					{healthValue === ContainerHealth.Starting && <CircleDashedIcon aria-hidden="true" className="size-4 me-1.5 text-[#976f00] dark:text-yellow-500" />}
+					{healthValue === ContainerHealth.None && <CircleMinusIcon aria-hidden="true" className="size-4 me-1.5 text-zinc-500" />}
 					{healthStatus}
 				</Badge>
 			)

--- a/internal/site/src/components/routes/system/info-bar.tsx
+++ b/internal/site/src/components/routes/system/info-bar.tsx
@@ -31,7 +31,7 @@ import { FreeBsdIcon, TuxIcon, WebSocketIcon, WindowsIcon } from "@/components/u
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { ConnectionType, connectionTypeLabels, Os, SystemStatus } from "@/lib/enums"
-import { cn, formatBytes, getHostDisplayValue, secondsToUptimeString, toFixedFloat } from "@/lib/utils"
+import { formatBytes, getHostDisplayValue, secondsToUptimeString, toFixedFloat } from "@/lib/utils"
 import type { ChartData, SystemDetailsRecord, SystemRecord } from "@/types"
 
 export default function InfoBar({
@@ -152,17 +152,17 @@ export default function InfoBar({
 												className="animate-ping absolute inline-flex size-2 rounded-full bg-green-400 opacity-75"
 												style={{ animationDuration: "1.5s" }}
 											/>
-											<CircleCheckIcon className="relative size-4 text-green-500" />
+											<CircleCheckIcon className="relative size-4 text-[#356144] dark:text-green-500" />
 										</span>
 									)}
 									{system.status === SystemStatus.Down && (
-										<CircleXIcon className="size-4 text-red-500" />
+										<CircleXIcon className="size-4 text-[#913e42] dark:text-red-500" />
 									)}
 									{system.status === SystemStatus.Paused && (
 										<CirclePauseIcon className="size-4 text-primary/40" />
 									)}
 									{system.status === SystemStatus.Pending && (
-										<CircleDashedIcon className="size-4 text-yellow-500" />
+										<CircleDashedIcon className="size-4 text-[#976f00] dark:text-yellow-500" />
 									)}
 									{translatedStatus}
 								</div>

--- a/internal/site/src/components/routes/system/info-bar.tsx
+++ b/internal/site/src/components/routes/system/info-bar.tsx
@@ -152,17 +152,17 @@ export default function InfoBar({
 												className="animate-ping absolute inline-flex size-2 rounded-full bg-green-400 opacity-75"
 												style={{ animationDuration: "1.5s" }}
 											/>
-											<CircleCheckIcon className="relative size-4 text-[#356144] dark:text-green-500" />
+											<CircleCheckIcon aria-hidden="true" className="relative size-4 text-[#356144] dark:text-green-500" />
 										</span>
 									)}
 									{system.status === SystemStatus.Down && (
-										<CircleXIcon className="size-4 text-[#913e42] dark:text-red-500" />
+										<CircleXIcon aria-hidden="true" className="size-4 text-[#913e42] dark:text-red-500" />
 									)}
 									{system.status === SystemStatus.Paused && (
-										<CirclePauseIcon className="size-4 text-primary/40" />
+										<CirclePauseIcon aria-hidden="true" className="size-4 text-primary/40" />
 									)}
 									{system.status === SystemStatus.Pending && (
-										<CircleDashedIcon className="size-4 text-[#976f00] dark:text-yellow-500" />
+										<CircleDashedIcon aria-hidden="true" className="size-4 text-[#976f00] dark:text-yellow-500" />
 									)}
 									{translatedStatus}
 								</div>

--- a/internal/site/src/components/routes/system/info-bar.tsx
+++ b/internal/site/src/components/routes/system/info-bar.tsx
@@ -3,6 +3,10 @@ import { Trans, useLingui } from "@lingui/react/macro"
 import {
 	AppleIcon,
 	ChevronRightSquareIcon,
+	CircleCheckIcon,
+	CircleDashedIcon,
+	CirclePauseIcon,
+	CircleXIcon,
 	ClockArrowUp,
 	CpuIcon,
 	GlobeIcon,
@@ -142,22 +146,24 @@ export default function InfoBar({
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<div className="capitalize flex gap-2 items-center">
-									<span className={cn("relative flex h-3 w-3")}>
-										{system.status === SystemStatus.Up && (
+									{system.status === SystemStatus.Up && (
+										<span className="relative flex size-4 items-center justify-center">
 											<span
-												className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"
+												className="animate-ping absolute inline-flex size-2 rounded-full bg-green-400 opacity-75"
 												style={{ animationDuration: "1.5s" }}
-											></span>
-										)}
-										<span
-											className={cn("relative inline-flex rounded-full h-3 w-3", {
-												"bg-green-500": system.status === SystemStatus.Up,
-												"bg-red-500": system.status === SystemStatus.Down,
-												"bg-primary/40": system.status === SystemStatus.Paused,
-												"bg-yellow-500": system.status === SystemStatus.Pending,
-											})}
-										></span>
-									</span>
+											/>
+											<CircleCheckIcon className="relative size-4 text-green-500" />
+										</span>
+									)}
+									{system.status === SystemStatus.Down && (
+										<CircleXIcon className="size-4 text-red-500" />
+									)}
+									{system.status === SystemStatus.Paused && (
+										<CirclePauseIcon className="size-4 text-primary/40" />
+									)}
+									{system.status === SystemStatus.Pending && (
+										<CircleDashedIcon className="size-4 text-yellow-500" />
+									)}
 									{translatedStatus}
 								</div>
 							</TooltipTrigger>

--- a/internal/site/src/components/systemd-table/systemd-table-columns.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table-columns.tsx
@@ -24,13 +24,13 @@ import { t } from "@lingui/core/macro"
 export function getStatusIcon(status: ServiceStatus): [LucideIcon, string] {
 	switch (status) {
 		case ServiceStatus.Active:
-			return [CircleCheckIcon, "text-green-500"]
+			return [CircleCheckIcon, "text-[#356144] dark:text-green-500"]
 		case ServiceStatus.Failed:
-			return [CircleXIcon, "text-red-500"]
+			return [CircleXIcon, "text-[#913e42] dark:text-red-500"]
 		case ServiceStatus.Reloading:
 		case ServiceStatus.Activating:
 		case ServiceStatus.Deactivating:
-			return [CircleDashedIcon, "text-yellow-500"]
+			return [CircleDashedIcon, "text-[#976f00] dark:text-yellow-500"]
 		default:
 			return [CircleMinusIcon, "text-zinc-500"]
 	}
@@ -39,11 +39,11 @@ export function getStatusIcon(status: ServiceStatus): [LucideIcon, string] {
 function getSubStateIcon(subState: ServiceSubState): [LucideIcon, string] {
 	switch (subState) {
 		case ServiceSubState.Running:
-			return [CircleCheckIcon, "text-green-500"]
+			return [CircleCheckIcon, "text-[#356144] dark:text-green-500"]
 		case ServiceSubState.Failed:
-			return [CircleXIcon, "text-red-500"]
+			return [CircleXIcon, "text-[#913e42] dark:text-red-500"]
 		case ServiceSubState.Dead:
-			return [CircleDashedIcon, "text-yellow-500"]
+			return [CircleDashedIcon, "text-[#976f00] dark:text-yellow-500"]
 		default:
 			return [CircleMinusIcon, "text-zinc-500"]
 	}

--- a/internal/site/src/components/systemd-table/systemd-table-columns.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table-columns.tsx
@@ -85,7 +85,7 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 			const [StatusIcon, color] = getStatusIcon(statusValue)
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					<StatusIcon className={cn("size-3 me-1.5", color)} />
+					<StatusIcon className={cn("size-4 me-1.5", color)} />
 					{statusLabel}
 				</Badge>
 			)
@@ -101,7 +101,7 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 			const [SubStateIcon, color] = getSubStateIcon(subState)
 			return (
 				<Badge variant="outline" className="dark:border-white/12 text-xs capitalize">
-					<SubStateIcon className={cn("size-3 me-1.5", color)} />
+					<SubStateIcon className={cn("size-4 me-1.5", color)} />
 					{subStateLabel}
 				</Badge>
 			)

--- a/internal/site/src/components/systemd-table/systemd-table-columns.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table-columns.tsx
@@ -6,26 +6,46 @@ import { ServiceStatus, ServiceStatusLabels, ServiceSubState, ServiceSubStateLab
 import {
 	ActivityIcon,
 	ArrowUpDownIcon,
+	CircleCheckIcon,
+	CircleDashedIcon,
+	CircleMinusIcon,
+	CircleXIcon,
 	ClockIcon,
 	CpuIcon,
 	MemoryStickIcon,
 	TerminalSquareIcon,
 } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
 import { Badge } from "../ui/badge"
 import { t } from "@lingui/core/macro"
 // import { $allSystemsById } from "@/lib/stores"
 // import { useStore } from "@nanostores/react"
 
-function getSubStateColor(subState: ServiceSubState) {
+export function getStatusIcon(status: ServiceStatus): [LucideIcon, string] {
+	switch (status) {
+		case ServiceStatus.Active:
+			return [CircleCheckIcon, "text-green-500"]
+		case ServiceStatus.Failed:
+			return [CircleXIcon, "text-red-500"]
+		case ServiceStatus.Reloading:
+		case ServiceStatus.Activating:
+		case ServiceStatus.Deactivating:
+			return [CircleDashedIcon, "text-yellow-500"]
+		default:
+			return [CircleMinusIcon, "text-zinc-500"]
+	}
+}
+
+function getSubStateIcon(subState: ServiceSubState): [LucideIcon, string] {
 	switch (subState) {
 		case ServiceSubState.Running:
-			return "bg-green-500"
+			return [CircleCheckIcon, "text-green-500"]
 		case ServiceSubState.Failed:
-			return "bg-red-500"
+			return [CircleXIcon, "text-red-500"]
 		case ServiceSubState.Dead:
-			return "bg-yellow-500"
+			return [CircleDashedIcon, "text-yellow-500"]
 		default:
-			return "bg-zinc-500"
+			return [CircleMinusIcon, "text-zinc-500"]
 	}
 }
 
@@ -62,9 +82,10 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 		cell: ({ getValue }) => {
 			const statusValue = getValue() as ServiceStatus
 			const statusLabel = ServiceStatusLabels[statusValue] || "Unknown"
+			const [StatusIcon, color] = getStatusIcon(statusValue)
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					<span className={cn("size-2 me-1.5 rounded-full", getStatusColor(statusValue))} />
+					<StatusIcon className={cn("size-3 me-1.5", color)} />
 					{statusLabel}
 				</Badge>
 			)
@@ -77,9 +98,10 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 		cell: ({ getValue }) => {
 			const subState = getValue() as ServiceSubState
 			const subStateLabel = ServiceSubStateLabels[subState] || "Unknown"
+			const [SubStateIcon, color] = getSubStateIcon(subState)
 			return (
 				<Badge variant="outline" className="dark:border-white/12 text-xs capitalize">
-					<span className={cn("size-2 me-1.5 rounded-full", getSubStateColor(subState))} />
+					<SubStateIcon className={cn("size-3 me-1.5", color)} />
 					{subStateLabel}
 				</Badge>
 			)
@@ -184,17 +206,3 @@ function HeaderButton({ column, name, Icon }: { column: Column<SystemdRecord>; n
 	)
 }
 
-export function getStatusColor(status: ServiceStatus) {
-	switch (status) {
-		case ServiceStatus.Active:
-			return "bg-green-500"
-		case ServiceStatus.Failed:
-			return "bg-red-500"
-		case ServiceStatus.Reloading:
-		case ServiceStatus.Activating:
-		case ServiceStatus.Deactivating:
-			return "bg-yellow-500"
-		default:
-			return "bg-zinc-500"
-	}
-}

--- a/internal/site/src/components/systemd-table/systemd-table-columns.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table-columns.tsx
@@ -85,7 +85,7 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 			const [StatusIcon, color] = getStatusIcon(statusValue)
 			return (
 				<Badge variant="outline" className="dark:border-white/12">
-					<StatusIcon className={cn("size-4 me-1.5", color)} />
+					<StatusIcon aria-hidden="true" className={cn("size-4 me-1.5", color)} />
 					{statusLabel}
 				</Badge>
 			)
@@ -101,7 +101,7 @@ export const systemdTableCols: ColumnDef<SystemdRecord>[] = [
 			const [SubStateIcon, color] = getSubStateIcon(subState)
 			return (
 				<Badge variant="outline" className="dark:border-white/12 text-xs capitalize">
-					<SubStateIcon className={cn("size-4 me-1.5", color)} />
+					<SubStateIcon aria-hidden="true" className={cn("size-4 me-1.5", color)} />
 					{subStateLabel}
 				</Badge>
 			)

--- a/internal/site/src/components/systemd-table/systemd-table.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table.tsx
@@ -16,7 +16,7 @@ import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual"
 import { LoaderCircleIcon } from "lucide-react"
 import { listenKeys } from "nanostores"
 import { memo, type ReactNode, useEffect, useMemo, useRef, useState } from "react"
-import { getStatusColor, systemdTableCols } from "@/components/systemd-table/systemd-table-columns"
+import { getStatusIcon, systemdTableCols } from "@/components/systemd-table/systemd-table-columns"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Card, CardHeader, CardTitle } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
@@ -391,9 +391,10 @@ function SystemdSheet({
 			}
 		}
 
+		const [StatusIcon, color] = getStatusIcon(service.state)
 		return (
 			<div className="flex items-center gap-2">
-				<div className={cn("w-2 h-2 rounded-full flex-shrink-0", getStatusColor(service.state))} />
+				<StatusIcon className={cn("size-3 flex-shrink-0", color)} />
 				{stateText}
 			</div>
 		)

--- a/internal/site/src/components/systemd-table/systemd-table.tsx
+++ b/internal/site/src/components/systemd-table/systemd-table.tsx
@@ -394,7 +394,7 @@ function SystemdSheet({
 		const [StatusIcon, color] = getStatusIcon(service.state)
 		return (
 			<div className="flex items-center gap-2">
-				<StatusIcon className={cn("size-3 flex-shrink-0", color)} />
+				<StatusIcon className={cn("size-4 flex-shrink-0", color)} />
 				{stateText}
 			</div>
 		)

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -244,16 +244,16 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 				return (
 					<div className="flex items-center gap-[.35em] w-full tabular-nums tracking-tight">
 						{status === SystemStatus.Up && threshold === MeterState.Good && (
-							<CircleCheckIcon className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
+							<CircleCheckIcon aria-hidden="true" className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
 						)}
 						{status === SystemStatus.Up && threshold === MeterState.Warn && (
-							<TriangleAlertIcon className="size-4 shrink-0 text-[#976f00] dark:text-yellow-500" />
+							<TriangleAlertIcon aria-hidden="true" className="size-4 shrink-0 text-[#976f00] dark:text-yellow-500" />
 						)}
 						{status === SystemStatus.Up && threshold === MeterState.Crit && (
-							<OctagonXIcon className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
+							<OctagonXIcon aria-hidden="true" className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
 						)}
 						{status !== SystemStatus.Up && (
-							<CircleDashedIcon className="size-4 shrink-0 text-primary/40" />
+							<CircleDashedIcon aria-hidden="true" className="size-4 shrink-0 text-primary/40" />
 						)}
 						{loadAverages?.map((la, i) => (
 							<span key={i}>{decimalString(la, la >= 10 ? 1 : 2)}</span>
@@ -378,9 +378,9 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 				return (
 					<span className="tabular-nums whitespace-nowrap flex gap-1.5 items-center">
 						{numFailed > 0 ? (
-							<CircleXIcon className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
+							<CircleXIcon aria-hidden="true" className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
 						) : (
-							<CircleCheckIcon className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
+							<CircleCheckIcon aria-hidden="true" className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
 						)}
 						{totalCount}{" "}
 						<span className="text-muted-foreground text-sm -ms-0.5">
@@ -498,10 +498,10 @@ function TableCellWithMeter(info: CellContext<SystemRecord, unknown>) {
 			<span className="flex items-center gap-0.5 shrink-0">
 				<span className="size-3 flex items-center justify-center">
 					{status === SystemStatus.Up && threshold === MeterState.Warn && (
-						<TriangleAlertIcon className="size-3 text-[#976f00] dark:text-yellow-500" />
+						<TriangleAlertIcon aria-hidden="true" className="size-3 text-[#976f00] dark:text-yellow-500" />
 					)}
 					{status === SystemStatus.Up && threshold === MeterState.Crit && (
-						<OctagonXIcon className="size-3 text-[#913e42] dark:text-red-500" />
+						<OctagonXIcon aria-hidden="true" className="size-3 text-[#913e42] dark:text-red-500" />
 					)}
 				</span>
 				<span className="min-w-8">{decimalString(val, val >= 10 ? 1 : 2)}%</span>
@@ -557,10 +557,10 @@ function DiskCellWithMultiple(info: CellContext<SystemRecord, unknown>) {
 						<span className="flex items-center gap-0.5 shrink-0">
 							<span className="size-3 flex items-center justify-center">
 								{status === SystemStatus.Up && getMeterStateByThresholds(rootDiskPct, colorWarn, colorCrit) === MeterState.Warn && (
-									<TriangleAlertIcon className="size-3 text-[#976f00] dark:text-yellow-500" />
+									<TriangleAlertIcon aria-hidden="true" className="size-3 text-[#976f00] dark:text-yellow-500" />
 								)}
 								{status === SystemStatus.Up && getMeterStateByThresholds(rootDiskPct, colorWarn, colorCrit) === MeterState.Crit && (
-									<OctagonXIcon className="size-3 text-[#913e42] dark:text-red-500" />
+									<OctagonXIcon aria-hidden="true" className="size-3 text-[#913e42] dark:text-red-500" />
 								)}
 							</span>
 							<span className="min-w-8">{decimalString(rootDiskPct, rootDiskPct >= 10 ? 1 : 2)}%</span>
@@ -620,6 +620,7 @@ export function IndicatorDot({ system, className }: { system: SystemRecord; clas
 	const Icon = STATUS_ICONS[system.status as keyof typeof STATUS_ICONS] ?? CircleDashedIcon
 	return (
 		<Icon
+			aria-hidden="true"
 			className={cn(
 				"shrink-0 size-4",
 				STATUS_ICON_COLORS[system.status as keyof typeof STATUS_ICON_COLORS],

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -92,10 +92,10 @@ const STATUS_ICONS = {
 } as const
 
 const STATUS_ICON_COLORS = {
-	[SystemStatus.Up]: "text-green-500",
-	[SystemStatus.Down]: "text-red-500",
+	[SystemStatus.Up]: "text-[#356144] dark:text-green-500",
+	[SystemStatus.Down]: "text-[#913e42] dark:text-red-500",
 	[SystemStatus.Paused]: "text-primary/40",
-	[SystemStatus.Pending]: "text-yellow-500",
+	[SystemStatus.Pending]: "text-[#976f00] dark:text-yellow-500",
 } as const
 
 function getMeterStateByThresholds(value: number, warn = 65, crit = 90): MeterState {

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -595,7 +595,7 @@ export function IndicatorDot({ system, className }: { system: SystemRecord; clas
 	return (
 		<Icon
 			className={cn(
-				"shrink-0 size-3",
+				"shrink-0 size-4",
 				STATUS_ICON_COLORS[system.status as keyof typeof STATUS_ICON_COLORS],
 				className
 			)}

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -13,6 +13,8 @@ import {
 	CirclePauseIcon,
 	CircleXIcon,
 	ClockArrowUp,
+	OctagonXIcon,
+	TriangleAlertIcon,
 	CopyIcon,
 	CpuIcon,
 	HardDriveIcon,
@@ -241,14 +243,18 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 
 				return (
 					<div className="flex items-center gap-[.35em] w-full tabular-nums tracking-tight">
-						<span
-							className={cn("inline-block size-2 rounded-full me-0.5", {
-								[STATUS_COLORS[SystemStatus.Up]]: threshold === MeterState.Good,
-								[STATUS_COLORS[SystemStatus.Pending]]: threshold === MeterState.Warn,
-								[STATUS_COLORS[SystemStatus.Down]]: threshold === MeterState.Crit,
-								[STATUS_COLORS[SystemStatus.Paused]]: status !== SystemStatus.Up,
-							})}
-						/>
+						{status === SystemStatus.Up && threshold === MeterState.Good && (
+							<CircleCheckIcon className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
+						)}
+						{status === SystemStatus.Up && threshold === MeterState.Warn && (
+							<TriangleAlertIcon className="size-4 shrink-0 text-[#976f00] dark:text-yellow-500" />
+						)}
+						{status === SystemStatus.Up && threshold === MeterState.Crit && (
+							<OctagonXIcon className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
+						)}
+						{status !== SystemStatus.Up && (
+							<CircleDashedIcon className="size-4 shrink-0 text-primary/40" />
+						)}
 						{loadAverages?.map((la, i) => (
 							<span key={i}>{decimalString(la, la >= 10 ? 1 : 2)}</span>
 						))}
@@ -371,12 +377,11 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 				}
 				return (
 					<span className="tabular-nums whitespace-nowrap flex gap-1.5 items-center">
-						<span
-							className={cn("block size-2 rounded-full", {
-								[STATUS_COLORS[SystemStatus.Down]]: numFailed > 0,
-								[STATUS_COLORS[SystemStatus.Up]]: numFailed === 0,
-							})}
-						/>
+						{numFailed > 0 ? (
+							<CircleXIcon className="size-4 shrink-0 text-[#913e42] dark:text-red-500" />
+						) : (
+							<CircleCheckIcon className="size-4 shrink-0 text-[#356144] dark:text-green-500" />
+						)}
 						{totalCount}{" "}
 						<span className="text-muted-foreground text-sm -ms-0.5">
 							({t`Failed`.toLowerCase()}: {numFailed})
@@ -416,9 +421,9 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 				}
 				const system = info.row.original
 				const color = {
-					"text-green-500": version === globalThis.BESZEL.HUB_VERSION,
-					"text-yellow-500": version !== globalThis.BESZEL.HUB_VERSION,
-					"text-red-500": system.status !== SystemStatus.Up,
+					"text-[#356144] dark:text-green-500": version === globalThis.BESZEL.HUB_VERSION,
+					"text-[#976f00] dark:text-yellow-500": version !== globalThis.BESZEL.HUB_VERSION,
+					"text-[#913e42] dark:text-red-500": system.status !== SystemStatus.Up,
 				}
 				return (
 					<Link
@@ -432,10 +437,10 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 						role="none"
 					>
 						{system.info.ct === ConnectionType.WebSocket && (
-							<WebSocketIcon className={cn("size-3 pointer-events-none", color)} />
+							<WebSocketIcon className={cn("size-4 pointer-events-none", color)} />
 						)}
 						{system.info.ct === ConnectionType.SSH && (
-							<ChevronRightSquareIcon className={cn("size-3 pointer-events-none", color)} />
+							<ChevronRightSquareIcon className={cn("size-4 pointer-events-none", color)} />
 						)}
 						{!system.info.ct && <IndicatorDot system={system} className={cn(color, "mx-0.5")} />}
 						<span className="truncate max-w-14">{info.getValue() as string}</span>
@@ -487,9 +492,20 @@ function TableCellWithMeter(info: CellContext<SystemRecord, unknown>) {
 			(threshold === MeterState.Warn && STATUS_COLORS.pending) ||
 			STATUS_COLORS.down
 	)
+	const status = info.row.original.status
 	return (
 		<div className="flex gap-2 items-center tabular-nums tracking-tight w-full">
-			<span className="min-w-8 shrink-0">{decimalString(val, val >= 10 ? 1 : 2)}%</span>
+			<span className="flex items-center gap-0.5 shrink-0">
+				<span className="size-3 flex items-center justify-center">
+					{status === SystemStatus.Up && threshold === MeterState.Warn && (
+						<TriangleAlertIcon className="size-3 text-[#976f00] dark:text-yellow-500" />
+					)}
+					{status === SystemStatus.Up && threshold === MeterState.Crit && (
+						<OctagonXIcon className="size-3 text-[#913e42] dark:text-red-500" />
+					)}
+				</span>
+				<span className="min-w-8">{decimalString(val, val >= 10 ? 1 : 2)}%</span>
+			</span>
 			<span className="flex-1 min-w-8 grid bg-muted h-[1em] rounded-sm overflow-hidden">
 				<span className={meterClass} style={{ width: `${val}%` }}></span>
 			</span>
@@ -538,7 +554,17 @@ function DiskCellWithMultiple(info: CellContext<SystemRecord, unknown>) {
 					className="flex flex-col gap-0.5 w-full relative z-10"
 				>
 					<div className="flex gap-2 items-center tabular-nums tracking-tight">
-						<span className="min-w-8 shrink-0">{decimalString(rootDiskPct, rootDiskPct >= 10 ? 1 : 2)}%</span>
+						<span className="flex items-center gap-0.5 shrink-0">
+							<span className="size-3 flex items-center justify-center">
+								{status === SystemStatus.Up && getMeterStateByThresholds(rootDiskPct, colorWarn, colorCrit) === MeterState.Warn && (
+									<TriangleAlertIcon className="size-3 text-[#976f00] dark:text-yellow-500" />
+								)}
+								{status === SystemStatus.Up && getMeterStateByThresholds(rootDiskPct, colorWarn, colorCrit) === MeterState.Crit && (
+									<OctagonXIcon className="size-3 text-[#913e42] dark:text-red-500" />
+								)}
+							</span>
+							<span className="min-w-8">{decimalString(rootDiskPct, rootDiskPct >= 10 ? 1 : 2)}%</span>
+						</span>
 						<span className="flex-1 min-w-8 flex items-center gap-0.5 px-1 justify-end bg-muted h-[1em] rounded-sm overflow-hidden relative">
 							{/* Root disk */}
 							<span

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -8,6 +8,10 @@ import type { ClassValue } from "clsx"
 import {
 	ArrowUpDownIcon,
 	ChevronRightSquareIcon,
+	CircleCheckIcon,
+	CircleDashedIcon,
+	CirclePauseIcon,
+	CircleXIcon,
 	ClockArrowUp,
 	CopyIcon,
 	CpuIcon,
@@ -78,6 +82,20 @@ const STATUS_COLORS = {
 	[SystemStatus.Down]: "bg-red-500",
 	[SystemStatus.Paused]: "bg-primary/40",
 	[SystemStatus.Pending]: "bg-yellow-500",
+} as const
+
+const STATUS_ICONS = {
+	[SystemStatus.Up]: CircleCheckIcon,
+	[SystemStatus.Down]: CircleXIcon,
+	[SystemStatus.Paused]: CirclePauseIcon,
+	[SystemStatus.Pending]: CircleDashedIcon,
+} as const
+
+const STATUS_ICON_COLORS = {
+	[SystemStatus.Up]: "text-green-500",
+	[SystemStatus.Down]: "text-red-500",
+	[SystemStatus.Paused]: "text-primary/40",
+	[SystemStatus.Pending]: "text-yellow-500",
 } as const
 
 function getMeterStateByThresholds(value: number, warn = 65, crit = 90): MeterState {
@@ -419,7 +437,7 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 						{system.info.ct === ConnectionType.SSH && (
 							<ChevronRightSquareIcon className={cn("size-3 pointer-events-none", color)} />
 						)}
-						{!system.info.ct && <IndicatorDot system={system} className={cn(color, "bg-current mx-0.5")} />}
+						{!system.info.ct && <IndicatorDot system={system} className={cn(color, "mx-0.5")} />}
 						<span className="truncate max-w-14">{info.getValue() as string}</span>
 					</Link>
 				)
@@ -573,11 +591,14 @@ function DiskCellWithMultiple(info: CellContext<SystemRecord, unknown>) {
 }
 
 export function IndicatorDot({ system, className }: { system: SystemRecord; className?: ClassValue }) {
-	className ||= STATUS_COLORS[system.status as keyof typeof STATUS_COLORS] || ""
+	const Icon = STATUS_ICONS[system.status as keyof typeof STATUS_ICONS] ?? CircleDashedIcon
 	return (
-		<span
-			className={cn("shrink-0 size-2 rounded-full", className)}
-			// style={{ marginBottom: "-1px" }}
+		<Icon
+			className={cn(
+				"shrink-0 size-3",
+				STATUS_ICON_COLORS[system.status as keyof typeof STATUS_ICON_COLORS],
+				className
+			)}
 		/>
 	)
 }


### PR DESCRIPTION
## 📃 Description

Replaces color-only dot indicators with meaningful icons across all status and health badges, addressing **WCAG 2.2 SC 1.4.1 (Use of Color)**. Previously, system/container/service status was communicated solely through colored dots, making it inaccessible to color-blind users. Each status now has a distinct icon shape as a second visual channel, independent of color. All icons are marked `aria-hidden="true"` since adjacent text labels already convey the status to screen readers. Light-mode colors have also been adjusted to meet non-text contrast requirements (SC 1.4.11).

Closes #2021
Closes https://github.com/henrygd/beszel/issues/1715


## 🪵 Changelog

### ✏️ Changed

- **Systems table & grid** — status dot replaced with shaped icons: `CircleCheckIcon` (up), `CircleXIcon` (down), `CirclePauseIcon` (paused), `CircleDashedIcon` (pending)
- **System detail info bar** — same icon set for the inline status indicator; the animated ping on "Up" is now layered behind the check icon
- **Containers table** — health dot replaced with `CircleCheckIcon` (healthy), `CircleXIcon` (unhealthy), `CircleDashedIcon` (starting), `CircleMinusIcon` (none)
- **Services (systemd) table** — state and sub-state badges replaced with icons via new `getStatusIcon` / `getSubStateIcon` helpers (exported for reuse)
- **Meter cells** (CPU, memory, disk, load average) — threshold state icons added: `CircleCheckIcon` (good), `TriangleAlertIcon` (warn), `OctagonXIcon` (crit), `CircleDashedIcon` (system not up)
- **Light-mode status colors** updated from default Tailwind green/red/yellow to darker hex values (`#356144`, `#913e42`, `#976f00`) to meet WCAG SC 1.4.11 non-text contrast ratio on white backgrounds
- All status icons sized up from `size-2` (8 px) to `size-4` (16 px) for improved legibility
- All decorative status icons marked `aria-hidden="true"` to avoid redundant screen reader announcements

## 📷 Screenshots
<img width="1621" height="79" alt="Scherm­afbeelding 2026-05-19 om 19 17 11" src="https://github.com/user-attachments/assets/5f795de7-4256-4101-8a3f-ad48f3c5ef95" />

<img width="1642" height="94" alt="image" src="https://github.com/user-attachments/assets/3be90769-7c61-4ae6-8d70-f1b9d4a42924" />