### PR TITLE
feat(hub): add containers column to systems overview

### DIFF
--- a/internal/entities/system/system.go
+++ b/internal/entities/system/system.go
@@ -155,6 +155,7 @@ type Info struct {
 	ExtraFsPct     map[string]float64 `json:"efs,omitempty" cbor:"21,keyasint,omitempty"`
 	Services       []uint16           `json:"sv,omitempty" cbor:"22,keyasint,omitempty"` // [totalServices, numFailedServices]
 	Battery        [2]uint8           `json:"bat,omitzero" cbor:"23,keyasint,omitzero"`  // [percent, charge state]
+	Containers     []uint16           `json:"cn,omitempty" cbor:"24,keyasint,omitempty"` // [totalContainers, numUnhealthyContainers]
 }
 
 // Data that does not change during process lifetime and is not needed in All Systems table

--- a/internal/hub/systems/system.go
+++ b/internal/hub/systems/system.go
@@ -240,6 +240,7 @@ func (sys *System) createRecords(data *system.CombinedData) (*core.Record, error
 
 		// update system record (do this last because it triggers alerts and we need above records to be inserted first)
 		systemRecord.Set("status", up)
+		data.Info.Containers = getContainerCounts(data.Containers)
 		systemRecord.Set("info", data.Info)
 		if err := txApp.SaveNoValidate(systemRecord); err != nil {
 			return err
@@ -248,6 +249,19 @@ func (sys *System) createRecords(data *system.CombinedData) (*core.Record, error
 	})
 
 	return systemRecord, err
+}
+
+func getContainerCounts(stats []*container.Stats) []uint16 {
+	if len(stats) == 0 {
+		return nil
+	}
+	unhealthy := uint16(0)
+	for _, stat := range stats {
+		if stat.Health == container.DockerHealthUnhealthy {
+			unhealthy++
+		}
+	}
+	return []uint16{uint16(len(stats)), unhealthy}
 }
 
 func createSystemDetailsRecord(app core.App, data *system.Details, systemId string) error {

--- a/internal/hub/systems/system_test.go
+++ b/internal/hub/systems/system_test.go
@@ -5,8 +5,47 @@ package systems
 import (
 	"testing"
 
+	"github.com/henrygd/beszel/internal/entities/container"
 	"github.com/henrygd/beszel/internal/entities/system"
 )
+
+func TestGetContainerCounts(t *testing.T) {
+	tests := []struct {
+		name     string
+		stats    []*container.Stats
+		expected []uint16
+	}{
+		{
+			name:     "no containers",
+			stats:    nil,
+			expected: nil,
+		},
+		{
+			name: "counts total and unhealthy containers",
+			stats: []*container.Stats{
+				{Health: container.DockerHealthHealthy},
+				{Health: container.DockerHealthUnhealthy},
+				{Health: container.DockerHealthNone},
+				{Health: container.DockerHealthUnhealthy},
+			},
+			expected: []uint16{4, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getContainerCounts(tt.stats)
+			if len(got) != len(tt.expected) {
+				t.Fatalf("expected %v, got %v", tt.expected, got)
+			}
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Fatalf("expected %v, got %v", tt.expected, got)
+				}
+			}
+		})
+	}
+}
 
 func TestCombinedData_MigrateDeprecatedFields(t *testing.T) {
 	t.Run("Migrate NetworkSent and NetworkRecv to Bandwidth", func(t *testing.T) {

--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -9,6 +9,7 @@ import {
 	ArrowUpDownIcon,
 	ChevronRightSquareIcon,
 	ClockArrowUp,
+	ContainerIcon,
 	CopyIcon,
 	CpuIcon,
 	HardDriveIcon,
@@ -25,7 +26,15 @@ import {
 import { memo, useMemo, useRef, useState } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip"
 import { isReadOnlyUser, pb } from "@/lib/api"
-import { BatteryState, ConnectionType, connectionTypeLabels, MeterState, SystemStatus } from "@/lib/enums"
+import {
+	BatteryState,
+	ConnectionType,
+	connectionTypeLabels,
+	ContainerHealth,
+	ContainerHealthLabels,
+	MeterState,
+	SystemStatus,
+} from "@/lib/enums"
 import { $longestSystemNameLen, $userSettings } from "@/lib/stores"
 import {
 	cn,
@@ -325,6 +334,45 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 						<Icon className={cn("size-3.5", iconColor)} />
 						<span className="min-w-10">{pct}%</span>
 					</Link>
+				)
+			},
+		},
+		{
+			accessorFn: ({ info }) => info.cn?.[0],
+			id: "containers",
+			name: () => t`Containers`,
+			size: 50,
+			Icon: ContainerIcon,
+			header: sortableHeader,
+			hideSort: true,
+			sortingFn: (a, b) => {
+				// sort priorities: 1) unhealthy containers, 2) total containers
+				const [totalCountA, numUnhealthyA] = a.original.info.cn ?? [0, 0]
+				const [totalCountB, numUnhealthyB] = b.original.info.cn ?? [0, 0]
+				if (numUnhealthyA !== numUnhealthyB) {
+					return numUnhealthyA - numUnhealthyB
+				}
+				return totalCountA - totalCountB
+			},
+			cell(info) {
+				const sys = info.row.original
+				const [totalCount, numUnhealthy] = sys.info.cn ?? [0, 0]
+				if (sys.status !== SystemStatus.Up || totalCount === 0) {
+					return null
+				}
+				return (
+					<span className="tabular-nums whitespace-nowrap flex gap-1.5 items-center">
+						<span
+							className={cn("block size-2 rounded-full", {
+								[STATUS_COLORS[SystemStatus.Down]]: numUnhealthy > 0,
+								[STATUS_COLORS[SystemStatus.Up]]: numUnhealthy === 0,
+							})}
+						/>
+						{totalCount}{" "}
+						<span className="text-muted-foreground text-sm -ms-0.5">
+							({ContainerHealthLabels[ContainerHealth.Unhealthy].toLowerCase()}: {numUnhealthy})
+						</span>
+					</span>
 				)
 			},
 		},

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -78,6 +78,8 @@ export interface SystemInfo {
 	efs?: Record<string, number>
 	/** services [totalServices, numFailedServices] */
 	sv?: [number, number]
+	/** containers [totalContainers, numUnhealthyContainers] */
+	cn?: [number, number]
 }
 
 export interface SystemStats {


### PR DESCRIPTION
## 📃 Description

This closes #2124.

It adds a new `Containers` column to the systems overview page.

I've added a new `Containers` item (json: `"cn": [totalContainers, numUnhealthyContainers]`) to the `systems/records` response. There are tests for this and all translation keys could be reused.

## 📷 Screenshot

Here's how this looks:

<img width="1972" height="1090" alt="SCR-20260708-rzxw-2" src="https://github.com/user-attachments/assets/0e848e37-4461-44c1-b9d4-bbb9da65d41d" />


<img width="582" height="460" alt="image" src="https://github.com/user-attachments/assets/7a435742-7eda-4aa0-a415-276d73bf8cc7" />

This is from an instance where I already run this change via `jk779/beszel:feature-containers-overview`.