### PR TITLE
fix (hub): refresh system details after reconnect

### DIFF
--- a/internal/hub/systems/system.go
+++ b/internal/hub/systems/system.go
@@ -388,6 +388,7 @@ func (sys *System) setDown(originalError error) error {
 	if originalError != nil {
 		sys.manager.hub.Logger().Error("System down", "system", record.GetString("name"), "err", originalError)
 	}
+	sys.detailsFetched.Store(false)
 	record.Set("status", down)
 	return sys.manager.hub.SaveNoValidate(record)
 }


### PR DESCRIPTION
## 📃 Description

After a system goes down, the `detailsFetched` flag was never reset on SSH-connected systems. Since SSH systems reuse the same `System` object across down/up cycles (unlike WebSocket, which recreates it on reconnect), details were only ever fetched once and never updated — even after a hardware upgrade (e.g. RAM or CPU change) that required a reboot. The fix resets `detailsFetched` whenever a system goes down, so the next successful reconnect re-fetches and saves the updated hardware info.

fixes #2057
fixes #2084

## 🪵 Changelog

### 🔧 Fixed

- System details (CPU, memory, kernel, etc.) not updating in `system_details` after a hardware upgrade or system upgrade on SSH-connected systems
