### PR TITLE
feat(ui): persist theme preference in user settings

### DIFF
--- a/internal/site/src/components/routes/settings/layout.tsx
+++ b/internal/site/src/components/routes/settings/layout.tsx
@@ -14,7 +14,7 @@ import { lazy, useEffect } from "react"
 import { $router } from "@/components/router.tsx"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card.tsx"
 import { toast } from "@/components/ui/use-toast.ts"
-import { pb } from "@/lib/api"
+import { saveUserSettings } from "@/lib/api"
 import { $userSettings } from "@/lib/stores.ts"
 import type { UserSettings } from "@/types"
 import { Separator } from "../../ui/separator"
@@ -36,18 +36,7 @@ const HeartbeatSettings = lazy(heartbeatSettingsImport)
 
 export async function saveSettings(newSettings: Partial<UserSettings>) {
 	try {
-		// get fresh copy of settings
-		const req = await pb.collection("user_settings").getFirstListItem("", {
-			fields: "id,settings",
-		})
-		// update user settings
-		const updatedSettings = await pb.collection("user_settings").update(req.id, {
-			settings: {
-				...req.settings,
-				...newSettings,
-			},
-		})
-		$userSettings.set(updatedSettings.settings)
+		await saveUserSettings(newSettings)
 		toast({
 			title: t`Settings saved`,
 			description: t`Your user settings have been updated.`,

--- a/internal/site/src/components/theme-provider.tsx
+++ b/internal/site/src/components/theme-provider.tsx
@@ -1,6 +1,10 @@
+import { useStore } from "@nanostores/react"
 import { createContext, useContext, useEffect, useState } from "react"
+import { pb, saveUserSettings } from "@/lib/api"
+import { $userSettings } from "@/lib/stores"
+import { THEME_STORAGE_KEY } from "@/lib/utils"
 
-type Theme = "dark" | "light" | "system"
+export type Theme = "dark" | "light" | "system"
 
 type ThemeProviderProps = {
 	children: React.ReactNode
@@ -23,10 +27,11 @@ const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
 export function ThemeProvider({
 	children,
 	defaultTheme = "system",
-	storageKey = "ui-theme",
+	storageKey = THEME_STORAGE_KEY,
 	...props
 }: ThemeProviderProps) {
 	const [theme, setTheme] = useState<Theme>(() => (localStorage.getItem(storageKey) as Theme) || defaultTheme)
+	const { theme: savedTheme } = useStore($userSettings, { keys: ["theme"] })
 
 	useEffect(() => {
 		const root = window.document.documentElement
@@ -43,11 +48,25 @@ export function ThemeProvider({
 		root.classList.add(theme)
 	}, [theme])
 
+	// an undefined value is ignored so logging out, which clears user settings,
+	// doesn't reset the theme
+	useEffect(() => {
+		if (savedTheme && savedTheme !== theme) {
+			localStorage.setItem(storageKey, savedTheme)
+			setTheme(savedTheme)
+		}
+	}, [savedTheme])
+
 	const value = {
 		theme,
 		setTheme: (theme: Theme) => {
 			localStorage.setItem(storageKey, theme)
 			setTheme(theme)
+			// local storage alone is lost in private windows and on other devices
+			if (pb.authStore.isValid) {
+				$userSettings.setKey("theme", theme)
+				saveUserSettings({ theme }).catch((e) => console.error("save theme", e))
+			}
 		},
 	}
 

--- a/internal/site/src/lib/api.ts
+++ b/internal/site/src/lib/api.ts
@@ -4,7 +4,7 @@ import { basePath } from "@/components/router"
 import { toast } from "@/components/ui/use-toast"
 import type { ChartTimes, UserSettings } from "@/types"
 import { $alerts, $allSystemsById, $allSystemsByName, $userSettings } from "./stores"
-import { chartTimeData } from "./utils"
+import { chartTimeData, THEME_STORAGE_KEY } from "./utils"
 
 /** PocketBase JS Client */
 export const pb = new PocketBase(basePath)
@@ -41,6 +41,7 @@ export async function updateUserSettings() {
 	try {
 		const req = await pb.collection("user_settings").getFirstListItem("", { fields: "settings" })
 		$userSettings.set(req.settings)
+		backfillTheme(req.settings)
 		return
 	} catch (e) {
 		console.error("get settings", e)
@@ -49,8 +50,34 @@ export async function updateUserSettings() {
 	try {
 		const createdSettings = await pb.collection("user_settings").create({ user: pb.authStore.record?.id })
 		$userSettings.set(createdSettings.settings)
+		backfillTheme(createdSettings.settings)
 	} catch (e) {
 		console.error("create settings", e)
+	}
+}
+
+/** Save a partial update to user settings in database */
+export async function saveUserSettings(newSettings: Partial<UserSettings>) {
+	// get fresh copy of settings so concurrent changes aren't overwritten
+	const req = await pb.collection("user_settings").getFirstListItem("", { fields: "id,settings" })
+	const updatedSettings = await pb.collection("user_settings").update(req.id, {
+		settings: {
+			...req.settings,
+			...newSettings,
+		},
+	})
+	$userSettings.set(updatedSettings.settings)
+}
+
+/** Users who set a theme before it was stored in the database only have it in
+ *  local storage, so seed the database from it once to avoid losing their choice. */
+function backfillTheme(settings: UserSettings) {
+	if (settings?.theme) {
+		return
+	}
+	const localTheme = localStorage.getItem(THEME_STORAGE_KEY) as UserSettings["theme"]
+	if (localTheme && localTheme !== "system") {
+		saveUserSettings({ theme: localTheme }).catch((e) => console.error("backfill theme", e))
 	}
 }
 

--- a/internal/site/src/lib/api.ts
+++ b/internal/site/src/lib/api.ts
@@ -4,7 +4,7 @@ import { basePath } from "@/components/router"
 import { toast } from "@/components/ui/use-toast"
 import type { ChartTimes, UserSettings } from "@/types"
 import { $alerts, $allSystemsById, $allSystemsByName, $userSettings } from "./stores"
-import { chartTimeData, debounce } from "./utils"
+import { chartTimeData, debounce, THEME_STORAGE_KEY } from "./utils"
 
 /** PocketBase JS Client */
 export const pb = new PocketBase(basePath)
@@ -57,6 +57,7 @@ export async function updateUserSettings() {
 	try {
 		const req = await pb.collection("user_settings").getFirstListItem("", { fields: "settings" })
 		$userSettings.set(req.settings)
+		backfillTheme(req.settings)
 		return
 	} catch (e) {
 		console.error("get settings", e)
@@ -65,8 +66,34 @@ export async function updateUserSettings() {
 	try {
 		const createdSettings = await pb.collection("user_settings").create({ user: pb.authStore.record?.id })
 		$userSettings.set(createdSettings.settings)
+		backfillTheme(createdSettings.settings)
 	} catch (e) {
 		console.error("create settings", e)
+	}
+}
+
+/** Save a partial update to user settings in database */
+export async function saveUserSettings(newSettings: Partial<UserSettings>) {
+	// get fresh copy of settings so concurrent changes aren't overwritten
+	const req = await pb.collection("user_settings").getFirstListItem("", { fields: "id,settings" })
+	const updatedSettings = await pb.collection("user_settings").update(req.id, {
+		settings: {
+			...req.settings,
+			...newSettings,
+		},
+	})
+	$userSettings.set(updatedSettings.settings)
+}
+
+/** Users who set a theme before it was stored in the database only have it in
+ *  local storage, so seed the database from it once to avoid losing their choice. */
+function backfillTheme(settings: UserSettings) {
+	if (settings?.theme) {
+		return
+	}
+	const localTheme = localStorage.getItem(THEME_STORAGE_KEY) as UserSettings["theme"]
+	if (localTheme && localTheme !== "system") {
+		saveUserSettings({ theme: localTheme }).catch((e) => console.error("backfill theme", e))
 	}
 }
 

--- a/internal/site/src/lib/utils.ts
+++ b/internal/site/src/lib/utils.ts
@@ -198,6 +198,9 @@ export function decimalString(num: number, digits = 2) {
 	return formatter.format(num)
 }
 
+/** Must match the inline theme script in index.html, which runs before React mounts. */
+export const THEME_STORAGE_KEY = "ui-theme"
+
 /** Get value from local or session storage */
 function getStorageValue(key: string, defaultValue: unknown, storageInterface: Storage = localStorage) {
 	const saved = storageInterface?.getItem(key)

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -1,4 +1,5 @@
 import type { RecordModel } from "pocketbase"
+import type { Theme } from "@/components/theme-provider"
 import type { Unit, Os, BatteryState, HourFormat, ConnectionType, ServiceStatus, ServiceSubState } from "@/lib/enums"
 
 // global window properties
@@ -361,6 +362,7 @@ export interface UserSettings {
 	colorCrit?: number
 	hourFormat?: HourFormat
 	layoutWidth?: number
+	theme?: Theme
 }
 
 type ChartDataContainer = {

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -1,4 +1,5 @@
 import type { RecordModel } from "pocketbase"
+import type { Theme } from "@/components/theme-provider"
 import type { Unit, Os, BatteryState, HourFormat, ConnectionType, ServiceStatus, ServiceSubState } from "@/lib/enums"
 
 // global window properties
@@ -297,6 +298,7 @@ export interface UserSettings {
 	colorCrit?: number
 	hourFormat?: HourFormat
 	layoutWidth?: number
+	theme?: Theme
 }
 
 type ChartDataContainer = {


### PR DESCRIPTION
## 📃 Description

Addresses the theme half of #2142.

The theme was only stored in `localStorage`, so it was lost in private windows, on other devices, and after clearing site data. It is now persisted to `user_settings` alongside the other display preferences, so it follows the account after login.

`localStorage` is still written, because the inline script in `index.html` needs it to set the theme class before React mounts, and because the toggle has to keep working on the login page where there is no account yet.

No migration is needed — `user_settings.settings` is a free-form JSON field.

Rebased onto current `main`. The only conflict was the `./utils` import in `lib/api.ts`, which #2310 had also touched; resolved to `{ chartTimeData, debounce, THEME_STORAGE_KEY }`.

A few details worth flagging for review:

- The stored value is only applied when it is defined, so logging out (which resets user settings) does not reset the theme.
- Users who already picked a theme get it copied to the database once on load, so an existing preference is not silently lost.
- `saveSettings` in the settings layout is now a toast wrapper around a new `saveUserSettings` in `lib/api.ts`. The toggle needs to save without a toast, and importing from the lazily loaded settings route would have pulled it into the main bundle.

## On verification

There are no automated tests covering this, and the behaviour it exists for — surviving a private window or a different device — cannot be checked from the source alone, so I ran it against a real hub build and checked each path end to end:

| scenario | result |
| --- | --- |
| toggle the theme in the UI | `"theme": "light"` written to `user_settings` |
| empty `localStorage` + valid session (new device, private window) | theme read from the database, applied, and written back to `localStorage` |
| theme only in `localStorage`, absent from the database (pre-existing user) | database seeded once from the local value; the choice is not lost |
| log out | theme retained, confirming the `undefined` guard behaves as intended |

One caveat I should flag rather than leave to be discovered: with an empty `localStorage` there is a brief flash of the default theme before `user_settings` arrives over the network. The inline script in `index.html` runs before there is anything to read, so this is inherent to fetching the preference remotely rather than something introduced here — but it is visible, and worth knowing about. Writing back to `localStorage` means it only happens on the first load on a given device.

Note: `internal/site/package.json` has no `check`/`check:fix` script, so I ran the local Biome binary directly over the touched files, plus the full `bun run build`. Biome reports a formatter error in `lib/utils.ts` (the favicon SVG, lines 112-126) and an ineffective `biome-ignore` in `settings/layout.tsx:100`; both reproduce on an unmodified `main` and are untouched here. `lingui extract` produced no catalog changes.

## 🪵 Changelog

### ➕ Added

- Theme preference is saved to user settings, so it persists in private windows and across browsers.
