### PR TITLE
fix(agent): prevent a malformed Docker response from permanently breaking container stats

### DIFF
--- a/agent/docker.go
+++ b/agent/docker.go
@@ -65,7 +65,6 @@ type dockerManager struct {
 	dockerVersionChecked bool                        // Whether a version probe has completed successfully
 	isWindows            bool                        // Whether the Docker Engine API is running on Windows
 	buf                  *bytes.Buffer               // Buffer to store and read response bodies
-	decoder              *json.Decoder               // Reusable JSON decoder that reads from buf
 	apiStats             *container.ApiStats         // Reusable API stats object
 	excludeContainers    []string                    // Patterns to exclude containers by name
 	usingPodman          bool                        // Whether the Docker Engine API is running on Podman
@@ -747,20 +746,18 @@ func (dm *dockerManager) applyDockerVersionInfo(serverHeader string, versionInfo
 	}
 }
 
-// Decodes Docker API JSON response using a reusable buffer and decoder. Not thread safe.
+// Decodes a Docker API JSON response using a reusable buffer. Not thread safe.
 func (dm *dockerManager) decode(resp *http.Response, d any) error {
 	if dm.buf == nil {
 		// initialize buffer with 256kb starting size
 		dm.buf = bytes.NewBuffer(make([]byte, 0, 1024*256))
-		dm.decoder = json.NewDecoder(dm.buf)
 	}
 	defer resp.Body.Close()
 	defer dm.buf.Reset()
-	_, err := dm.buf.ReadFrom(resp.Body)
-	if err != nil {
+	if _, err := dm.buf.ReadFrom(resp.Body); err != nil {
 		return err
 	}
-	return dm.decoder.Decode(d)
+	return json.Unmarshal(dm.buf.Bytes(), d)
 }
 
 // Test docker / podman sockets and return if one exists

--- a/agent/docker_test.go
+++ b/agent/docker_test.go
@@ -804,6 +804,24 @@ func TestGetDockerStatsRetriesVersionCheckUntilSuccess(t *testing.T) {
 	assert.Equal(t, 2, requestCounts["/version"])
 }
 
+// A failed decode must not break later decodes. Previously the reused json.Decoder
+// stayed desynced after one truncated response, breaking decode until restart.
+func TestDecodeRecoversFromError(t *testing.T) {
+	dm := &dockerManager{}
+
+	// truncated JSON: body reads fine, decode fails
+	var bad []container.ApiInfo
+	err := dm.decode(&http.Response{Body: io.NopCloser(strings.NewReader(`[{"Id":"abc`))}, &bad)
+	require.Error(t, err)
+
+	// the next decode must still succeed
+	var good []container.ApiInfo
+	err = dm.decode(&http.Response{Body: io.NopCloser(strings.NewReader(`[{"Id":"abcdef012345","Names":["/ok"]}]`))}, &good)
+	require.NoError(t, err)
+	require.Len(t, good, 1)
+	assert.Equal(t, "abcdef012345", good[0].Id)
+}
+
 func TestCycleCpuDeltas(t *testing.T) {
 	dm := &dockerManager{
 		lastCpuContainer: map[uint16]map[string]uint64{


### PR DESCRIPTION
## 📃 Description

Fixes a bug where an agent's container stats stop showing in the hub and don't recover until the agent restarts. System stats keep working, so the agent looks healthy.

`dockerManager.decode()` reuses a single `json.Decoder` across all responses. If one response is truncated or malformed (e.g. a container removed mid-request, easy to hit during a redeploy), the decoder is left desynced and never recovers. Every later decode then fails, including the container list, so stats silently stop.

This was a regression from d67d638, which switched from a fresh `json.NewDecoder(...).Decode()` per call to a shared decoder.

The fix decodes the buffered bytes with `json.Unmarshal` instead. This keeps the reusable read buffer but holds no state between calls, so one bad response can't break later ones.

## 🪵 Changelog

### ➕ Added

- `TestDecodeRecoversFromError`, a regression test that fails on the current code and passes with the fix.

### ✏️ Changed

- `dockerManager.decode()` now uses `json.Unmarshal` over the reusable buffer instead of a shared `json.Decoder`.

### 🔧 Fixed

- Container stats no longer stop permanently after a single malformed or truncated Docker/Podman API response.

### 🗑️ Removed

- Unused reusable `json.Decoder` field on `dockerManager`.
