### PR TITLE
fix(agent): preserve extra filesystems with different block devices

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/henrygd/beszel/agent/utils"
 	"github.com/henrygd/beszel/internal/common"
 	"github.com/henrygd/beszel/internal/entities/system"
+	"github.com/shirou/gopsutil/v4/disk"
 	gossh "golang.org/x/crypto/ssh"
 )
 
@@ -28,6 +29,7 @@ type Agent struct {
 	memCalc                   string                                                // Memory calculation formula
 	fsNames                   []string                                              // List of filesystem device names being monitored
 	fsStats                   map[string]*system.FsStats                            // Keeps track of disk stats for each filesystem
+    partitions                []disk.PartitionStat                                  // Disk partitions for device lookup
 	diskPrev                  map[uint16]map[string]prevDisk                        // Previous disk I/O counters per cache interval
 	diskUsageCacheDuration    time.Duration                                         // How long to cache disk usage (to avoid waking sleeping disks)
 	lastDiskUsageUpdate       time.Time                                             // Last time disk usage was collected

--- a/agent/disk.go
+++ b/agent/disk.go
@@ -304,11 +304,12 @@ func (a *Agent) initializeDiskInfo() {
 	hasRoot := false
 	isWindows := runtime.GOOS == "windows"
 
-	partitions, err := disk.PartitionsWithContext(context.Background(), true)
-	if err != nil {
-		slog.Error("Error getting disk partitions", "err", err)
-	}
-	slog.Debug("Disk", "partitions", partitions)
+    partitions, err := disk.PartitionsWithContext(context.Background(), true)
+    if err != nil {
+            slog.Error("Error getting disk partitions", "err", err)
+    }
+    a.partitions = partitions  // <-- NEU: Speichere partitions im Agent
+    slog.Debug("Disk", "partitions", partitions)
 
 	// trim trailing backslash for Windows devices (#1361)
 	if isWindows {
@@ -377,29 +378,88 @@ func (a *Agent) initializeDiskInfo() {
 // Removes extra filesystems that mirror root usage (https://github.com/henrygd/beszel/issues/1428).
 func (a *Agent) pruneDuplicateRootExtraFilesystems() {
 	var rootMountpoint string
+	var rootDevice string
 	for _, stats := range a.fsStats {
 		if stats != nil && stats.Root {
 			rootMountpoint = stats.Mountpoint
+			for _, p := range a.partitions {
+				if p.Mountpoint == rootMountpoint {
+					rootDevice = p.Device
+					break
+				}
+			}
 			break
 		}
 	}
 	if rootMountpoint == "" {
 		return
 	}
-	rootUsage, err := disk.Usage(rootMountpoint)
-	if err != nil {
-		return
+
+	// Build map of extra-filesystem names to their real mountpoints
+	extraFsMountpoints := make(map[string]string)
+	for _, p := range a.partitions {
+		if strings.HasPrefix(p.Mountpoint, "/mnt/") || strings.HasPrefix(p.Mountpoint, "/home") || strings.HasPrefix(p.Mountpoint, "/boot") {
+			for name, stats := range a.fsStats {
+				if stats == nil || stats.Root {
+					continue
+				}
+				if p.Device == stats.Mountpoint || p.Mountpoint == stats.Mountpoint {
+					extraFsMountpoints[name] = p.Mountpoint
+				}
+			}
+		}
 	}
+
 	for name, stats := range a.fsStats {
 		if stats == nil || stats.Root {
 			continue
 		}
-		extraUsage, err := disk.Usage(stats.Mountpoint)
-		if err != nil {
+		for _, p := range a.partitions {
+			if p.Mountpoint == stats.Mountpoint {
+				extraFsMountpoints[name] = p.Mountpoint
+				break
+			}
+			if strings.HasSuffix(p.Mountpoint, "/"+name) {
+				extraFsMountpoints[name] = p.Mountpoint
+				break
+			}
+		}
+	}
+
+	for name, stats := range a.fsStats {
+		if stats == nil || stats.Root {
 			continue
 		}
-		if hasSameDiskUsage(rootUsage, extraUsage) {
-			slog.Info("Ignoring duplicate FS", "name", name, "mount", stats.Mountpoint)
+
+		realMountpoint, ok := extraFsMountpoints[name]
+		if !ok {
+			lowerName := strings.ToLower(name)
+			for _, p := range a.partitions {
+				if strings.HasSuffix(p.Mountpoint, "/"+lowerName) ||
+					strings.Contains(p.Mountpoint, lowerName) {
+					realMountpoint = p.Mountpoint
+					break
+				}
+			}
+		}
+
+		var extraDevice string
+		if realMountpoint != "" {
+			for _, p := range a.partitions {
+				if p.Mountpoint == realMountpoint {
+					extraDevice = p.Device
+					break
+				}
+			}
+		}
+
+		if rootDevice != "" && extraDevice != "" && rootDevice != extraDevice {
+			continue
+		}
+
+		rootUsage := a.diskUsage(rootMountpoint)
+		candidateUsage := a.diskUsage(stats.Mountpoint)
+		if rootUsage == candidateUsage && rootUsage > 0 {
 			delete(a.fsStats, name)
 		}
 	}
@@ -742,4 +802,14 @@ func (a *Agent) getRootMountPoint() string {
 	}
 
 	return "/"
+}
+
+// diskUsage returns the disk usage for a given path
+func (a *Agent) diskUsage(path string) uint64 {
+        usage, err := disk.Usage(path)
+        if err != nil {
+                slog.Error("Error getting disk usage", "path", path, "error", err)
+                return 0
+        }
+        return usage.Used
 }


### PR DESCRIPTION
## Problem
Extra filesystems (EXTRA_FILESYSTEMS) are incorrectly identified as duplicates
when their disk usage matches the root filesystem inside the container.

This happens because the agent compares disk usage bytes between root and
extra filesystems while running inside a Docker container. When the Docker
Root Dir is on the same partition as an extra filesystem, the usage numbers
coincidentally match and the extra filesystem gets wrongly deleted.

## Solution
Compare the actual block device names (e.g. /dev/nvme0n1p6) instead of
relying on disk usage. The agent now:
1. Gets the real device name for root from partitions
2. Gets the real device name for each extra filesystem from partitions
3. Keeps the extra filesystem if the device names differ

## Testing
- Verified with multiple extra filesystems on different block devices:
  - /boot (/dev/nvme0n1p2)
  - /home (/dev/nvme0n1p5)
  - /mnt/data (/dev/nvme0n1p6)
  - /mnt/backup (/dev/sda1)
- Confirmed that legitimate duplicates are still pruned
- No regression observed

Fixes #2103