### PR TITLE
agent: Add mDNS resolution support for .local hostnames [WIP]

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -13,11 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/henrygd/beszel"
 	"github.com/henrygd/beszel/agent/utils"
 	"github.com/henrygd/beszel/internal/common"
-
-	"github.com/fxamacker/cbor/v2"
 	"github.com/lxzan/gws"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/proxy"
@@ -105,13 +104,38 @@ func (client *WebSocketClient) getOptions() *gws.ClientOption {
 	}
 	client.hubURL.Path = path.Join(client.hubURL.Path, "api/beszel/agent-connect")
 
+	// Resolve .local (mDNS) hostnames to IP addresses before passing to gws.
+	// Go's native DNS resolver (used when CGO_ENABLED=0) doesn't support mDNS,
+	// so we handle this explicitly here.
+	var wsAddress string
+	switch hostname := client.hubURL.Hostname(); strings.HasSuffix(hostname, ".local") {
+	case true:
+		slog.Debug("Attempting mDNS resolution", "hostname", hostname)
+		resolvedIP, err := mDnsResolve(hostname)
+		if err == nil {
+			// Replace the hostname with the resolved IP in the address string.
+			// The original client.hubURL is kept unchanged for logging purposes.
+			resolvedURL := *client.hubURL
+			resolvedURL.Host = net.JoinHostPort(resolvedIP, client.hubURL.Port())
+			wsAddress = resolvedURL.String()
+			slog.Info("Resolved mDNS hostname", "host", hostname, "ip", resolvedIP)
+			break
+		} else {
+			slog.Warn("Failed to resolve mDNS hostname, will attempt connection anyway", "host", hostname, "err", err)
+		}
+		fallthrough
+	case false:
+		wsAddress = client.hubURL.String()
+	}
+	slog.Info("Effective WebSocket address", "addr", wsAddress)
+
 	// make sure BESZEL_AGENT_ALL_PROXY works (GWS only checks ALL_PROXY)
 	if val := os.Getenv("BESZEL_AGENT_ALL_PROXY"); val != "" {
 		os.Setenv("ALL_PROXY", val)
 	}
 
 	client.options = &gws.ClientOption{
-		Addr:      client.hubURL.String(),
+		Addr:      wsAddress,
 		TlsConfig: &tls.Config{InsecureSkipVerify: true},
 		RequestHeader: http.Header{
 			"User-Agent": []string{getUserAgent()},

--- a/agent/mdns.go
+++ b/agent/mdns.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/net/dns/dnsmessage"
+)
+
+const MdnsTimeout = 5 * time.Second
+
+var multicastAddress = net.UDPAddr{IP: net.IPv4(224, 0, 0, 251), Port: 5353}
+
+// mDnsResolve resolves a .local (mDNS) hostname to an IPv4 address. It sends a raw
+// DNS A-record query to the mDNS multicast address (224.0.0.251:5353) and
+// returns the first matching IPv4 address.
+func mDnsResolve(host string) (string, error) {
+	// Build an A-record DNS query using the standard message library
+	packed, err := new(dnsmessage.Message{
+		Header: dnsmessage.Header{ID: 0, Response: false},
+		Questions: []dnsmessage.Question{{
+			Name:  dnsmessage.MustNewName(host + "."),
+			Type:  dnsmessage.TypeA,
+			Class: dnsmessage.ClassINET,
+		}},
+	}).Pack()
+	if err != nil {
+		return "", fmt.Errorf("mDNS: failed to pack query: %w", err)
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: 0})
+	if err != nil {
+		return "", fmt.Errorf("mDNS: failed to create UDP socket: %w", err)
+	}
+	defer conn.Close()
+	if _, err := conn.WriteTo(packed, &multicastAddress); err != nil {
+		return "", fmt.Errorf("mDNS: failed to send query: %w", err)
+	} else if err := conn.SetReadDeadline(time.Now().Add(MdnsTimeout)); err != nil {
+		return "", fmt.Errorf("mDNS: failed to set deadline: %w", err)
+	}
+	for buffer := [1500]byte{}; ; {
+		count, _, err := conn.ReadFromUDP(buffer[:])
+		if err != nil {
+			break
+		}
+		var message dnsmessage.Message
+		if err := message.Unpack(buffer[:count]); err != nil {
+			continue
+		}
+		for _, answer := range message.Answers {
+			if answer.Header.Name.String() == host+"." && answer.Header.Type == dnsmessage.TypeA {
+				if aBody, ok := answer.Body.(*dnsmessage.AResource); ok {
+					return net.IP(aBody.A[:]).String(), nil
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("mDNS: no A record found for %s", host)
+}


### PR DESCRIPTION
## 📃 Description

Add the ability for agent's websocket client to resolve the mDNS `.local` address to IPv4.

Hostname that end with `.local` are specifically reserved to use with mDNS, so theoretically doesn't affect anything.

WARNING: WIP, current status is "WORK ON MY MACHINE".

WARNING: Security not verified, and seem like not ready for now: `mDnsResolve` can easily be tricked to connect to different IPv4. (And the fact that the websocket client *does not* force TLS and also *does not* check for server certificate make this worse).

Ref: https://github.com/henrygd/beszel/issues/353

## 📖 Documentation

TODO: Add a link to the PR for [documentation](https://github.com/henrygd/beszel-docs) changes.

## 🪵 Changelog

### ➕ Added

- `func mDnsResolve(host string) (string, error)`

### ✏️ Changed

- `func (client *WebSocketClient) getOptions() *gws.ClientOption`
- two
