### PR TITLE
Handle WebSocket redirects in `beszel-agent`

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -24,7 +24,9 @@ import (
 )
 
 const (
-	wsDeadline = 70 * time.Second
+	wsDeadline        = 70 * time.Second
+	maxWSRedirects    = 5
+	agentConnectRoute = "api/beszel/agent-connect"
 )
 
 // WebSocketClient manages the WebSocket connection between the agent and hub.
@@ -97,13 +99,9 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 		return client.options
 	}
 
-	// update the hub url to use websocket scheme and api path
-	if client.hubURL.Scheme == "https" {
-		client.hubURL.Scheme = "wss"
-	} else {
-		client.hubURL.Scheme = "ws"
-	}
-	client.hubURL.Path = path.Join(client.hubURL.Path, "api/beszel/agent-connect")
+	hubURL := *client.hubURL
+	hubURL.Path = path.Join(hubURL.Path, agentConnectRoute)
+	updateURLToWebSocketScheme(&hubURL)
 
 	// make sure BESZEL_AGENT_ALL_PROXY works (GWS only checks ALL_PROXY)
 	if val := os.Getenv("BESZEL_AGENT_ALL_PROXY"); val != "" {
@@ -111,7 +109,7 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 	}
 
 	client.options = &gws.ClientOption{
-		Addr:      client.hubURL.String(),
+		Addr:      hubURL.String(),
 		TlsConfig: &tls.Config{InsecureSkipVerify: true},
 		RequestHeader: http.Header{
 			"User-Agent": []string{getUserAgent()},
@@ -133,14 +131,80 @@ func (client *WebSocketClient) Connect() (err error) {
 	// make sure previous connection is closed
 	client.Close()
 
-	client.Conn, _, err = gws.NewClient(client, client.getOptions())
-	if err != nil {
-		return err
+	options := client.getOptions()
+	for redirectCount := 0; ; redirectCount++ {
+		var resp *http.Response
+		client.Conn, resp, err = gws.NewClient(client, options)
+		if err == nil {
+			break
+		}
+
+		nextAddr, redirected, redirectErr := resolveWebSocketRedirect(options.Addr, resp)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if redirectErr != nil {
+			return fmt.Errorf("%w: %v", err, redirectErr)
+		}
+		if !redirected {
+			return err
+		}
+		if redirectCount >= maxWSRedirects {
+			return fmt.Errorf("%w: stopped after %d websocket redirects", err, maxWSRedirects)
+		}
+
+		slog.Info("Following WebSocket redirect", "from", options.Addr, "to", nextAddr)
+		options.Addr = nextAddr
 	}
 
 	go client.Conn.ReadLoop()
 
 	return nil
+}
+
+func resolveWebSocketRedirect(currentAddr string, resp *http.Response) (string, bool, error) {
+	if resp == nil || !isHTTPRedirect(resp.StatusCode) {
+		return "", false, nil
+	}
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", false, fmt.Errorf("websocket redirect status %d missing Location header", resp.StatusCode)
+	}
+
+	baseURL, err := url.Parse(currentAddr)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid current websocket URL: %w", err)
+	}
+
+	redirectURL, err := baseURL.Parse(location)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid websocket redirect URL %q: %w", location, err)
+	}
+	updateURLToWebSocketScheme(redirectURL)
+	return redirectURL.String(), true, nil
+}
+
+func isHTTPRedirect(statusCode int) bool {
+	switch statusCode {
+	case http.StatusMovedPermanently,
+		http.StatusFound,
+		http.StatusSeeOther,
+		http.StatusTemporaryRedirect,
+		http.StatusPermanentRedirect:
+		return true
+	default:
+		return false
+	}
+}
+
+func updateURLToWebSocketScheme(u *url.URL) {
+	switch u.Scheme {
+	case "https", "wss":
+		u.Scheme = "wss"
+	default:
+		u.Scheme = "ws"
+	}
 }
 
 // OnOpen handles WebSocket connection establishment.

