### PR TITLE
feat(alerts): add container health alerts

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -20,10 +20,11 @@ type hubLike interface {
 }
 
 type AlertManager struct {
-	hub           hubLike
-	stopOnce      sync.Once
-	pendingAlerts sync.Map
-	alertsCache   *AlertsCache
+	hub             hubLike
+	stopOnce        sync.Once
+	pendingAlerts   sync.Map
+	alertsCache     *AlertsCache
+	containerHealth *containerHealthTracker
 }
 
 type AlertMessageData struct {
@@ -98,8 +99,9 @@ var supportsTitle = map[string]struct{}{
 // NewAlertManager creates a new AlertManager instance.
 func NewAlertManager(app hubLike) *AlertManager {
 	am := &AlertManager{
-		hub:         app,
-		alertsCache: NewAlertsCache(app),
+		hub:             app,
+		alertsCache:     NewAlertsCache(app),
+		containerHealth: newContainerHealthTracker(),
 	}
 	am.bindEvents()
 	return am

--- a/internal/alerts/alerts_api.go
+++ b/internal/alerts/alerts_api.go
@@ -22,6 +22,7 @@ func UpsertUserAlerts(e *core.RequestEvent) error {
 		Min       uint8    `json:"min"`
 		Value     float64  `json:"value"`
 		Name      string   `json:"name"`
+		Container string   `json:"container"`
 		Systems   []string `json:"systems"`
 		Overwrite bool     `json:"overwrite"`
 	}{}
@@ -39,8 +40,8 @@ func UpsertUserAlerts(e *core.RequestEvent) error {
 		for _, systemId := range reqData.Systems {
 			// find existing matching alert
 			alertRecord, err := txApp.FindFirstRecordByFilter(alertsCollection,
-				"system={:system} && name={:name} && user={:user}",
-				dbx.Params{"system": systemId, "name": reqData.Name, "user": userID})
+				"system={:system} && name={:name} && user={:user} && container={:container}",
+				dbx.Params{"system": systemId, "name": reqData.Name, "user": userID, "container": reqData.Container})
 
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
 				return err
@@ -57,6 +58,7 @@ func UpsertUserAlerts(e *core.RequestEvent) error {
 				alertRecord.Set("user", userID)
 				alertRecord.Set("system", systemId)
 				alertRecord.Set("name", reqData.Name)
+				alertRecord.Set("container", reqData.Container)
 			}
 
 			alertRecord.Set("value", reqData.Value)
@@ -83,6 +85,7 @@ func DeleteUserAlerts(e *core.RequestEvent) error {
 
 	reqData := struct {
 		AlertName string   `json:"name"`
+		Container string   `json:"container"`
 		Systems   []string `json:"systems"`
 	}{}
 	err := e.BindBody(&reqData)
@@ -96,8 +99,8 @@ func DeleteUserAlerts(e *core.RequestEvent) error {
 		for _, systemId := range reqData.Systems {
 			// Find existing alert to delete
 			alertRecord, err := txApp.FindFirstRecordByFilter("alerts",
-				"system={:system} && name={:name} && user={:user}",
-				dbx.Params{"system": systemId, "name": reqData.AlertName, "user": userID})
+				"system={:system} && name={:name} && user={:user} && container={:container}",
+				dbx.Params{"system": systemId, "name": reqData.AlertName, "user": userID, "container": reqData.Container})
 
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {

--- a/internal/alerts/alerts_cache.go
+++ b/internal/alerts/alerts_cache.go
@@ -12,6 +12,7 @@ type CachedAlertData struct {
 	SystemID  string
 	UserID    string
 	Name      string
+	Container string
 	Value     float64
 	Triggered bool
 	Min       uint8
@@ -23,6 +24,7 @@ func (a *CachedAlertData) PopulateFromRecord(record *core.Record) {
 	a.SystemID = record.GetString("system")
 	a.UserID = record.GetString("user")
 	a.Name = record.GetString("name")
+	a.Container = record.GetString("container")
 	a.Value = record.GetFloat("value")
 	a.Triggered = record.GetBool("triggered")
 	a.Min = uint8(record.GetInt("min"))

--- a/internal/alerts/alerts_container.go
+++ b/internal/alerts/alerts_container.go
@@ -1,0 +1,191 @@
+package alerts
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/henrygd/beszel/internal/entities/container"
+	"github.com/henrygd/beszel/internal/entities/system"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// containerHealthAlertName is the alert type key for container health alerts.
+const containerHealthAlertName = "ContainerHealth"
+
+// containerHealthTracker records, per system, the time each container was first
+// observed in an unhealthy state. State is kept in-memory and rebuilt naturally
+// from incoming agent data, so it is reset (not restored) on hub restart. Access
+// per system is already serialized by the system's update goroutine; the mutex
+// guards concurrent access across different systems.
+type containerHealthTracker struct {
+	mu sync.Mutex
+	// systemID -> containerName -> time first observed unhealthy
+	unhealthySince map[string]map[string]time.Time
+}
+
+func newContainerHealthTracker() *containerHealthTracker {
+	return &containerHealthTracker{unhealthySince: make(map[string]map[string]time.Time)}
+}
+
+// reconcile updates the tracked unhealthy containers for a system to match the
+// current set of unhealthy container names, preserving the original "since" time
+// for containers that remain unhealthy. It returns a map of currently unhealthy
+// container names to the time they were first seen unhealthy.
+func (t *containerHealthTracker) reconcile(systemID string, unhealthyNames []string, now time.Time) map[string]time.Time {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev := t.unhealthySince[systemID]
+	current := make(map[string]time.Time, len(unhealthyNames))
+	for _, name := range unhealthyNames {
+		if since, ok := prev[name]; ok {
+			current[name] = since
+		} else {
+			current[name] = now
+		}
+	}
+	if len(current) == 0 {
+		delete(t.unhealthySince, systemID)
+	} else {
+		t.unhealthySince[systemID] = current
+	}
+	return current
+}
+
+// clear removes all tracked container health state for a system.
+func (t *containerHealthTracker) clear(systemID string) {
+	t.mu.Lock()
+	delete(t.unhealthySince, systemID)
+	t.mu.Unlock()
+}
+
+// HandleContainerAlerts evaluates container health alerts for a system on each
+// metrics update. It triggers an alert when any container has been unhealthy for
+// at least the alert's configured duration (min minutes), and resolves it once
+// no container on the system is unhealthy.
+func (am *AlertManager) HandleContainerAlerts(systemRecord *core.Record, data *system.CombinedData) error {
+	alerts := am.alertsCache.GetAlertsByName(systemRecord.Id, containerHealthAlertName)
+	if len(alerts) == 0 {
+		am.containerHealth.clear(systemRecord.Id)
+		return nil
+	}
+
+	// Health is only populated by CBOR-capable agents. Older agents send stats
+	// without container Id/Health, in which case we skip evaluation.
+	if len(data.Containers) == 0 || data.Containers[0].Id == "" {
+		am.containerHealth.clear(systemRecord.Id)
+		return nil
+	}
+
+	now := systemRecord.GetDateTime("updated").Time().UTC()
+
+	var unhealthyNames []string
+	for _, ctr := range data.Containers {
+		if ctr.Health == container.DockerHealthUnhealthy {
+			unhealthyNames = append(unhealthyNames, ctr.Name)
+		}
+	}
+
+	unhealthy := am.containerHealth.reconcile(systemRecord.Id, unhealthyNames, now)
+	systemName := systemRecord.GetString("name")
+
+	for _, alertData := range alerts {
+		min := max(1, int(alertData.Min))
+		threshold := time.Duration(min) * time.Minute
+
+		if alertData.Container == "" {
+			// "any container" mode: trigger when any container has been unhealthy
+			// long enough, resolve once every container has recovered.
+			var offending []string
+			for name, since := range unhealthy {
+				if now.Sub(since) >= threshold {
+					offending = append(offending, name)
+				}
+			}
+			switch {
+			case len(offending) > 0 && !alertData.Triggered:
+				slices.Sort(offending)
+				if err := am.sendContainerHealthAlert(systemRecord, systemName, alertData, offending, min, true); err != nil {
+					am.hub.Logger().Error("Failed to send container alert", "err", err)
+				}
+			case len(unhealthy) == 0 && alertData.Triggered:
+				if err := am.sendContainerHealthAlert(systemRecord, systemName, alertData, nil, min, false); err != nil {
+					am.hub.Logger().Error("Failed to send container alert", "err", err)
+				}
+			}
+			continue
+		}
+
+		// specific container mode: only watch the named container
+		since, isUnhealthy := unhealthy[alertData.Container]
+		longEnough := isUnhealthy && now.Sub(since) >= threshold
+		switch {
+		case longEnough && !alertData.Triggered:
+			if err := am.sendContainerHealthAlert(systemRecord, systemName, alertData, []string{alertData.Container}, min, true); err != nil {
+				am.hub.Logger().Error("Failed to send container alert", "err", err)
+			}
+		case !isUnhealthy && alertData.Triggered:
+			// resolve once the container is healthy again or no longer present
+			if err := am.sendContainerHealthAlert(systemRecord, systemName, alertData, []string{alertData.Container}, min, false); err != nil {
+				am.hub.Logger().Error("Failed to send container alert", "err", err)
+			}
+		}
+	}
+	return nil
+}
+
+// sendContainerHealthAlert updates the alert's triggered state and notifies the user.
+func (am *AlertManager) sendContainerHealthAlert(systemRecord *core.Record, systemName string, alertData CachedAlertData, offending []string, min int, triggered bool) error {
+	if err := am.setAlertTriggered(alertData, triggered); err != nil {
+		return err
+	}
+
+	minutesLabel := "minute"
+	if min > 1 {
+		minutesLabel += "s"
+	}
+
+	var title, message string
+	if triggered {
+		emoji := "\U0001F534" // red circle
+		if alertData.Container != "" {
+			title = fmt.Sprintf("%s container %s unhealthy %v", systemName, alertData.Container, emoji)
+			message = fmt.Sprintf("%s unhealthy for over %d %s", alertData.Container, min, minutesLabel)
+		} else {
+			noun := "container"
+			if len(offending) > 1 {
+				noun = "containers"
+			}
+			title = fmt.Sprintf("%s has unhealthy %s %v", systemName, noun, emoji)
+			message = fmt.Sprintf("Unhealthy for over %d %s: %s", min, minutesLabel, strings.Join(offending, ", "))
+		}
+	} else {
+		emoji := "✅" // green checkmark
+		if alertData.Container != "" {
+			title = fmt.Sprintf("%s container %s healthy %v", systemName, alertData.Container, emoji)
+			message = fmt.Sprintf("%s healthy", alertData.Container)
+		} else {
+			title = fmt.Sprintf("%s containers healthy %v", systemName, emoji)
+			message = fmt.Sprintf("%s containers healthy", systemName)
+		}
+	}
+
+	return am.SendAlert(AlertMessageData{
+		UserID:   alertData.UserID,
+		SystemID: systemRecord.Id,
+		Title:    title,
+		Message:  message,
+		Link:     am.hub.MakeLink("system", systemRecord.Id),
+		LinkText: "View " + systemName,
+	})
+}
+
+// ClearContainerHealthState removes tracked container health state for a system.
+// Called when a system is paused or removed to avoid leaking state.
+func (am *AlertManager) ClearContainerHealthState(systemID string) {
+	am.containerHealth.clear(systemID)
+}

--- a/internal/alerts/alerts_container_test.go
+++ b/internal/alerts/alerts_container_test.go
@@ -1,0 +1,189 @@
+//go:build testing
+
+package alerts_test
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/henrygd/beszel/internal/entities/container"
+	"github.com/henrygd/beszel/internal/entities/system"
+	beszelTests "github.com/henrygd/beszel/internal/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type containerAlertTestFixture struct {
+	hub     *beszelTests.TestHub
+	alertID string
+	submit  func(containers []*container.Stats) error
+}
+
+func newContainerAlertTestFixture(t *testing.T, min int) *containerAlertTestFixture {
+	return newContainerAlertTestFixtureFor(t, min, "")
+}
+
+func newContainerAlertTestFixtureFor(t *testing.T, min int, containerName string) *containerAlertTestFixture {
+	t.Helper()
+
+	hub, user := beszelTests.GetHubWithUser(t)
+
+	systems, err := beszelTests.CreateSystems(hub, 1, user.Id, "up")
+	require.NoError(t, err)
+	systemRecord := systems[0]
+
+	sysManagerSystem, err := hub.GetSystemManager().GetSystemFromStore(systemRecord.Id)
+	require.NoError(t, err)
+	require.NotNil(t, sysManagerSystem)
+	sysManagerSystem.StopUpdater()
+
+	userSettings, err := hub.FindFirstRecordByFilter("user_settings", "user={:user}", map[string]any{"user": user.Id})
+	require.NoError(t, err)
+	userSettings.Set("settings", `{"emails":["test@example.com"],"webhooks":[]}`)
+	require.NoError(t, hub.Save(userSettings))
+
+	alertRecord, err := beszelTests.CreateRecord(hub, "alerts", map[string]any{
+		"name":      "ContainerHealth",
+		"system":    systemRecord.Id,
+		"user":      user.Id,
+		"min":       min,
+		"value":     0,
+		"container": containerName,
+	})
+	require.NoError(t, err)
+	assert.False(t, alertRecord.GetBool("triggered"), "Alert should not be triggered initially")
+
+	return &containerAlertTestFixture{
+		hub:     hub,
+		alertID: alertRecord.Id,
+		submit: func(containers []*container.Stats) error {
+			_, err := sysManagerSystem.CreateRecords(&system.CombinedData{Containers: containers})
+			return err
+		},
+	}
+}
+
+func (f *containerAlertTestFixture) assertTriggered(t *testing.T, triggered bool, msg string) {
+	t.Helper()
+	alertRecord, err := f.hub.FindRecordById("alerts", f.alertID)
+	require.NoError(t, err)
+	assert.Equal(t, triggered, alertRecord.GetBool("triggered"), msg)
+}
+
+func waitForContainerAlert(d time.Duration) {
+	time.Sleep(d)
+	synctest.Wait()
+}
+
+func unhealthy(name string) *container.Stats {
+	return &container.Stats{Name: name, Id: name + "id", Health: container.DockerHealthUnhealthy}
+}
+
+func healthy(name string) *container.Stats {
+	return &container.Stats{Name: name, Id: name + "id", Health: container.DockerHealthHealthy}
+}
+
+// A container unhealthy for longer than the configured duration should trigger,
+// and resolve once it recovers.
+func TestContainerHealthAlertTriggersAndResolves(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newContainerAlertTestFixture(t, 1)
+		defer fixture.hub.Cleanup()
+
+		// first observation: unhealthy but duration is 0, should not trigger yet
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should not trigger on first unhealthy observation")
+		assert.Equal(t, 0, fixture.hub.TestMailer.TotalSend(), "No email yet")
+
+		// still unhealthy after more than a minute: should trigger
+		waitForContainerAlert(time.Minute + time.Second)
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, true, "Alert should trigger after unhealthy longer than 1 minute")
+		assert.Equal(t, 1, fixture.hub.TestMailer.TotalSend(), "Triggered email should be sent")
+		assert.Contains(t, fixture.hub.TestMailer.LastMessage().Text, "web", "Message should name the unhealthy container")
+
+		// container recovers: should resolve
+		require.NoError(t, fixture.submit([]*container.Stats{healthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should resolve after container becomes healthy")
+		assert.Equal(t, 2, fixture.hub.TestMailer.TotalSend(), "Resolved email should be sent")
+
+		waitForContainerAlert(time.Minute)
+	})
+}
+
+// A container that recovers before the duration elapses should never trigger.
+func TestContainerHealthAlertDoesNotTriggerBeforeDuration(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newContainerAlertTestFixture(t, 5)
+		defer fixture.hub.Cleanup()
+
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("web")}))
+		waitForContainerAlert(time.Minute + time.Second)
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should not trigger before 5 minutes")
+
+		// recovers well before threshold
+		require.NoError(t, fixture.submit([]*container.Stats{healthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should remain untriggered after early recovery")
+		assert.Equal(t, 0, fixture.hub.TestMailer.TotalSend(), "No email should be sent")
+
+		waitForContainerAlert(time.Minute)
+	})
+}
+
+// A per-container alert should only react to its own container, ignoring others.
+func TestContainerHealthAlertSpecificContainer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newContainerAlertTestFixtureFor(t, 1, "web")
+		defer fixture.hub.Cleanup()
+
+		// a different container being unhealthy must not trigger the "web" alert
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("db"), healthy("web")}))
+		waitForContainerAlert(time.Minute + time.Second)
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("db"), healthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert for 'web' should ignore other containers")
+		assert.Equal(t, 0, fixture.hub.TestMailer.TotalSend(), "No email for unrelated container")
+
+		// now "web" becomes unhealthy long enough -> triggers
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("db"), unhealthy("web")}))
+		waitForContainerAlert(time.Minute + time.Second)
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("db"), unhealthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, true, "Alert should trigger when 'web' is unhealthy long enough")
+		assert.Equal(t, 1, fixture.hub.TestMailer.TotalSend(), "One email for 'web'")
+		assert.Contains(t, fixture.hub.TestMailer.LastMessage().Text, "web")
+
+		// "web" recovers -> resolves (even though "db" is still unhealthy)
+		require.NoError(t, fixture.submit([]*container.Stats{unhealthy("db"), healthy("web")}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should resolve when 'web' recovers")
+		assert.Equal(t, 2, fixture.hub.TestMailer.TotalSend(), "Resolved email for 'web'")
+
+		waitForContainerAlert(time.Minute)
+	})
+}
+
+// Stats without container Id (older agents, no health data) should be a no-op.
+func TestContainerHealthAlertIgnoresStatsWithoutHealth(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newContainerAlertTestFixture(t, 1)
+		defer fixture.hub.Cleanup()
+
+		// no Id => health unavailable
+		require.NoError(t, fixture.submit([]*container.Stats{{Name: "web"}}))
+		waitForContainerAlert(time.Minute + time.Second)
+		require.NoError(t, fixture.submit([]*container.Stats{{Name: "web"}}))
+		waitForContainerAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should never trigger without health data")
+		assert.Equal(t, 0, fixture.hub.TestMailer.TotalSend(), "No email should be sent")
+
+		waitForContainerAlert(time.Minute)
+	})
+}

