### PR TITLE
Fixes redirect-based OAuth login when OAUTH_DISABLE_POPUP=true is set

### DIFF
--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -176,7 +176,7 @@ export function UserAuthForm({
 	function redirectToOauthProvider(provider: AuthProviderInfo) {
 		const url = new URL(provider.authURL)
 		url.searchParams.set("redirect_uri", `${window.location.origin}${basePath}`)
-		sessionStorage.setItem("provider", JSON.stringify(provider))
+		localStorage.setItem("provider", JSON.stringify(provider))
 		window.location.href = url.toString()
 	}
 
@@ -186,12 +186,13 @@ export function UserAuthForm({
 		const code = params.get("code")
 		if (code) {
 			const state = params.get("state")
-			const provider: AuthProviderInfo = JSON.parse(sessionStorage.getItem("provider") ?? "{}")
+			const provider: AuthProviderInfo = JSON.parse(localStorage.getItem("provider") ?? "{}")
+		    localStorage.removeItem("provider")
+			window.history.replaceState({}, "", window.location.pathname)
 			if (!state || provider.state !== state) {
 				showLoginFaliedToast()
 			} else {
 				setIsOauthLoading(true)
-				window.history.replaceState({}, "", window.location.pathname)
 				pb.collection("users")
 					.authWithOAuth2Code(provider.name, code, provider.codeVerifier, `${window.location.origin}${basePath}`)
 					.then(() => $authenticated.set(pb.authStore.isValid))

--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -175,7 +175,7 @@ export function UserAuthForm({
 	 */
 	function redirectToOauthProvider(provider: AuthProviderInfo) {
 		const url = new URL(provider.authURL)
-		// url.searchParams.set("redirect_uri", `${window.location.origin}${basePath}`)
+		url.searchParams.set("redirect_uri", `${window.location.origin}${basePath}`)
 		sessionStorage.setItem("provider", JSON.stringify(provider))
 		window.location.href = url.toString()
 	}


### PR DESCRIPTION
## 📃 Description

Fixes redirect-based OAuth login when `OAUTH_DISABLE_POPUP=true` is set. Two defects prevented the redirect flow from completing:

1. The required `redirect_uri` parameter was commented out of the OAuth authorization request, producing a malformed request and a `redirect_uri` mismatch at the code-exchange step.
2. The provider state (used for CSRF `state` verification and the PKCE `codeVerifier`), was persisted in `sessionStorage`, which is tab-scoped. When the OAuth callback is delivered in a new browsing context - as happens with e.g. Authelia - the stored provider is missing and state verification always fails.

Both changes are confined to `auth-form.tsx`.

Fixes #2170

## 📖 Documentation

N/A — no documentation changes required.

## 🪵 Changelog

### 🔧 Fixed

- Restore the required `redirect_uri` parameter on the OAuth authorization redirect URL so redirect-based login (`OAUTH_DISABLE_POPUP=true`) works.
Store OAuth redirect provider state in `localStorage` instead of `sessionStorage`, so the callback succeeds when delivered in a new browsing context.
Clean up the stored provider entry and strip the OAuth callback parameters from the URL on both the success and failure paths.

## 📷 Screenshots

N/A — no visual/UI changes.