--- a/agent/client_test.go
+++ b/agent/client_test.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"crypto/ed25519"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -153,6 +154,85 @@ func TestWebSocketClient_GetOptions(t *testing.T) {
 			// Test options caching
 			options2 := client.getOptions()
 			assert.Same(t, options, options2, "Options should be cached")
+		})
+	}
+}
+
+func TestResolveWebSocketRedirect(t *testing.T) {
+	testCases := []struct {
+		name           string
+		currentAddr    string
+		statusCode     int
+		location       string
+		expectedAddr   string
+		expectedFollow bool
+		expectError    bool
+	}{
+		{
+			name:           "308 http to https redirect",
+			currentAddr:    "ws://hub.example.com/api/beszel/agent-connect",
+			statusCode:     http.StatusPermanentRedirect,
+			location:       "https://hub.example.com/api/beszel/agent-connect",
+			expectedAddr:   "wss://hub.example.com/api/beszel/agent-connect",
+			expectedFollow: true,
+		},
+		{
+			name:           "relative redirect",
+			currentAddr:    "ws://hub.example.com/api/beszel/agent-connect",
+			statusCode:     http.StatusTemporaryRedirect,
+			location:       "/new/api/beszel/agent-connect",
+			expectedAddr:   "ws://hub.example.com/new/api/beszel/agent-connect",
+			expectedFollow: true,
+		},
+		{
+			name:           "wss redirect stays wss",
+			currentAddr:    "wss://hub.example.com/api/beszel/agent-connect",
+			statusCode:     http.StatusMovedPermanently,
+			location:       "wss://other.example.com/api/beszel/agent-connect",
+			expectedAddr:   "wss://other.example.com/api/beszel/agent-connect",
+			expectedFollow: true,
+		},
+		{
+			name:           "non redirect response",
+			currentAddr:    "ws://hub.example.com/api/beszel/agent-connect",
+			statusCode:     http.StatusBadGateway,
+			expectedFollow: false,
+		},
+		{
+			name:        "redirect missing location",
+			currentAddr: "ws://hub.example.com/api/beszel/agent-connect",
+			statusCode:  http.StatusPermanentRedirect,
+			expectError: true,
+		},
+		{
+			name:        "invalid location",
+			currentAddr: "ws://hub.example.com/api/beszel/agent-connect",
+			statusCode:  http.StatusPermanentRedirect,
+			location:    "http://[::1",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Header:     http.Header{},
+			}
+			if tc.location != "" {
+				resp.Header.Set("Location", tc.location)
+			}
+
+			addr, followed, err := resolveWebSocketRedirect(tc.currentAddr, resp)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedFollow, followed)
+			assert.Equal(t, tc.expectedAddr, addr)
 		})
 	}
 }


### PR DESCRIPTION
## 📃 Description

  Handles HTTP redirect responses during the agent WebSocket handshake, including 308 Permanent Redirect
  responses from HTTP-to-HTTPS proxy setups. This prevents agents configured with an HTTP hub URL from failing
  immediately when the hub redirects to HTTPS.

  ## 📖 Documentation

  No documentation changes.

  ## 🪵 Changelog

  ### ✏️ Changed

  - Build the agent WebSocket URL from a copy of the configured hub URL instead of mutating the stored URL.
  - Normalize redirected http/https targets back to ws/wss before retrying the WebSocket connection.

  ### 🔧 Fixed

  - Follow WebSocket handshake redirects, including 308 Permanent Redirect.
  - Resolve absolute and relative Location headers during WebSocket redirects.
  - Cap WebSocket redirect following at five hops to avoid redirect loops.
  - Close redirect response bodies before retrying.
  - Add unit coverage for 308 redirects, relative redirects, preserved wss redirects, non-redirect responses,
    missing Location headers, and malformed redirect URLs.

  ## 📷 Screenshots

  No UI/UX changes.

## Testing

Tested with `go test -tags testing ./agent -run TestResolveWebSocketRedirect`.