### PR TITLE
fix(ui): prevent usage bars from overflowing card border in grid view

### DIFF
--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -470,7 +470,7 @@ function TableCellWithMeter(info: CellContext<SystemRecord, unknown>) {
 			STATUS_COLORS.down
 	)
 	return (
-		<div className="flex gap-2 items-center tabular-nums tracking-tight w-full">
+		<div className="flex gap-2 items-center tabular-nums tracking-tight w-full min-w-0">
 			<span className="min-w-8 shrink-0">{decimalString(val, val >= 10 ? 1 : 2)}%</span>
 			<span className="flex-1 min-w-8 grid bg-muted h-[1em] rounded-sm overflow-hidden">
 				<span className={meterClass} style={{ width: `${val}%` }}></span>

--- a/internal/site/src/components/systems-table/systems-table.tsx
+++ b/internal/site/src/components/systems-table/systems-table.tsx
@@ -477,7 +477,7 @@ const SystemCard = memo(
 						</div>
 					</CardHeader>
 					<CardContent className="text-sm px-5 pt-3.5 pb-4">
-						<div className="grid gap-2.5" style={{ gridTemplateColumns: "24px minmax(80px, max-content) 1fr" }}>
+						<div className="grid gap-2.5" style={{ gridTemplateColumns: "24px minmax(80px, max-content) minmax(0, 1fr)" }}>
 							{table.getAllColumns().map((column) => {
 								if (!column.getIsVisible() || column.id === "system" || column.id === "actions") return null
 								const cell = row.getAllCells().find((cell) => cell.column.id === column.id)
@@ -496,7 +496,7 @@ const SystemCard = memo(
 										<div key={`${column.id}-label`} className="flex items-center text-muted-foreground pr-3">
 											{name()}:
 										</div>
-										<div key={`${column.id}-value`} className="flex items-center">
+										<div key={`${column.id}-value`} className="flex items-center min-w-0">
 											{flexRender(cell.column.columnDef.cell, cell.getContext())}
 										</div>
 									</>


### PR DESCRIPTION
## 📃 Description

Fixes usage bars overflowing the card border in the grid view at narrow window widths. The `SystemCard` grid used `1fr` (equivalent to `minmax(auto, 1fr)`), which prevented the value column from shrinking below its content's minimum size. Combined with missing `min-w-0` on the value cell wrapper and `TableCellWithMeter`'s flex container, this caused the card content to visually overflow the card border when cards became narrow (e.g. just past the `sm` breakpoint where the grid switches from 1 to 2 columns).

fixes #2062 

## 🪵 Changelog

### 🔧 Fixed

- Usage bars extending past the agent card border in grid view at narrow window widths 
