### PR TITLE
fix(agent): use nvethernet MAC counters

### DIFF
--- a/agent/network.go
+++ b/agent/network.go
@@ -83,6 +83,7 @@ func (a *Agent) updateNetworkStats(cacheTimeMs uint16, systemStats *system.Stats
 	a.ensureNetworkInterfacesMap(systemStats)
 
 	if netIO, err := psutilNet.IOCounters(true); err == nil {
+		netIO = correctNetworkCounterStats(netIO)
 		nis, msElapsed := a.loadAndTickNetBaseline(cacheTimeMs)
 		totalBytesSent, totalBytesRecv := a.sumAndTrackPerNicDeltas(cacheTimeMs, msElapsed, netIO, systemStats)
 		bytesSentPerSecond, bytesRecvPerSecond := a.computeBytesPerSecond(msElapsed, totalBytesSent, totalBytesRecv, nis)
@@ -103,6 +104,7 @@ func (a *Agent) initializeNetIoStats() {
 
 	// get current network I/O stats and record valid interfaces
 	if netIO, err := psutilNet.IOCounters(true); err == nil {
+		netIO = correctNetworkCounterStats(netIO)
 		for _, v := range netIO {
 			if skipNetworkInterface(v, nicCfg) {
 				continue
@@ -198,10 +200,17 @@ func (a *Agent) sumAndTrackPerNicDeltas(cacheTimeMs uint16, msElapsed uint64, ne
 // computeBytesPerSecond calculates per-second totals from elapsed time and totals
 func (a *Agent) computeBytesPerSecond(msElapsed, totalBytesSent, totalBytesRecv uint64, nis system.NetIoStats) (bytesSentPerSecond, bytesRecvPerSecond uint64) {
 	if msElapsed > 0 {
-		bytesSentPerSecond = (totalBytesSent - nis.BytesSent) * 1000 / msElapsed
-		bytesRecvPerSecond = (totalBytesRecv - nis.BytesRecv) * 1000 / msElapsed
+		bytesSentPerSecond = counterDelta(totalBytesSent, nis.BytesSent) * 1000 / msElapsed
+		bytesRecvPerSecond = counterDelta(totalBytesRecv, nis.BytesRecv) * 1000 / msElapsed
 	}
 	return bytesSentPerSecond, bytesRecvPerSecond
+}
+
+func counterDelta(current, previous uint64) uint64 {
+	if current >= previous {
+		return current - previous
+	}
+	return current
 }
 
 // applyNetworkTotals validates and writes computed network stats, or resets on anomaly

--- a/agent/network_counters.go
+++ b/agent/network_counters.go
@@ -1,0 +1,10 @@
+package agent
+
+import psutilNet "github.com/shirou/gopsutil/v4/net"
+
+func correctNetworkCounterStats(netIO []psutilNet.IOCountersStat) []psutilNet.IOCountersStat {
+	for i := range netIO {
+		netIO[i] = correctNetworkCounterStat(netIO[i])
+	}
+	return netIO
+}

--- a/agent/network_counters_linux.go
+++ b/agent/network_counters_linux.go
@@ -1,0 +1,102 @@
+//go:build linux
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	psutilNet "github.com/shirou/gopsutil/v4/net"
+)
+
+const ethtoolTimeout = 2 * time.Second
+
+func correctNetworkCounterStat(v psutilNet.IOCountersStat) psutilNet.IOCountersStat {
+	if !isNvidiaEthernet(v.Name) {
+		return v
+	}
+
+	tx, rx, ok := readEthtoolMACOctets(v.Name)
+	if !ok {
+		return v
+	}
+
+	v.BytesSent = tx
+	v.BytesRecv = rx
+	return v
+}
+
+func isNvidiaEthernet(name string) bool {
+	if name == "" || strings.Contains(name, "/") {
+		return false
+	}
+
+	driverPath := filepath.Join("/sys/class/net", name, "device/driver")
+	target, err := os.Readlink(driverPath)
+	if err != nil {
+		return false
+	}
+	return filepath.Base(target) == "nvethernet"
+}
+
+func readEthtoolMACOctets(name string) (tx, rx uint64, ok bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), ethtoolTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "ethtool", "-S", name).Output()
+	if err != nil {
+		slog.Debug("Failed to read ethtool network counters", "interface", name, "err", err)
+		return 0, 0, false
+	}
+
+	stats := parseEthtoolStats(string(out))
+	tx, okTx := ethtoolCounter(stats, "mmc_tx_octetcount_gb", "mmc_tx_octetcount_gb_h")
+	rx, okRx := ethtoolCounter(stats, "mmc_rx_octetcount_gb", "mmc_rx_octetcount_gb_h")
+	if !okTx || !okRx {
+		return 0, 0, false
+	}
+	return tx, rx, true
+}
+
+func parseEthtoolStats(out string) map[string]uint64 {
+	stats := make(map[string]uint64)
+	for _, line := range strings.Split(out, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key == "" || value == "" {
+			continue
+		}
+		fields := strings.Fields(value)
+		if len(fields) == 0 {
+			continue
+		}
+		parsed, err := strconv.ParseUint(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		stats[key] = parsed
+	}
+	return stats
+}
+
+func ethtoolCounter(stats map[string]uint64, lowKey, highKey string) (uint64, bool) {
+	low, ok := stats[lowKey]
+	if !ok {
+		return 0, false
+	}
+	high, hasHigh := stats[highKey]
+	if !hasHigh {
+		return low, true
+	}
+	return high<<32 | low, true
+}

--- a/agent/network_counters_linux_test.go
+++ b/agent/network_counters_linux_test.go
@@ -1,0 +1,44 @@
+//go:build linux && testing
+
+package agent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEthtoolStats(t *testing.T) {
+	stats := parseEthtoolStats(`
+NIC statistics:
+     mmc_tx_octetcount_gb: 4699696
+     mmc_rx_octetcount_gb: 101028343
+     ignored_text: not-a-number
+     with_suffix: 42 packets
+`)
+
+	assert.Equal(t, uint64(4_699_696), stats["mmc_tx_octetcount_gb"])
+	assert.Equal(t, uint64(101_028_343), stats["mmc_rx_octetcount_gb"])
+	assert.Equal(t, uint64(42), stats["with_suffix"])
+	assert.NotContains(t, stats, "ignored_text")
+}
+
+func TestEthtoolCounterCombinesHighWord(t *testing.T) {
+	stats := map[string]uint64{
+		"counter":   123,
+		"counter_h": 2,
+	}
+
+	value, ok := ethtoolCounter(stats, "counter", "counter_h")
+	require.True(t, ok)
+	assert.Equal(t, uint64(2<<32|123), value)
+}
+
+func TestEthtoolCounterFallsBackToLowWord(t *testing.T) {
+	stats := map[string]uint64{"counter": 456}
+
+	value, ok := ethtoolCounter(stats, "counter", "counter_h")
+	require.True(t, ok)
+	assert.Equal(t, uint64(456), value)
+}

--- a/agent/network_counters_unsupported.go
+++ b/agent/network_counters_unsupported.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package agent
+
+import psutilNet "github.com/shirou/gopsutil/v4/net"
+
+func correctNetworkCounterStat(v psutilNet.IOCountersStat) psutilNet.IOCountersStat {
+	return v
+}

--- a/agent/network_test.go
+++ b/agent/network_test.go
@@ -340,6 +340,11 @@ func TestComputeBytesPerSecond(t *testing.T) {
 	// (6000-1000)*1000/500 = 10000; (11000-1000)*1000/500 = 20000
 	assert.Equal(t, uint64(10000), bytesUp)
 	assert.Equal(t, uint64(20000), bytesDown)
+
+	// Counter reset -> treat current total as the delta instead of underflowing.
+	bytesUp, bytesDown = a.computeBytesPerSecond(1000, 2000, 3000, system.NetIoStats{BytesSent: 10000, BytesRecv: 12000})
+	assert.Equal(t, uint64(2000), bytesUp)
+	assert.Equal(t, uint64(3000), bytesDown)
 }
 
 func TestSumAndTrackPerNicDeltas(t *testing.T) {


### PR DESCRIPTION
## Summary
- correct Linux `nvethernet` interface byte totals using MAC octet counters from `ethtool -S`
- keep existing gopsutil behavior for other platforms/drivers
- make total bandwidth delta math reset-safe to avoid uint64 underflow after counter resets

## Why
On NVIDIA Jetson AGX Orin, `/sys/class/net/eth0/statistics/tx_bytes` can report impossible multi-terabyte TX totals while the hardware MAC counter shows only megabytes sent. Beszel reads the inflated sysfs counter and triggers bandwidth alerts even when traffic is idle.

## Evidence
Sanitized live snapshot from an affected Jetson AGX Orin, captured from Beszel's existing agent data plus a local counter probe. Account, URL, IP, and host-list details are intentionally omitted.

### Beszel alert/UI data
At `2026-06-18 08:16:52Z`, the current Beszel agent reported:

| Signal | Observed |
| --- | ---: |
| Bandwidth alert | triggered |
| Outgoing rate | `715,840,593 B/s` (~683 MiB/s) |
| Incoming rate | `15,987 B/s` |
| Per-interface cumulative TX | `20,302,331,773,103 bytes` (~18.47 TiB) |
| Per-interface cumulative RX | `447,818,781 bytes` (~427 MiB) |
| NIC temperature | `73.35 C` |

### Counter source mismatch
On the same interface/boot, Linux sysfs and the hardware MAC counters disagreed by several orders of magnitude:

```text
driver: nvethernet

sysfs tx_bytes: 20371051453685 bytes (~18.53 TiB)
sysfs tx_packets: 24758
sysfs tx_errors: 0
sysfs tx_dropped: 0

ethtool mmc_tx_octetcount_gb: 22371670 bytes (~21.33 MiB)
ethtool mmc_tx_framecount_gb: 34182
```

A 10-second sample showed the same behavior:

```text
sysfs_tx_delta=21474858046 bytes (~20.00 GiB)
mac_tx_delta=22315 bytes (~21.79 KiB)
sysfs_rx_delta=141250 bytes
mac_rx_delta=153958 bytes
```

This is why the fix is scoped to Linux interfaces whose driver symlink is exactly `nvethernet`: replace the bogus sysfs/gopsutil byte totals with the NIC's MAC octet counters before Beszel computes rates.

## Tests
- `go test -tags testing ./agent`
- `go test ./agent ./internal/cmd/agent`
- `go test -tags testing ./...` was attempted but this checkout lacks the embedded web `internal/site/dist` assets, so hub packages fail with `pattern all:dist: no matching files found`.

## Review
- Ran `codex review --uncommitted` before opening the PR; no actionable regressions reported. Codex review could not run tests in its read-only sandbox, so the focused tests above were run locally.
