### PR TITLE
Show GPU VRAM usage on dashboard overview

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -220,6 +220,8 @@ func (a *Agent) getSystemStats(cacheTimeMs uint16) system.Stats {
 	if a.gpuManager != nil {
 		// reset high gpu percent
 		a.systemInfo.GpuPct = 0
+		a.systemInfo.GpuMemUsed = 0
+		a.systemInfo.GpuMemTotal = 0
 		// get current GPU data
 		if gpuData := a.gpuManager.GetCurrentData(cacheTimeMs); len(gpuData) > 0 {
 			systemStats.GPUData = gpuData
@@ -241,6 +243,10 @@ func (a *Agent) getSystemStats(cacheTimeMs uint16) system.Stats {
 				}
 				// update high gpu percent for dashboard
 				a.systemInfo.GpuPct = max(a.systemInfo.GpuPct, gpu.Usage)
+				if gpu.MemoryUsed > 0 {
+					a.systemInfo.GpuMemUsed = max(a.systemInfo.GpuMemUsed, gpu.MemoryUsed)
+					a.systemInfo.GpuMemTotal = max(a.systemInfo.GpuMemTotal, gpu.MemoryTotal)
+				}
 			}
 			// use highest temp for dashboard temp if dashboard temp is unset
 			if a.systemInfo.DashboardTemp == 0 {

--- a/internal/entities/system/system.go
+++ b/internal/entities/system/system.go
@@ -143,6 +143,8 @@ type Info struct {
 	AgentVersion  string  `json:"v" cbor:"10,keyasint"`
 	Podman        bool    `json:"p,omitempty" cbor:"11,keyasint,omitempty"` // deprecated - moved to Details struct
 	GpuPct        float64 `json:"g,omitempty" cbor:"12,keyasint,omitempty"`
+	GpuMemUsed    float64 `json:"gm,omitempty" cbor:'24,keyasint,omitempty"`
+	GpuMemTotal   float64 `json:"gmt,omitempty" cbor:'25,keyasint,omitempty"`
 	DashboardTemp float64 `json:"dt,omitempty" cbor:"13,keyasint,omitempty"`
 	Os            Os      `json:"os,omitempty" cbor:"14,keyasint,omitempty"` // deprecated - moved to Details struct
 	// LoadAvg1       float64 `json:"l1,omitempty" cbor:"15,keyasint,omitempty"`  // deprecated - use `la` array instead

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -201,6 +201,17 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 			header: sortableHeader,
 		},
 		{
+			accessorFn: ({ info }) => {
+				if (!info.gm || !info.gmt) return undefined
+				return (info.gm / info.gmt) * 100
+			},
+			id: "gpuMem",
+			name: () => "VRAM",
+			cell: TableCellWithMeter,
+			Icon: GpuIcon,
+			header: sortableHeader,
+		},
+		{
 			id: "loadAverage",
 			accessorFn: ({ info }) => info.la?.reduce((acc, curr) => acc + curr, 0),
 			name: () => t({ message: "Load Avg", comment: "Short label for load average" }),

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -68,6 +68,10 @@ export interface SystemInfo {
 	p?: boolean
 	/** highest gpu utilization */
 	g?: number
+	/** gpu memory used (mb) */
+	gm?: number
+	/** gpu memory total (mb) */
+	gmt?: number
 	/** dashboard display temperature */
 	dt?: number
 	/** operating system */


### PR DESCRIPTION





📃 Description

Adds GPU VRAM usage as a visible metric on the dashboard overview. Currently the dashboard shows GPU utilization (compute) but not memory consumption, which is critical for ML workloads.

📖 Documentation
No documentation changes needed.

🪵 Changelog

➕ Added
- GpuMemUsed and GpuMemTotal fields to system.Info struct
- Agent now populates VRAM data from GPUData into Info
- New "VRAM" column on dashboard overview showing GPU memory usage percentage

✏️ Changed
- None



🔧 Fixed
- None

🗑️ Removed
- None

📷 Screenshots
<img width="950" height="125" alt="beszel screenshot" src="https://github.com/user-attachments/assets/2beb450d-d49a-4587-af76-a4dc5f337860" />