### PR TITLE
fix(agent): don't warn on mdraid consistency checks

### DIFF
--- a/agent/mdraid_linux.go
+++ b/agent/mdraid_linux.go
@@ -180,8 +180,11 @@ func mdraidSmartStatus(health mdraidHealth) string {
 	if health.degraded > 0 {
 		return "FAILED"
 	}
-	// "check" is a read-only consistency check. If the array is otherwise
-	// healthy, keep it green while still reporting the sync progress attributes.
+	if health.mismatchCnt > 0 {
+		return "WARNING"
+	}
+	// "check" scans for consistency problems without repairing mismatches.
+	// With no mismatches, keep it green while reporting progress attributes.
 	switch syncAction {
 	case "repair":
 		return "WARNING"

--- a/agent/mdraid_linux.go
+++ b/agent/mdraid_linux.go
@@ -180,8 +180,10 @@ func mdraidSmartStatus(health mdraidHealth) string {
 	if health.degraded > 0 {
 		return "FAILED"
 	}
+	// "check" is a read-only consistency check. If the array is otherwise
+	// healthy, keep it green while still reporting the sync progress attributes.
 	switch syncAction {
-	case "check", "repair":
+	case "repair":
 		return "WARNING"
 	}
 	switch state {

--- a/agent/mdraid_linux_test.go
+++ b/agent/mdraid_linux_test.go
@@ -97,6 +97,12 @@ func TestMdraidSmartStatus(t *testing.T) {
 	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", syncAction: "check"}); got != "PASSED" {
 		t.Fatalf("mdraidSmartStatus(clean+check) = %q, want PASSED", got)
 	}
+	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", syncAction: "check", mismatchCnt: 1}); got != "WARNING" {
+		t.Fatalf("mdraidSmartStatus(clean+check+mismatch) = %q, want WARNING", got)
+	}
+	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", mismatchCnt: 1}); got != "WARNING" {
+		t.Fatalf("mdraidSmartStatus(clean+mismatch) = %q, want WARNING", got)
+	}
 	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", syncAction: "repair"}); got != "WARNING" {
 		t.Fatalf("mdraidSmartStatus(repair) = %q, want WARNING", got)
 	}

--- a/agent/mdraid_linux_test.go
+++ b/agent/mdraid_linux_test.go
@@ -94,6 +94,12 @@ func TestMdraidSmartStatus(t *testing.T) {
 	if got := mdraidSmartStatus(mdraidHealth{arrayState: "active", syncAction: "recover"}); got != "WARNING" {
 		t.Fatalf("mdraidSmartStatus(recover) = %q, want WARNING", got)
 	}
+	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", syncAction: "check"}); got != "PASSED" {
+		t.Fatalf("mdraidSmartStatus(clean+check) = %q, want PASSED", got)
+	}
+	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean", syncAction: "repair"}); got != "WARNING" {
+		t.Fatalf("mdraidSmartStatus(repair) = %q, want WARNING", got)
+	}
 	if got := mdraidSmartStatus(mdraidHealth{arrayState: "clean"}); got != "PASSED" {
 		t.Fatalf("mdraidSmartStatus(clean) = %q, want PASSED", got)
 	}


### PR DESCRIPTION
## Summary
- Treat healthy Linux mdraid `sync_action=check` as `PASSED` instead of `WARNING`.
- Keep `repair`, rebuild/recovery, and degraded arrays warning/failing as before.
- Add coverage for healthy `check` and `repair` status mapping.

closes #1974

## Tests
- `go test ./agent ./internal/cmd/agent`
- `go test ./...` fails locally because `internal/site/embed.go` expects generated `dist` assets that are not present in this checkout.