### PR TITLE
fix(agent): skip disk.Partitions on Windows (prevents startup hang + CPU spin on unresponsive USB disks)

### DIFF
--- a/agent/disk.go
+++ b/agent/disk.go
@@ -304,7 +304,15 @@ func (a *Agent) initializeDiskInfo() {
 	hasRoot := false
 	isWindows := runtime.GOOS == "windows"
 
-	partitions, err := disk.PartitionsWithContext(context.Background(), true)
+	var partitions []disk.PartitionStat
+	var err error
+	// On Windows, disk.Partitions busy-loops and pins a CPU core forever on an
+	// unresponsive or spun-down external/USB volume (both all=true and all=false),
+	// hanging agent startup. Skip it there and rely on the I/O-counter + root
+	// device fallback below for root disk usage.
+	if !isWindows {
+		partitions, err = disk.PartitionsWithContext(context.Background(), true)
+	}
 	if err != nil {
 		slog.Error("Error getting disk partitions", "err", err)
 	}


### PR DESCRIPTION
## Problem

On Windows the agent can hang at startup and never connect to the hub. The log stops right after system-info init:

```
INFO Data directory path=...
DEBUG <version>
DEBUG Not monitoring ZFS ARC ...
```

…and never reaches `Detected network interface` or the hub connection. The process stays alive (pinning a CPU core — see below) and the system shows as **down** in the hub.

## Root cause

`initializeDiskInfo()` in `agent/disk.go` calls:

```go
partitions, err := disk.PartitionsWithContext(context.Background(), true)
```

On Windows, when an external/USB volume is **unresponsive or spun down**, gopsutil **busy-loops inside this call, pinning a full CPU core, and never returns**. Verified on the affected machine with **both `all=true` and `all=false`** — same hang and same ~100% single-core CPU.

> Note: I first tried wrapping the call in a goroutine + `select` timeout. That lets startup proceed, but it does **not** fix the problem: the abandoned goroutine keeps spinning at ~100% CPU forever, because the underlying call never returns and a goroutine cannot be cancelled. So a timeout wrapper trades a hang for a permanent CPU drain.

This is environment-specific (needs a slow/unresponsive disk), which is why most Windows machines are fine — but on machines with idle USB/external drives the agent is unusable.

## Fix

Skip partition discovery on Windows and rely on the existing I/O-counter + most-active-root-device fallback (already in `initializeDiskInfo`) for root disk usage.

```go
var partitions []disk.PartitionStat
var err error
if !isWindows {
    partitions, err = disk.PartitionsWithContext(context.Background(), true)
}
```

**Trade-off:** per-partition usage is not reported on Windows; root (C:) disk usage still works via the existing fallback. The agent starts, connects, and idles at ~0% CPU.

## Reproduction

- Windows host with an external USB HDD that is spun down / has no mounted volume.
- Start agent → logs data dir + version + "Not monitoring ZFS ARC", then hangs at ~100% of one core; system stays `down`.
- Confirmed on agent 0.17.0 and 0.18.7, WebSocket and SSH modes, run directly / scheduled task / service. WMI, performance counters, CPU, network, SMART all respond fast — only `disk.Partitions` blocks+spins.

## Testing

Built `GOOS=windows GOARCH=amd64` on the affected machine (Intel i5-1135G7, two external WD USB drives — 4TB My Book + 20TB Elements).

| | Before | After (this fix) |
|---|---|---|
| Startup | hangs | completes |
| Hub status | `down` | `up` |
| Agent CPU | ~100% of one core | ~0% |
| Root disk usage | n/a | reported (C:) |

`gofmt` clean; builds for `windows/amd64`.

## Notes

This is intentionally pragmatic — it prioritizes "the agent always starts and stays cheap" over Windows multi-partition usage. If you'd prefer a different direction (a vetted gopsutil-level fix, or a non-blocking Windows partition enumeration), I'm glad to adjust. Mainly wanted to surface the root cause and a verified working fix.