--- a/internal/alerts/alerts_history.go
+++ b/internal/alerts/alerts_history.go
@@ -65,6 +65,7 @@ func createAlertHistoryRecord(app core.App, alertRecord *core.Record) (alertHist
 	alertHistoryRecord.Set("user", alertRecord.GetString("user"))
 	alertHistoryRecord.Set("system", alertRecord.GetString("system"))
 	alertHistoryRecord.Set("name", alertRecord.GetString("name"))
+	alertHistoryRecord.Set("container", alertRecord.GetString("container"))
 	alertHistoryRecord.Set("value", alertRecord.GetFloat("value"))
 	err = app.Save(alertHistoryRecord)
 	if err != nil {

--- a/internal/alerts/alerts_system.go
+++ b/internal/alerts/alerts_system.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *system.CombinedData) error {
-	alerts := am.alertsCache.GetAlertsExcludingNames(systemRecord.Id, "Status")
+	alerts := am.alertsCache.GetAlertsExcludingNames(systemRecord.Id, "Status", containerHealthAlertName)
 	if len(alerts) == 0 {
 		return nil
 	}

--- a/internal/hub/systems/system_manager.go
+++ b/internal/hub/systems/system_manager.go
@@ -54,7 +54,9 @@ type hubLike interface {
 	GetSSHKey(dataDir string) (ssh.Signer, error)
 	HandleSystemAlerts(systemRecord *core.Record, data *system.CombinedData) error
 	HandleStatusAlerts(status string, systemRecord *core.Record) error
+	HandleContainerAlerts(systemRecord *core.Record, data *system.CombinedData) error
 	CancelPendingStatusAlerts(systemID string)
+	ClearContainerHealthState(systemID string)
 }
 
 // NewSystemManager creates a new SystemManager instance with the provided hub.
@@ -191,6 +193,7 @@ func (sm *SystemManager) onRecordAfterUpdateSuccess(e *core.RecordEvent) error {
 		}
 		_ = deactivateAlerts(e.App, e.Record.Id)
 		sm.hub.CancelPendingStatusAlerts(e.Record.Id)
+		sm.hub.ClearContainerHealthState(e.Record.Id)
 		return e.Next()
 	case pending:
 		// Resume monitoring, preferring existing WebSocket connection
@@ -215,6 +218,9 @@ func (sm *SystemManager) onRecordAfterUpdateSuccess(e *core.RecordEvent) error {
 	if newStatus == up {
 		if err := sm.hub.HandleSystemAlerts(e.Record, system.data); err != nil {
 			e.App.Logger().Error("Error handling system alerts", "err", err)
+		}
+		if err := sm.hub.HandleContainerAlerts(e.Record, system.data); err != nil {
+			e.App.Logger().Error("Error handling container alerts", "err", err)
 		}
 	}
 
@@ -273,6 +279,7 @@ func (sm *SystemManager) RemoveSystem(systemID string) error {
 	// Clean up all connections
 	system.closeSSHConnection()
 	system.closeWebSocketConnection()
+	sm.hub.ClearContainerHealthState(systemID)
 	sm.systems.Remove(systemID)
 	return nil
 }

--- a/internal/migrations/0_collections_snapshot_0_19_0_dev_1.go
+++ b/internal/migrations/0_collections_snapshot_0_19_0_dev_1.go
@@ -79,8 +79,23 @@ func init() {
 					"LoadAvg1",
 					"LoadAvg5",
 					"LoadAvg15",
-					"Battery"
+					"Battery",
+					"ContainerHealth"
 				]
+			},
+			{
+				"autogeneratePattern": "",
+				"hidden": false,
+				"id": "textcontaineral",
+				"max": 0,
+				"min": 0,
+				"name": "container",
+				"pattern": "",
+				"presentable": false,
+				"primaryKey": false,
+				"required": false,
+				"system": false,
+				"type": "text"
 			},
 			{
 				"hidden": false,
@@ -137,7 +152,7 @@ func init() {
 			}
 		],
 		"indexes": [
-			"CREATE UNIQUE INDEX ` + "`" + `idx_MnhEt21L5r` + "`" + ` ON ` + "`" + `alerts` + "`" + ` (\n  ` + "`" + `user` + "`" + `,\n  ` + "`" + `system` + "`" + `,\n  ` + "`" + `name` + "`" + `\n)"
+			"CREATE UNIQUE INDEX ` + "`" + `idx_MnhEt21L5r` + "`" + ` ON ` + "`" + `alerts` + "`" + ` (\n  ` + "`" + `user` + "`" + `,\n  ` + "`" + `system` + "`" + `,\n  ` + "`" + `name` + "`" + `,\n  ` + "`" + `container` + "`" + `\n)"
 		],
 		"system": false
 	},
@@ -216,6 +231,20 @@ func init() {
 					"presentable": false,
 					"primaryKey": false,
 					"required": true,
+					"system": false,
+					"type": "text"
+				},
+				{
+					"autogeneratePattern": "",
+					"hidden": false,
+					"id": "texthistcontain",
+					"max": 0,
+					"min": 0,
+					"name": "container",
+					"pattern": "",
+					"presentable": false,
+					"primaryKey": false,
+					"required": false,
 					"system": false,
 					"type": "text"
 				},

--- a/internal/migrations/1_add_container_health_alert.go
+++ b/internal/migrations/1_add_container_health_alert.go
@@ -1,0 +1,92 @@
+package migrations
+
+import (
+	"slices"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+// Adds container health alerts support:
+//   - "ContainerHealth" option on the alerts "name" select field
+//   - "container" text field on alerts and alerts_history (empty = any container)
+//   - alerts unique index extended with "container" so multiple ContainerHealth
+//     alerts (one per container + one "any") can coexist for a system
+func init() {
+	const alertName = "ContainerHealth"
+	const oldIndex = "CREATE UNIQUE INDEX `idx_MnhEt21L5r` ON `alerts` (`user`, `system`, `name`)"
+	const newIndex = "CREATE UNIQUE INDEX `idx_MnhEt21L5r` ON `alerts` (`user`, `system`, `name`, `container`)"
+
+	m.Register(func(app core.App) error {
+		alerts, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		if field, ok := alerts.Fields.GetByName("name").(*core.SelectField); ok {
+			if !slices.Contains(field.Values, alertName) {
+				field.Values = append(field.Values, alertName)
+			}
+		}
+		if alerts.Fields.GetByName("container") == nil {
+			alerts.Fields.Add(&core.TextField{Name: "container"})
+		}
+		// extend the unique index to include container
+		for i, idx := range alerts.Indexes {
+			if normalizeIndex(idx) == normalizeIndex(oldIndex) {
+				alerts.Indexes[i] = newIndex
+			}
+		}
+		if err := app.Save(alerts); err != nil {
+			return err
+		}
+
+		history, err := app.FindCollectionByNameOrId("alerts_history")
+		if err != nil {
+			return err
+		}
+		if history.Fields.GetByName("container") == nil {
+			history.Fields.Add(&core.TextField{Name: "container"})
+		}
+		return app.Save(history)
+	}, func(app core.App) error {
+		alerts, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		if field, ok := alerts.Fields.GetByName("name").(*core.SelectField); ok {
+			field.Values = slices.DeleteFunc(field.Values, func(v string) bool {
+				return v == alertName
+			})
+		}
+		alerts.Fields.RemoveByName("container")
+		for i, idx := range alerts.Indexes {
+			if normalizeIndex(idx) == normalizeIndex(newIndex) {
+				alerts.Indexes[i] = oldIndex
+			}
+		}
+		if err := app.Save(alerts); err != nil {
+			return err
+		}
+
+		history, err := app.FindCollectionByNameOrId("alerts_history")
+		if err != nil {
+			return err
+		}
+		history.Fields.RemoveByName("container")
+		return app.Save(history)
+	})
+}
+
+// normalizeIndex strips whitespace so index definitions can be compared
+// regardless of formatting differences (newlines/spaces).
+func normalizeIndex(idx string) string {
+	var b []byte
+	for i := 0; i < len(idx); i++ {
+		c := idx[i]
+		if c == ' ' || c == '\n' || c == '\t' {
+			continue
+		}
+		b = append(b, c)
+	}
+	return string(b)
+}

--- a/internal/site/src/components/active-alerts.tsx
+++ b/internal/site/src/components/active-alerts.tsx
@@ -56,11 +56,22 @@ export const ActiveAlerts = () => {
 									>
 										<info.icon className="h-4 w-4" />
 										<AlertTitle>
-											{systems[alert.system]?.name} {info.name()}
+											{systems[alert.system]?.name}{" "}
+											{alert.name === "ContainerHealth" && alert.container ? alert.container : info.name()}
 										</AlertTitle>
 										<AlertDescription>
 											{alert.name === "Status" ? (
 												<Trans>Connection is down</Trans>
+											) : alert.name === "ContainerHealth" ? (
+												alert.container ? (
+													<Trans>
+														Unhealthy for <Plural value={alert.min} one="# minute" other="# minutes" />
+													</Trans>
+												) : (
+													<Trans>
+														Any container unhealthy for <Plural value={alert.min} one="# minute" other="# minutes" />
+													</Trans>
+												)
 											) : info.invert ? (
 												<Trans>
 													Below {alert.value}

--- a/internal/site/src/components/alerts-history-columns.tsx
+++ b/internal/site/src/components/alerts-history-columns.tsx
@@ -30,7 +30,11 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 		accessorFn: (record) => {
 			const name = record.name
 			const info = alertInfo[name]
-			return info?.name().replace("cpu", "CPU") || name
+			const label = info?.name().replace("cpu", "CPU") || name
+			if (name === "ContainerHealth" && record.container) {
+				return `${label}: ${record.container}`
+			}
+			return label
 		},
 		header: ({ column }) => (
 			<Button variant="ghost" onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}>
@@ -62,6 +66,9 @@ export const alertsHistoryColumns: ColumnDef<AlertsHistoryRecord>[] = [
 			const name = row.original.name
 			if (name === "Status") {
 				return <span className="ps-2">{t`Down`}</span>
+			}
+			if (name === "ContainerHealth") {
+				return <span className="ps-2">{t`Unhealthy`}</span>
 			}
 			const value = getValue() as number
 			const unit = alertInfo[name]?.unit

--- a/internal/site/src/components/alerts/alerts-sheet.tsx
+++ b/internal/site/src/components/alerts/alerts-sheet.tsx
@@ -2,8 +2,8 @@ import { t } from "@lingui/core/macro"
 import { Plural, Trans } from "@lingui/react/macro"
 import { useStore } from "@nanostores/react"
 import { getPagePath } from "@nanostores/router"
-import { ChevronDownIcon, GlobeIcon, ServerIcon } from "lucide-react"
-import { lazy, memo, Suspense, useMemo, useState } from "react"
+import { ChevronDownIcon, ContainerIcon, GlobeIcon, SearchIcon, ServerIcon } from "lucide-react"
+import { lazy, memo, Suspense, useEffect, useMemo, useState } from "react"
 import { $router, Link } from "@/components/router"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -13,7 +13,7 @@ import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { toast } from "@/components/ui/use-toast"
-import { alertInfo } from "@/lib/alerts"
+import { alertInfo, alertStoreKey } from "@/lib/alerts"
 import { pb } from "@/lib/api"
 import { $alerts, $systems } from "@/lib/stores"
 import { cn, debounce } from "@/lib/utils"
@@ -38,12 +38,24 @@ const failedUpdateToast = (error: unknown) => {
 
 /** Create or update alerts for a given name and systems */
 const upsertAlerts = debounce(
-	async ({ name, value, min, systems }: { name: string; value: number; min: number; systems: string[] }) => {
+	async ({
+		name,
+		value,
+		min,
+		systems,
+		container = "",
+	}: {
+		name: string
+		value: number
+		min: number
+		systems: string[]
+		container?: string
+	}) => {
 		try {
 			await pb.send<{ success: boolean }>(endpoint, {
 				method: "POST",
 				// overwrite is always true because we've done filtering client side
-				body: { name, value, min, systems, overwrite: true },
+				body: { name, value, min, systems, container, overwrite: true },
 			})
 		} catch (error) {
 			failedUpdateToast(error)
@@ -53,16 +65,19 @@ const upsertAlerts = debounce(
 )
 
 /** Delete alerts for a given name and systems */
-const deleteAlerts = debounce(async ({ name, systems }: { name: string; systems: string[] }) => {
-	try {
-		await pb.send<{ success: boolean }>(endpoint, {
-			method: "DELETE",
-			body: { name, systems },
-		})
-	} catch (error) {
-		failedUpdateToast(error)
-	}
-}, alertDebounce)
+const deleteAlerts = debounce(
+	async ({ name, systems, container = "" }: { name: string; systems: string[]; container?: string }) => {
+		try {
+			await pb.send<{ success: boolean }>(endpoint, {
+				method: "DELETE",
+				body: { name, systems, container },
+			})
+		} catch (error) {
+			failedUpdateToast(error)
+		}
+	},
+	alertDebounce
+)
 
 export const AlertDialogContent = memo(function AlertDialogContent({ system }: { system: SystemRecord }) {
 	const alerts = useStore($alerts)
@@ -86,21 +101,23 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 		if (!sourceAlerts?.size) return
 		try {
 			const currentTargetAlerts = $alerts.get()[system.id] ?? new Map()
-			// Alert names present on target but absent from source should be deleted
-			const namesToDelete = Array.from(currentTargetAlerts.keys()).filter((name) => !sourceAlerts.has(name))
+			// Alerts present on target but absent from source should be deleted
+			const recordsToDelete = Array.from(currentTargetAlerts.entries())
+				.filter(([key]) => !sourceAlerts.has(key))
+				.map(([, record]) => record)
 			await Promise.all([
-				...Array.from(sourceAlerts.values()).map(({ name, value, min }) =>
+				...Array.from(sourceAlerts.entries()).map(([key, { name, value, min, container = "" }]) =>
 					pb.send<{ success: boolean }>(endpoint, {
 						method: "POST",
-						body: { name, value, min, systems: [system.id], overwrite: true },
-						requestKey: name,
+						body: { name, value, min, container, systems: [system.id], overwrite: true },
+						requestKey: key,
 					})
 				),
-				...namesToDelete.map((name) =>
+				...recordsToDelete.map(({ name, container = "" }) =>
 					pb.send<{ success: boolean }>(endpoint, {
 						method: "DELETE",
-						body: { name, systems: [system.id] },
-						requestKey: name,
+						body: { name, container, systems: [system.id] },
+						requestKey: alertStoreKey({ name, container }),
 					})
 				),
 			])
@@ -108,7 +125,7 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 			// before the realtime subscription event arrives.
 			const newSystemAlerts = new Map<string, AlertRecord>()
 			for (const alert of sourceAlerts.values()) {
-				newSystemAlerts.set(alert.name, { ...alert, system: system.id, triggered: false })
+				newSystemAlerts.set(alertStoreKey(alert), { ...alert, system: system.id, triggered: false })
 			}
 			$alerts.setKey(system.id, newSystemAlerts)
 			setCopyKey((k) => k + 1)
@@ -172,15 +189,19 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 				</div>
 				<TabsContent value="system">
 					<div key={copyKey} className="grid gap-3">
-						{alertKeys.map((name) => (
-							<AlertContent
-								key={name}
-								alertKey={name}
-								data={alertInfo[name as keyof typeof alertInfo]}
-								alert={systemAlerts.get(name)}
-								system={system}
-							/>
-						))}
+						{alertKeys.map((name) =>
+							name === "ContainerHealth" ? (
+								<ContainerAlerts key={name} system={system} systemAlerts={systemAlerts} />
+							) : (
+								<AlertContent
+									key={name}
+									alertKey={name}
+									data={alertInfo[name as keyof typeof alertInfo]}
+									alert={systemAlerts.get(name)}
+									system={system}
+								/>
+							)
+						)}
 					</div>
 				</TabsContent>
 				<TabsContent value="global">
@@ -197,18 +218,29 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 						<Trans>Overwrite existing alerts</Trans>
 					</label>
 					<div className="grid gap-3">
-						{alertKeys.map((name) => (
-							<AlertContent
-								key={name}
-								alertKey={name}
-								system={system}
-								alert={systemAlerts.get(name)}
-								data={alertInfo[name as keyof typeof alertInfo]}
-								global={true}
-								overwriteExisting={!!overwriteExisting}
-								initialAlertsState={alertsWhenGlobalSelected}
-							/>
-						))}
+						{alertKeys.map((name) =>
+							name === "ContainerHealth" ? (
+								<ContainerAlerts
+									key={name}
+									system={system}
+									systemAlerts={systemAlerts}
+									global={true}
+									overwriteExisting={!!overwriteExisting}
+									initialAlertsState={alertsWhenGlobalSelected}
+								/>
+							) : (
+								<AlertContent
+									key={name}
+									alertKey={name}
+									system={system}
+									alert={systemAlerts.get(name)}
+									data={alertInfo[name as keyof typeof alertInfo]}
+									global={true}
+									overwriteExisting={!!overwriteExisting}
+									initialAlertsState={alertsWhenGlobalSelected}
+								/>
+							)
+						)}
 					</div>
 				</TabsContent>
 			</Tabs>
@@ -218,6 +250,8 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 
 export function AlertContent({
 	alertKey,
+	apiName = alertKey,
+	container = "",
 	data: alertData,
 	system,
 	alert,
@@ -226,6 +260,10 @@ export function AlertContent({
 	initialAlertsState = {},
 }: {
 	alertKey: string
+	/** alert type name sent to the API (defaults to alertKey) */
+	apiName?: string
+	/** optional container name for ContainerHealth alerts */
+	container?: string
 	data: AlertInfo
 	system: SystemRecord
 	alert?: AlertRecord
@@ -265,7 +303,8 @@ export function AlertContent({
 		const systems = getSystemIds()
 		systems.length &&
 			upsertAlerts({
-				name: alertKey,
+				name: apiName,
+				container,
 				value,
 				min,
 				systems,
@@ -296,7 +335,7 @@ export function AlertContent({
 							sendUpsert(min, value)
 						} else {
 							// if unchecked, delete alert (unless global and overwriteExisting is false)
-							deleteAlerts({ name: alertKey, systems: getSystemIds() })
+							deleteAlerts({ name: apiName, container, systems: getSystemIds() })
 							// when force deleting all alerts of a type, also remove them from initialAlertsState
 							if (overwriteExisting) {
 								for (const curAlerts of Object.values(initialAlertsState)) {
@@ -402,6 +441,119 @@ export function AlertContent({
 						</div>
 					</Suspense>
 				</div>
+			)}
+		</div>
+	)
+}
+
+const containerHealthName = "ContainerHealth"
+
+/** AlertInfo for the "All Containers" (any container) card */
+const allContainersInfo: AlertInfo = {
+	name: () => t`All Containers`,
+	unit: "",
+	icon: ContainerIcon,
+	desc: () => t`Triggers when any container is unhealthy`,
+	singleDesc: () => t`Any container unhealthy`,
+}
+
+/** Build AlertInfo for a specific container card */
+function containerInfo(name: string): AlertInfo {
+	return {
+		name: () => name,
+		unit: "",
+		icon: ContainerIcon,
+		desc: () => t`Triggers when this container is unhealthy`,
+		singleDesc: () => t`Unhealthy`,
+	}
+}
+
+/** Renders the container health alerts: an "all containers" card plus, for a
+ *  single system, a searchable list of per-container cards. */
+function ContainerAlerts({
+	system,
+	systemAlerts,
+	global = false,
+	overwriteExisting = false,
+	initialAlertsState = {},
+}: {
+	system: SystemRecord
+	systemAlerts: Map<string, AlertRecord>
+	global?: boolean
+	overwriteExisting?: boolean
+	initialAlertsState?: Record<string, Map<string, AlertRecord>>
+}) {
+	const [containers, setContainers] = useState<string[]>([])
+	const [search, setSearch] = useState("")
+
+	useEffect(() => {
+		// per-container alerts only make sense when targeting a single system
+		if (global) {
+			return
+		}
+		let cancelled = false
+		pb.collection("containers")
+			.getList(1, 2000, {
+				fields: "name",
+				filter: pb.filter("system={:system}", { system: system.id }),
+			})
+			.then(({ items }) => {
+				if (cancelled) {
+					return
+				}
+				const names = Array.from(new Set(items.map((i) => i.name as string))).sort((a, b) => a.localeCompare(b))
+				setContainers(names)
+			})
+			.catch(() => {})
+		return () => {
+			cancelled = true
+		}
+	}, [global, system.id])
+
+	const filtered = useMemo(() => {
+		const q = search.trim().toLowerCase()
+		return q ? containers.filter((n) => n.toLowerCase().includes(q)) : containers
+	}, [containers, search])
+
+	return (
+		<div className="grid gap-3">
+			<AlertContent
+				alertKey={containerHealthName}
+				apiName={containerHealthName}
+				container=""
+				data={allContainersInfo}
+				alert={systemAlerts.get(containerHealthName)}
+				system={system}
+				global={global}
+				overwriteExisting={overwriteExisting}
+				initialAlertsState={initialAlertsState}
+			/>
+			{!global && containers.length > 0 && (
+				<>
+					<div className="relative">
+						<SearchIcon className="absolute start-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+						<Input
+							value={search}
+							onChange={(e) => setSearch(e.target.value)}
+							placeholder={t`Search containers...`}
+							className="ps-9"
+						/>
+					</div>
+					{filtered.map((name) => {
+						const key = `${containerHealthName}:${name}`
+						return (
+							<AlertContent
+								key={key}
+								alertKey={key}
+								apiName={containerHealthName}
+								container={name}
+								data={containerInfo(name)}
+								alert={systemAlerts.get(key)}
+								system={system}
+							/>
+						)
+					})}
+				</>
 			)}
 		</div>
 	)

--- a/internal/site/src/components/routes/settings/alerts-history-data-table.tsx
+++ b/internal/site/src/components/routes/settings/alerts-history-data-table.tsx
@@ -67,7 +67,7 @@ export default function AlertsHistoryDataTable() {
 	const [globalFilter, setGlobalFilter] = useState("")
 	const { toast } = useToast()
 	const [deleteOpen, setDeleteDialogOpen] = useState(false)
-	
+
 	// Store pagination preference in local storage
 	const [pagination, setPagination] = useBrowserStorage<PaginationState>("ah-pagination", {
 		pageIndex: 0,
@@ -78,7 +78,7 @@ export default function AlertsHistoryDataTable() {
 		let unsubscribe: (() => void) | undefined
 		const pbOptions = {
 			expand: "system",
-			fields: "id,name,value,state,created,resolved,expand.system.name",
+			fields: "id,name,container,value,state,created,resolved,expand.system.name",
 		}
 		// Initial load
 		pb.collection<AlertsHistoryRecord>("alerts_history")
@@ -327,7 +327,7 @@ export default function AlertsHistoryDataTable() {
 						<Select
 							value={`${table.getState().pagination.pageSize}`}
 							onValueChange={(value) => {
-								table.setPageSize(Number(value));
+								table.setPageSize(Number(value))
 							}}
 						>
 							<SelectTrigger className="w-18" id="rows-per-page">

--- a/internal/site/src/lib/alerts.ts
+++ b/internal/site/src/lib/alerts.ts
@@ -1,5 +1,5 @@
 import { t } from "@lingui/core/macro"
-import { CpuIcon, HardDriveIcon, MemoryStickIcon, ServerIcon } from "lucide-react"
+import { ContainerIcon, CpuIcon, HardDriveIcon, MemoryStickIcon, ServerIcon } from "lucide-react"
 import type { RecordSubscription } from "pocketbase"
 import { EthernetIcon, GpuIcon } from "@/components/ui/icons"
 import { $alerts } from "@/lib/stores"
@@ -16,6 +16,14 @@ export const alertInfo: Record<string, AlertInfo> = {
 		desc: () => t`Triggers when status switches between up and down`,
 		/** "for x minutes" is appended to desc when only one value */
 		singleDesc: () => `${t`System`} ${t`Down`}`,
+	},
+	ContainerHealth: {
+		name: () => t`Container Health`,
+		unit: "",
+		icon: ContainerIcon,
+		desc: () => t`Triggers when a container is unhealthy`,
+		/** no threshold value - only duration. "for x minutes" is appended */
+		singleDesc: () => t`Unhealthy`,
 	},
 	CPU: {
 		name: () => t`CPU Usage`,
@@ -94,13 +102,23 @@ export const alertInfo: Record<string, AlertInfo> = {
 	},
 } as const
 
+/**
+ * Store key for an alert. Most alerts are unique per (system, name), but
+ * ContainerHealth alerts can also be scoped to a specific container, so the
+ * container is folded into the key. Empty container ("any") keeps the bare name
+ * for backward compatibility.
+ */
+export function alertStoreKey(alert: Pick<AlertRecord, "name" | "container">): string {
+	return alert.container ? `${alert.name}:${alert.container}` : alert.name
+}
+
 /** Helper to manage user alerts */
 export const alertManager = (() => {
 	const collection = pb.collection<AlertRecord>("alerts")
 	let unsub: () => void
 
 	/** Fields to fetch from alerts collection */
-	const fields = "id,name,system,value,min,triggered"
+	const fields = "id,name,system,value,min,triggered,container"
 
 	/** Fetch alerts from collection */
 	async function fetchAlerts(): Promise<AlertRecord[]> {
@@ -113,17 +131,17 @@ export const alertManager = (() => {
 			const systemId = alert.system
 			const systemAlerts = $alerts.get()[systemId] ?? new Map()
 			const newAlerts = new Map(systemAlerts)
-			newAlerts.set(alert.name, alert)
+			newAlerts.set(alertStoreKey(alert), alert)
 			$alerts.setKey(systemId, newAlerts)
 		}
 	}
 
-	function remove(alerts: Pick<AlertRecord, "name" | "system">[]) {
+	function remove(alerts: Pick<AlertRecord, "name" | "system" | "container">[]) {
 		for (const alert of alerts) {
 			const systemId = alert.system
 			const systemAlerts = $alerts.get()[systemId]
 			const newAlerts = new Map(systemAlerts)
-			newAlerts.delete(alert.name)
+			newAlerts.delete(alertStoreKey(alert))
 			$alerts.setKey(systemId, newAlerts)
 		}
 	}
@@ -141,7 +159,7 @@ export const alertManager = (() => {
 
 		return (data: RecordSubscription<AlertRecord>) => {
 			const { record } = data
-			batch.set(`${record.system}${record.name}`, data)
+			batch.set(`${record.system}${alertStoreKey(record)}`, data)
 			clearTimeout(timeout)
 			timeout = setTimeout(() => {
 				const groups = { create: [], update: [], delete: [] } as Record<string, AlertRecord[]>

--- a/internal/site/src/locales/ar/ar.po
+++ b/internal/site/src/locales/ar/ar.po
@@ -179,6 +179,15 @@ msgstr "جميع الحاويات"
 msgid "All Systems"
 msgstr "جميع الأنظمة"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "هل أنت متأكد أنك تريد حذف {name}؟"
@@ -422,6 +431,10 @@ msgstr "التعارضات"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "الاتصال مقطوع"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "جدولة ساعات الهدوء حيث لن يتم إرسال الإ�
 msgid "Search"
 msgstr "بحث"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "البحث عن الأنظمة أو الإعدادات..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "يتم التفعيل عندما يتجاوز متوسط التحميل لمدة 5 دقائق عتبة معينة"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "يتم التفعيل عندما يتجاوز أي مستشعر عتبة معينة"
 
@@ -1752,6 +1777,10 @@ msgstr "يتم التفعيل عندما يتجاوز استخدام الذاك�
 msgid "Triggers when status switches between up and down"
 msgstr "يتم التفعيل عندما يتغير الحالة بين التشغيل والإيقاف"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "يتم التفعيل عندما يتجاوز استخدام أي قرص عتبة معينة"
@@ -1761,6 +1790,17 @@ msgstr "يتم التفعيل عندما يتجاوز استخدام أي قرص
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "النوع"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/bg/bg.po
+++ b/internal/site/src/locales/bg/bg.po
@@ -179,6 +179,15 @@ msgstr "Всички контейнери"
 msgid "All Systems"
 msgstr "Всички системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Сигурен ли си, че искаш да изтриеш {name}?"
@@ -422,6 +431,10 @@ msgstr "Конфликти"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Връзката е прекъсната"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Планирай тихи часове, когато няма да се 
 msgid "Search"
 msgstr "Търси"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Търси за системи или настройки..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Задейства се, когато употребата на паметта за 5 минута надвиши зададен праг"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Задейства се, когато някой даден сензор надвиши зададен праг"
 
@@ -1752,6 +1777,10 @@ msgstr "Задейства се, когато употребата на паме
 msgid "Triggers when status switches between up and down"
 msgstr "Задейства се, когато статуса превключва между долу и горе"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Задейства се, когато употребата на някой диск надивши зададен праг"
@@ -1761,6 +1790,17 @@ msgstr "Задейства се, когато употребата на няко
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Тип"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/cs/cs.po
+++ b/internal/site/src/locales/cs/cs.po
@@ -179,6 +179,15 @@ msgstr "Všechny kontejnery"
 msgid "All Systems"
 msgstr "Všechny systémy"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Opravdu chcete odstranit {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikty"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Připojení je nedostupné"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Naplánujte tiché hodiny, kdy se nebudou odesílat oznámení."
 msgid "Search"
 msgstr "Hledat"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Hledat systémy nebo nastavení..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Spustí se, když využití paměti během 5 minut překročí prahovou hodnotu"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Spustí se, když některý senzor překročí prahovou hodnotu"
 
@@ -1752,6 +1777,10 @@ msgstr "Spustí se, když využití paměti překročí prahovou hodnotu"
 msgid "Triggers when status switches between up and down"
 msgstr "Spouští se, když se změní dostupnost"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Spustí se, když využití disku překročí prahovou hodnotu"
@@ -1761,6 +1790,17 @@ msgstr "Spustí se, když využití disku překročí prahovou hodnotu"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Typ"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/da/da.po
+++ b/internal/site/src/locales/da/da.po
@@ -179,6 +179,15 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle systemer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på, at du vil slette {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikter"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Forbindelsen er nede"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Planlæg stille timer hvor meddelelser ikke vil blive sendt."
 msgid "Search"
 msgstr "Søg"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Søg efter systemer eller indstillinger..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Udløser når 5 minut belastning gennemsnit overstiger en tærskel"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Udløser når en sensor overstiger en tærskel"
 
@@ -1752,6 +1777,10 @@ msgstr "Udløser når hukommelsesforbruget overstiger en tærskel"
 msgid "Triggers when status switches between up and down"
 msgstr "Udløser når status skifter mellem op og ned"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Udløser når brugen af en disk overstiger en tærskel"
@@ -1760,6 +1789,17 @@ msgstr "Udløser når brugen af en disk overstiger en tærskel"
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
+msgstr ""
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx

--- a/internal/site/src/locales/de/de.po
+++ b/internal/site/src/locales/de/de.po
@@ -179,6 +179,15 @@ msgstr "Alle Container"
 msgid "All Systems"
 msgstr "Alle Systeme"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Möchtest du {name} wirklich löschen?"
@@ -422,6 +431,10 @@ msgstr "Konflikte"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Verbindung unterbrochen"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Plane Ruhezeiten, in denen keine Benachrichtigungen gesendet werden."
 msgid "Search"
 msgstr "Suche"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Nach Systemen oder Einstellungen suchen..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Löst aus, wenn der Lastdurchschnitt der letzten 5 Minuten einen Schwellenwert überschreitet"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Löst aus, wenn ein Sensor einen Schwellenwert überschreitet"
 
@@ -1752,6 +1777,10 @@ msgstr "Löst aus, wenn die Arbeitsspeichernutzung einen Schwellenwert überschr
 msgid "Triggers when status switches between up and down"
 msgstr "Löst aus, wenn der Status zwischen online und offline wechselt"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Löst aus, wenn die Nutzung einer Festplatte einen Schwellenwert überschreitet"
@@ -1761,6 +1790,17 @@ msgstr "Löst aus, wenn die Nutzung einer Festplatte einen Schwellenwert übersc
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Typ"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/en/en.po
+++ b/internal/site/src/locales/en/en.po
@@ -174,6 +174,15 @@ msgstr "All Containers"
 msgid "All Systems"
 msgstr "All Systems"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr "Any container unhealthy"
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Are you sure you want to delete {name}?"
@@ -417,6 +426,10 @@ msgstr "Conflicts"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Connection is down"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr "Container Health"
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1434,6 +1447,10 @@ msgstr "Schedule quiet hours where notifications will not be sent."
 msgid "Search"
 msgstr "Search"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr "Search containers..."
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Search for systems or settings..."
@@ -1720,6 +1737,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Triggers when 5 minute load average exceeds a threshold"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr "Triggers when a container is unhealthy"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr "Triggers when any container is unhealthy"
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Triggers when any sensor exceeds a threshold"
 
@@ -1747,6 +1772,10 @@ msgstr "Triggers when memory usage exceeds a threshold"
 msgid "Triggers when status switches between up and down"
 msgstr "Triggers when status switches between up and down"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr "Triggers when this container is unhealthy"
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Triggers when usage of any disk exceeds a threshold"
@@ -1756,6 +1785,17 @@ msgstr "Triggers when usage of any disk exceeds a threshold"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Type"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr "Unhealthy"
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/es/es.po
+++ b/internal/site/src/locales/es/es.po
@@ -179,6 +179,15 @@ msgstr "Todos los contenedores"
 msgid "All Systems"
 msgstr "Todos los sistemas"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "¿Estás seguro de que deseas eliminar {name}?"
@@ -422,6 +431,10 @@ msgstr "Conflictos"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "La conexión está caída"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Programe horas de silencio donde no se enviarán notificaciones."
 msgid "Search"
 msgstr "Buscar"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Buscar sistemas o configuraciones..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Se activa cuando la carga media de 5 minutos supera un umbral"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Se activa cuando cualquier sensor supera un umbral"
 
@@ -1752,6 +1777,10 @@ msgstr "Se activa cuando el uso de memoria supera un umbral"
 msgid "Triggers when status switches between up and down"
 msgstr "Se activa cuando el estado cambia entre activo e inactivo"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Se activa cuando el uso de cualquier disco supera un umbral"
@@ -1761,6 +1790,17 @@ msgstr "Se activa cuando el uso de cualquier disco supera un umbral"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tipo"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/fa/fa.po
+++ b/internal/site/src/locales/fa/fa.po
@@ -179,6 +179,15 @@ msgstr "همه کانتینرها"
 msgid "All Systems"
 msgstr "همه سیستم‌ها"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "آیا مطمئن هستید که می‌خواهید {name} را حذف کنید؟"
@@ -422,6 +431,10 @@ msgstr "تعارض‌ها"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "اتصال قطع است"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "برنامه‌ریزی ساعات آرام که در آن اعلان‌
 msgid "Search"
 msgstr "جستجو"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "جستجو برای سیستم‌ها یا تنظیمات..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "هنگامی که میانگین بار ۵ دقیقه‌ای از یک آستانه فراتر رود، فعال می‌شود"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "هنگامی که هر حسگری از یک آستانه فراتر رود، فعال می‌شود"
 
@@ -1752,6 +1777,10 @@ msgstr "هنگامی که میزان استفاده از حافظه از یک آ
 msgid "Triggers when status switches between up and down"
 msgstr "هنگامی که وضعیت بین بالا و پایین تغییر می‌کند، فعال می‌شود"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "هنگامی که استفاده از هر دیسکی از یک آستانه فراتر رود، فعال می‌شود"
@@ -1761,6 +1790,17 @@ msgstr "هنگامی که استفاده از هر دیسکی از یک آستا
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "نوع"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -179,6 +179,15 @@ msgstr "Tous les conteneurs"
 msgid "All Systems"
 msgstr "Tous les systèmes"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {name} ?"
@@ -422,6 +431,10 @@ msgstr "Conflits"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Connexion interrompue"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Programmez des heures calmes où les notifications ne seront pas envoyé
 msgid "Search"
 msgstr "Recherche"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Rechercher des systèmes ou des paramètres..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Se déclenche lorsque la charge moyenne sur 5 minutes dépasse un seuil"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Déclenchement lorsque tout capteur dépasse un seuil"
 
@@ -1752,6 +1777,10 @@ msgstr "Déclenchement lorsque l'utilisation de la mémoire dépasse un seuil"
 msgid "Triggers when status switches between up and down"
 msgstr "Se déclenche lorsque le statut passe de \"Joignable\" à \"Injoignable\""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Déclenchement lorsque l'utilisation de tout disque dépasse un seuil"
@@ -1760,6 +1789,17 @@ msgstr "Déclenchement lorsque l'utilisation de tout disque dépasse un seuil"
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
+msgstr ""
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx

--- a/internal/site/src/locales/he/he.po
+++ b/internal/site/src/locales/he/he.po
@@ -179,6 +179,15 @@ msgstr "כל הקונטיינרים"
 msgid "All Systems"
 msgstr "כל המערכות"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "האם אתה בטוח שברצונך למחוק את {name}?"
@@ -422,6 +431,10 @@ msgstr "התנגשויות"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "החיבור נפל"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "קבע שעות שקט שבהן לא יישלחו התראות."
 msgid "Search"
 msgstr "חיפוש"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "חפש מערכות או הגדרות..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "מופעל כאשר ממוצע העומס ל-5 דקות עולה על סף"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "מופעל כאשר כל חיישן עולה על סף"
 
@@ -1752,6 +1777,10 @@ msgstr "מופעל כאשר שימוש בזיכרון עולה על סף"
 msgid "Triggers when status switches between up and down"
 msgstr "מופעל כאשר הסטטוס מתחלף בין למעלה ולמטה"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "מופעל כאשר שימוש בכל דיסק עולה על סף"
@@ -1761,6 +1790,17 @@ msgstr "מופעל כאשר שימוש בכל דיסק עולה על סף"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "סוג"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/hr/hr.po
+++ b/internal/site/src/locales/hr/hr.po
@@ -179,6 +179,15 @@ msgstr "Svi spremnici"
 msgid "All Systems"
 msgstr "Svi Sustavi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Jeste li sigurni da želite izbrisati {name}?"
@@ -422,6 +431,10 @@ msgstr "Sukobi"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Veza je pala"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Rasporedi tihe sate kada se obavijesti neće slati."
 msgid "Search"
 msgstr "Pretraži"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Pretraži sustave ili postavke..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Pokreće se kada prosječna opterećenost sustava unutar 5 minuta prijeđe prag"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Pokreće se kada bilo koji senzor prijeđe prag"
 
@@ -1752,6 +1777,10 @@ msgstr "Pokreće se kada iskorištenost memorije premaši prag"
 msgid "Triggers when status switches between up and down"
 msgstr "Pokreće se kada se status sustava promijeni"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Pokreće se kada iskorištenost bilo kojeg diska premaši prag"
@@ -1761,6 +1790,17 @@ msgstr "Pokreće se kada iskorištenost bilo kojeg diska premaši prag"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Vrsta"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/hu/hu.po
+++ b/internal/site/src/locales/hu/hu.po
@@ -179,6 +179,15 @@ msgstr "Minden konténer"
 msgid "All Systems"
 msgstr "Minden rendszer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Biztosan törölni szeretnéd {name}-t?"
@@ -422,6 +431,10 @@ msgstr "Konfliktusok"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Kapcsolat megszakadt"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Ütemezze a csendes órákat, amikor az értesítések nem kerülnek elk
 msgid "Search"
 msgstr "Keresés"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Keresés rendszerek vagy beállítások után..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Riaszt, ha az 5 perces terhelési átlag túllép egy küszöbértéket"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Riaszt, ha bármelyik hőmérséklet érzékelő túllép egy küszöbértéket"
 
@@ -1752,6 +1777,10 @@ msgstr "Riaszt, ha a memóriahasználat túllép egy küszöbértéket"
 msgid "Triggers when status switches between up and down"
 msgstr "Riaszt, amikor a rendszer online állapota változik"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Riaszt, ha a lemezhasználat túllép egy küszöbértéket"
@@ -1761,6 +1790,17 @@ msgstr "Riaszt, ha a lemezhasználat túllép egy küszöbértéket"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Típus"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/id/id.po
+++ b/internal/site/src/locales/id/id.po
@@ -179,6 +179,15 @@ msgstr "Semua Container"
 msgid "All Systems"
 msgstr "Semua Sistem"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Apakah anda yakin ingin menghapus {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflik"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Koneksi terputus"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Jadwalkan jam tenang dimana notifikasi tidak akan dikirim."
 msgid "Search"
 msgstr "Cari"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Cari sistem atau pengaturan..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Dipicu ketika rata-rata beban 5 menit melebihi ambang batas"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Dipicu ketika sensor apa pun melebihi ambang batas"
 
@@ -1752,6 +1777,10 @@ msgstr "Dipicu ketika penggunaan memori melebihi ambang batas"
 msgid "Triggers when status switches between up and down"
 msgstr "Dipicu ketika status beralih antara up dan down"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Dipicu ketika penggunaan disk apa pun melebihi ambang batas"
@@ -1761,6 +1790,17 @@ msgstr "Dipicu ketika penggunaan disk apa pun melebihi ambang batas"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tipe"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/it/it.po
+++ b/internal/site/src/locales/it/it.po
@@ -179,6 +179,15 @@ msgstr "Tutti i contenitori"
 msgid "All Systems"
 msgstr "Tutti i Sistemi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Sei sicuro di voler eliminare {name}?"
@@ -422,6 +431,10 @@ msgstr "Conflitti"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "La connessione è interrotta"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Pianifica le ore silenziose in cui le notifiche non verranno inviate."
 msgid "Search"
 msgstr "Cerca"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Cerca sistemi o impostazioni..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Si attiva quando la media di carico di 5 minuti supera una soglia"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Attiva quando un sensore supera una soglia"
 
@@ -1752,6 +1777,10 @@ msgstr "Attiva quando l'utilizzo della memoria supera una soglia"
 msgid "Triggers when status switches between up and down"
 msgstr "Attiva quando lo stato passa tra up e down"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Attiva quando l'utilizzo di un disco supera una soglia"
@@ -1761,6 +1790,17 @@ msgstr "Attiva quando l'utilizzo di un disco supera una soglia"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tipo"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/ja/ja.po
+++ b/internal/site/src/locales/ja/ja.po
@@ -179,6 +179,15 @@ msgstr "すべてのコンテナ"
 msgid "All Systems"
 msgstr "すべてのシステム"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}を削除してもよろしいですか？"
@@ -422,6 +431,10 @@ msgstr "競合"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "接続が切断されました"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "通知が送信されないサイレント時間をスケジュールし
 msgid "Search"
 msgstr "検索"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "システムまたは設定を検索..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "5分間の負荷平均がしきい値を超えたときにトリガーされます"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "センサーがしきい値を超えたときにトリガーされます"
 
@@ -1752,6 +1777,10 @@ msgstr "メモリ使用率がしきい値を超えたときにトリガーされ
 msgid "Triggers when status switches between up and down"
 msgstr "ステータスが上から下に切り替わるときにトリガーされます"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "ディスクの使用量がしきい値を超えたときにトリガーされます"
@@ -1761,6 +1790,17 @@ msgstr "ディスクの使用量がしきい値を超えたときにトリガー
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "タイプ"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/ko/ko.po
+++ b/internal/site/src/locales/ko/ko.po
@@ -179,6 +179,15 @@ msgstr "모든 컨테이너"
 msgid "All Systems"
 msgstr "모든 시스템"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}을(를) 삭제하시겠습니까?"
@@ -422,6 +431,10 @@ msgstr "충돌"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "연결이 끊겼습니다"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "알림이 전송되지 않을 조용한 시간을 예약하세요."
 msgid "Search"
 msgstr "검색"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "시스템 또는 설정 검색..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "5분 부하 평균이 임계값을 초과하면 트리거됩니다."
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "센서가 임계값을 초과할 때 트리거됩니다."
 
@@ -1752,6 +1777,10 @@ msgstr "메모리 사용량이 임계값을 초과할 때 트리거됩니다."
 msgid "Triggers when status switches between up and down"
 msgstr "시스템의 전원이 켜지거나 꺼질때 트리거됩니다."
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "디스크 사용량이 임계값을 초과할 때 트리거됩니다."
@@ -1761,6 +1790,17 @@ msgstr "디스크 사용량이 임계값을 초과할 때 트리거됩니다."
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "유형"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/nl/nl.po
+++ b/internal/site/src/locales/nl/nl.po
@@ -179,6 +179,15 @@ msgstr "Alle containers"
 msgid "All Systems"
 msgstr "Alle systemen"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Weet je zeker dat je {name} wilt verwijderen?"
@@ -422,6 +431,10 @@ msgstr "Conflicten"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Verbinding is niet actief"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Plan stille uren waarin meldingen niet worden verzonden."
 msgid "Search"
 msgstr "Zoeken"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Zoek naar systemen of instellingen..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Triggert wanneer de 5 minuten gemiddelde belasting een drempelwaarde overschrijdt"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Triggert wanneer een sensor een drempelwaarde overschrijdt"
 
@@ -1752,6 +1777,10 @@ msgstr "Triggert wanneer het geheugengebruik een drempelwaarde overschrijdt"
 msgid "Triggers when status switches between up and down"
 msgstr "Triggert wanneer de status schakelt tussen up en down"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Triggert wanneer het gebruik van een schijf een drempelwaarde overschrijdt"
@@ -1760,6 +1789,17 @@ msgstr "Triggert wanneer het gebruik van een schijf een drempelwaarde overschrij
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
+msgstr ""
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx

--- a/internal/site/src/locales/no/no.po
+++ b/internal/site/src/locales/no/no.po
@@ -179,6 +179,15 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle Systemer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på at du vil slette {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikter"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Tilkoblingen er nede"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Planlegg stille timer hvor varsler ikke sendes."
 msgid "Search"
 msgstr "Søk"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Søk etter systemer eller innstillinger..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Slår inn når gjennomsnittsbelastningen over 5 minutter overstiger en grenseverdi"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Slår inn når hvilken som helst sensor overstiger en grenseverdi"
 
@@ -1752,6 +1777,10 @@ msgstr "Slår inn når minnebruken overstiger en grenseverdi"
 msgid "Triggers when status switches between up and down"
 msgstr "Slår inn når statusen veksler mellom oppe og nede"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Slår inn når forbruk av hvilken som helst disk overstiger en grenseverdi"
@@ -1760,6 +1789,17 @@ msgstr "Slår inn når forbruk av hvilken som helst disk overstiger en grensever
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
+msgstr ""
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx

--- a/internal/site/src/locales/pl/pl.po
+++ b/internal/site/src/locales/pl/pl.po
@@ -179,6 +179,15 @@ msgstr "Wszystkie kontenery"
 msgid "All Systems"
 msgstr "Wszystkie systemy"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Czy na pewno chcesz usunąć {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikty"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Brak połączenia"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Zaplanuj godziny ciszy, w których powiadomienia nie będą wysyłane."
 msgid "Search"
 msgstr "Szukaj"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Szukaj systemów lub ustawień..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Uruchamia się, gdy 5-minutowe średnie obciążenie systemu przekroczy ustawiony próg"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Wyzwalane, gdy jakikolwiek czujnik przekroczy ustalony próg."
 
@@ -1752,6 +1777,10 @@ msgstr "Wyzwalane, wykorzystanie pamięci przekroczy ustalony próg"
 msgid "Triggers when status switches between up and down"
 msgstr "Wyzwalane, gdy status przełącza się między stanem aktywnym a nieaktywnym"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Wyzwalane, gdy wykorzystanie któregokolwiek dysku przekroczy ustalony próg"
@@ -1761,6 +1790,17 @@ msgstr "Wyzwalane, gdy wykorzystanie któregokolwiek dysku przekroczy ustalony p
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Typ"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/pt/pt.po
+++ b/internal/site/src/locales/pt/pt.po
@@ -179,6 +179,15 @@ msgstr "Todos os Contêineres"
 msgid "All Systems"
 msgstr "Todos os Sistemas"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Tem certeza de que deseja excluir {name}?"
@@ -422,6 +431,10 @@ msgstr "Conflitos"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "A conexão está inativa"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Agende horas silenciosas onde as notificações não serão enviadas."
 msgid "Search"
 msgstr "Pesquisar"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Pesquisar por sistemas ou configurações..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Dispara quando a média de carga de 5 minutos excede um limite"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Dispara quando qualquer sensor excede um limite"
 
@@ -1752,6 +1777,10 @@ msgstr "Dispara quando o uso de memória excede um limite"
 msgid "Triggers when status switches between up and down"
 msgstr "Dispara quando o status alterna entre ativo e inativo"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Dispara quando o uso de qualquer disco excede um limite"
@@ -1761,6 +1790,17 @@ msgstr "Dispara quando o uso de qualquer disco excede um limite"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tipo"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/ro/ro.po
+++ b/internal/site/src/locales/ro/ro.po
@@ -179,6 +179,15 @@ msgstr ""
 msgid "All Systems"
 msgstr ""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr ""
@@ -412,6 +421,10 @@ msgstr "Conflicte"
 
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
+msgstr ""
+
+#: src/lib/alerts.ts
+msgid "Container Health"
 msgstr ""
 
 #: src/components/routes/system.tsx
@@ -1400,6 +1413,10 @@ msgstr ""
 msgid "Search"
 msgstr "Caută"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr ""
@@ -1681,6 +1698,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr ""
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr ""
 
@@ -1708,6 +1733,10 @@ msgstr ""
 msgid "Triggers when status switches between up and down"
 msgstr ""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr ""
@@ -1717,6 +1746,17 @@ msgstr ""
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tip"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"
@@ -1879,4 +1919,3 @@ msgstr "Da"
 #: src/components/routes/settings/layout.tsx
 msgid "Your user settings have been updated."
 msgstr ""
-

--- a/internal/site/src/locales/ru/ru.po
+++ b/internal/site/src/locales/ru/ru.po
@@ -179,6 +179,15 @@ msgstr "Все контейнеры"
 msgid "All Systems"
 msgstr "Все системы"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Вы уверены, что хотите удалить {name}?"
@@ -422,6 +431,10 @@ msgstr "Конфликты"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Нет соединения"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Запланируйте тихие часы, когда уведомл�
 msgid "Search"
 msgstr "Поиск"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Поиск систем или настроек..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Срабатывает, когда средняя загрузка за 5 минут превышает порог"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Срабатывает, когда любой датчик превышает порог"
 
@@ -1752,6 +1777,10 @@ msgstr "Срабатывает, когда использование памят
 msgid "Triggers when status switches between up and down"
 msgstr "Срабатывает, когда статус переключается между включено и выключено"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Срабатывает, когда использование любого диска превышает порог"
@@ -1761,6 +1790,17 @@ msgstr "Срабатывает, когда использование любог
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Тип"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/sl/sl.po
+++ b/internal/site/src/locales/sl/sl.po
@@ -179,6 +179,15 @@ msgstr "Vsi kontejnerji"
 msgid "All Systems"
 msgstr "Vsi sistemi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ali ste prepričani, da želite izbrisati {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikti"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Povezava je prekinjena"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Razporedite tihi čas, ko obvestila ne bodo poslana."
 msgid "Search"
 msgstr "Iskanje"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Iskanje sistemov ali nastavitev..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Sproži se, ko 5-minutna povprečna obremenitev preseže prag"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Sproži se, ko kateri koli senzor preseže prag"
 
@@ -1752,6 +1777,10 @@ msgstr "Sproži se, ko uporaba pomnilnika preseže prag"
 msgid "Triggers when status switches between up and down"
 msgstr "Sproži se, ko se stanje preklaplja med gor in dol"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Sproži se, ko uporaba katerega koli diska preseže prag"
@@ -1761,6 +1790,17 @@ msgstr "Sproži se, ko uporaba katerega koli diska preseže prag"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Vrsta"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/sr/sr.po
+++ b/internal/site/src/locales/sr/sr.po
@@ -179,6 +179,15 @@ msgstr "Сви контејнери"
 msgid "All Systems"
 msgstr "Сви системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Да ли сте сигурни да желите да избришете {name}?"
@@ -422,6 +431,10 @@ msgstr "Конфликти"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Веза је прекинута"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Закажите тихе сате када се обавештења н
 msgid "Search"
 msgstr "Претрага"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Претражите системе или подешавања..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Окида се када просечно оптерећење од 5 минута премаши праг"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Окида се када било који сензор премаши праг"
 
@@ -1752,6 +1777,10 @@ msgstr "Окида се када употреба меморије премаш�
 msgid "Triggers when status switches between up and down"
 msgstr "Окида се када статус прелази између укљученог и искљученог"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Окида се када употреба било ког диска премаши праг"
@@ -1761,6 +1790,17 @@ msgstr "Окида се када употреба било ког диска п�
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Тип"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/sv/sv.po
+++ b/internal/site/src/locales/sv/sv.po
@@ -179,6 +179,15 @@ msgstr "Alla behållare"
 msgid "All Systems"
 msgstr "Alla system"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Är du säker på att du vill ta bort {name}?"
@@ -422,6 +431,10 @@ msgstr "Konflikter"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Ej ansluten"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Schemalägg tysta timmar där aviseringar inte skickas."
 msgid "Search"
 msgstr "Sök"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Sök efter system eller inställningar..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Utlöses när 5-minuters genomsnittlig belastning överskrider ett tröskelvärde"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Utlöses när någon sensor överskrider ett tröskelvärde"
 
@@ -1752,6 +1777,10 @@ msgstr "Utlöses när minnesanvändningen överskrider ett tröskelvärde"
 msgid "Triggers when status switches between up and down"
 msgstr "Utlöses när status växlar mellan upp och ner"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Utlöses när användningen av någon disk överskrider ett tröskelvärde"
@@ -1761,6 +1790,17 @@ msgstr "Utlöses när användningen av någon disk överskrider ett tröskelvär
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Typ"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/th/th.po
+++ b/internal/site/src/locales/th/th.po
@@ -179,6 +179,15 @@ msgstr ""
 msgid "All Systems"
 msgstr ""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr ""
@@ -412,6 +421,10 @@ msgstr ""
 
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
+msgstr ""
+
+#: src/lib/alerts.ts
+msgid "Container Health"
 msgstr ""
 
 #: src/components/routes/system.tsx
@@ -1400,6 +1413,10 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr ""
@@ -1681,6 +1698,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr ""
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr ""
 
@@ -1708,6 +1733,10 @@ msgstr ""
 msgid "Triggers when status switches between up and down"
 msgstr ""
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr ""
@@ -1716,6 +1745,17 @@ msgstr ""
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
+msgstr ""
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
 msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
@@ -1879,4 +1919,3 @@ msgstr ""
 #: src/components/routes/settings/layout.tsx
 msgid "Your user settings have been updated."
 msgstr ""
-

--- a/internal/site/src/locales/tr/tr.po
+++ b/internal/site/src/locales/tr/tr.po
@@ -179,6 +179,15 @@ msgstr "Tüm Konteynerler"
 msgid "All Systems"
 msgstr "Tüm Sistemler"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name} silmek istediğinizden emin misiniz?"
@@ -422,6 +431,10 @@ msgstr "Çakışmalar"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Bağlantı kesildi"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Bildirimlerin gönderilmeyeceği sessiz saatleri zamanlayın."
 msgid "Search"
 msgstr "Ara"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Sistemler veya ayarlar için ara..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "5 dakikalık yük ortalaması bir eşiği aştığında tetiklenir"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Herhangi bir sensör bir eşiği aştığında tetiklenir"
 
@@ -1752,6 +1777,10 @@ msgstr "Bellek kullanımı bir eşiği aştığında tetiklenir"
 msgid "Triggers when status switches between up and down"
 msgstr "Durum yukarı ve aşağı arasında değiştiğinde tetiklenir"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Herhangi bir diskin kullanımı bir eşiği aştığında tetiklenir"
@@ -1761,6 +1790,17 @@ msgstr "Herhangi bir diskin kullanımı bir eşiği aştığında tetiklenir"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Tür"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/uk/uk.po
+++ b/internal/site/src/locales/uk/uk.po
@@ -179,6 +179,15 @@ msgstr "Всі контейнери"
 msgid "All Systems"
 msgstr "Всі системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ви впевнені, що хочете видалити {name}?"
@@ -422,6 +431,10 @@ msgstr "Конфлікти"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "З'єднання розірвано"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Заплануйте години спокою, коли сповіще�
 msgid "Search"
 msgstr "Пошук"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Шукати системи або налаштування..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Спрацьовує, коли середнє навантаження за 5 хвилин перевищує поріг"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Спрацьовує, коли будь-який датчик перевищує поріг"
 
@@ -1752,6 +1777,10 @@ msgstr "Спрацьовує, коли використання пам'яті п
 msgid "Triggers when status switches between up and down"
 msgstr "Спрацьовує, коли статус перемикається між «працює» та «не працює»"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Спрацьовує, коли використання будь-якого диска перевищує поріг"
@@ -1761,6 +1790,17 @@ msgstr "Спрацьовує, коли використання будь-яко�
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Тип"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/vi/vi.po
+++ b/internal/site/src/locales/vi/vi.po
@@ -179,6 +179,15 @@ msgstr "Tất cả container"
 msgid "All Systems"
 msgstr "Tất cả Hệ thống"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Bạn có chắc chắn muốn xóa {name} không?"
@@ -422,6 +431,10 @@ msgstr "Xung đột"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "Mất kết nối"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "Lên lịch giờ yên tĩnh nơi thông báo sẽ không được gửi
 msgid "Search"
 msgstr "Tìm kiếm"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "Tìm kiếm hệ thống hoặc cài đặt..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "Kích hoạt khi tải trung bình 5 phút vượt quá ngưỡng"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "Kích hoạt khi bất kỳ cảm biến nào vượt quá ngưỡng"
 
@@ -1752,6 +1777,10 @@ msgstr "Kích hoạt khi sử dụng bộ nhớ vượt quá ngưỡng"
 msgid "Triggers when status switches between up and down"
 msgstr "Kích hoạt khi trạng thái chuyển đổi giữa lên và xuống"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Kích hoạt khi sử dụng bất kỳ đĩa nào vượt quá ngưỡng"
@@ -1761,6 +1790,17 @@ msgstr "Kích hoạt khi sử dụng bất kỳ đĩa nào vượt quá ngưỡn
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "Loại"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/zh-CN/zh-CN.po
+++ b/internal/site/src/locales/zh-CN/zh-CN.po
@@ -179,6 +179,15 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有客户端"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您确定要删除 {name} 吗？"
@@ -422,6 +431,10 @@ msgstr "冲突"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "连接已断开"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "安排静默时间，在此期间不会发送通知。"
 msgid "Search"
 msgstr "搜索"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "搜索系统或设置..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "当 5 分钟内的平均负载超过阈值时触发"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "当任何传感器超过阈值时触发"
 
@@ -1752,6 +1777,10 @@ msgstr "当内存使用率超过阈值时触发"
 msgid "Triggers when status switches between up and down"
 msgstr "当状态在上线与掉线之间切换时触发"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "当任何磁盘的使用率超过阈值时触发"
@@ -1761,6 +1790,17 @@ msgstr "当任何磁盘的使用率超过阈值时触发"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "类型"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/zh-HK/zh-HK.po
+++ b/internal/site/src/locales/zh-HK/zh-HK.po
@@ -179,6 +179,15 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -422,6 +431,10 @@ msgstr "衝突"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "連線中斷"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "安排不會發送通知的靜音時段。"
 msgid "Search"
 msgstr "搜索"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "搜索系統或設置..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "當 5 分鐘平均負載超過閾值時觸發"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "當任何傳感器超過閾值時觸發"
 
@@ -1752,6 +1777,10 @@ msgstr "當記憶體使用率超過閾值時觸發"
 msgid "Triggers when status switches between up and down"
 msgstr "當狀態在上和下之間切換時觸發"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "當任何磁碟的使用超過閾值時觸發"
@@ -1761,6 +1790,17 @@ msgstr "當任何磁碟的使用超過閾值時觸發"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "類型"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/locales/zh/zh.po
+++ b/internal/site/src/locales/zh/zh.po
@@ -179,6 +179,15 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any container unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Any container unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -422,6 +431,10 @@ msgstr "衝突"
 #: src/components/active-alerts.tsx
 msgid "Connection is down"
 msgstr "連線中斷"
+
+#: src/lib/alerts.ts
+msgid "Container Health"
+msgstr ""
 
 #: src/components/routes/system.tsx
 msgid "Containers"
@@ -1439,6 +1452,10 @@ msgstr "安排不會發送通知的靜音時段。"
 msgid "Search"
 msgstr "搜尋"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Search containers..."
+msgstr ""
+
 #: src/components/command-palette.tsx
 msgid "Search for systems or settings..."
 msgstr "在設定或系統中搜尋..."
@@ -1725,6 +1742,14 @@ msgid "Triggers when 5 minute load average exceeds a threshold"
 msgstr "當 5 分鐘平均負載超過閾值時觸發"
 
 #: src/lib/alerts.ts
+msgid "Triggers when a container is unhealthy"
+msgstr ""
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when any container is unhealthy"
+msgstr ""
+
+#: src/lib/alerts.ts
 msgid "Triggers when any sensor exceeds a threshold"
 msgstr "當任何感應器超過閾值時觸發"
 
@@ -1752,6 +1777,10 @@ msgstr "當記憶體使用率超過閾值時觸發"
 msgid "Triggers when status switches between up and down"
 msgstr "當連線和離線時觸發"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Triggers when this container is unhealthy"
+msgstr ""
+
 #: src/lib/alerts.ts
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "當任何磁碟使用率超過閾值時觸發"
@@ -1761,6 +1790,17 @@ msgstr "當任何磁碟使用率超過閾值時觸發"
 #: src/components/routes/system/smart-table.tsx
 msgid "Type"
 msgstr "類型"
+
+#: src/components/alerts-history-columns.tsx
+#: src/components/alerts/alerts-sheet.tsx
+#: src/lib/alerts.ts
+msgid "Unhealthy"
+msgstr ""
+
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Unhealthy for {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Unit file"

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -228,6 +228,8 @@ export interface AlertRecord extends RecordModel {
 	id: string
 	system: string
 	name: string
+	/** Optional container name for ContainerHealth alerts; empty = any container */
+	container?: string
 	triggered: boolean
 	value: number
 	min: number
@@ -239,6 +241,8 @@ export interface AlertsHistoryRecord extends RecordModel {
 	user: string
 	system: string
 	name: string
+	/** Optional container name for ContainerHealth alerts */
+	container?: string
 	val: number
 	created: string
 	resolved?: string | null


### PR DESCRIPTION
Add a new "ContainerHealth" alert type that fires when a container has been unhealthy for longer than a configured number of minutes. Alerts can target a specific container or any container on a system, and can be applied to one system or all systems (any-container only) like existing alert types.

Container health is already collected by the agent and available in CombinedData when alerts are evaluated, so no agent changes are needed. Duration is tracked in-memory and evaluated on each metrics push.

- alerts: new `container` field (empty = any); unique index extended to (user, system, name, container) so any + per-container alerts coexist
- alerts_history: `container` field to disambiguate per-container events
- HandleContainerAlerts evaluates per-container and any-container modes
- UpsertUserAlerts/DeleteUserAlerts accept `container`
- UI: "All Containers" card plus a searchable per-container list (single system); global tab shows any-container only
- store keys ContainerHealth alerts by name:container composite

## 📃 Description

A short description of the pull request changes should go here and the sections below should list in detail all changes. You can remove the sections you don't need.

## 📖 Documentation

Add a link to the PR for [documentation](https://github.com/henrygd/beszel-docs) changes.

## 🪵 Changelog

### ➕ Added

- one
- two

### ✏️ Changed

- one
- two

### 🔧 Fixed

- one
- two

### 🗑️ Removed

- one
- two

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.
