### PR TITLE
Add per-sensor temperature alert thresholds

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -74,6 +74,7 @@ type SystemAlertData struct {
 	count        uint8
 	min          uint8
 	mapSums      map[string]float32
+	mapCounts    map[string]uint8
 	descriptor   string // override descriptor in notification body (for temp sensor, disk partition, etc)
 }
 

--- a/internal/alerts/alerts_api.go
+++ b/internal/alerts/alerts_api.go
@@ -19,11 +19,12 @@ func UpsertUserAlerts(e *core.RequestEvent) error {
 	userID := e.Auth.Id
 
 	reqData := struct {
-		Min       uint8    `json:"min"`
-		Value     float64  `json:"value"`
-		Name      string   `json:"name"`
-		Systems   []string `json:"systems"`
-		Overwrite bool     `json:"overwrite"`
+		Min        uint8              `json:"min"`
+		Value      float64            `json:"value"`
+		Thresholds map[string]float64 `json:"thresholds"`
+		Name       string             `json:"name"`
+		Systems    []string           `json:"systems"`
+		Overwrite  bool               `json:"overwrite"`
 	}{}
 	err := e.BindBody(&reqData)
 	if err != nil || userID == "" || reqData.Name == "" || len(reqData.Systems) == 0 {
@@ -61,6 +62,9 @@ func UpsertUserAlerts(e *core.RequestEvent) error {
 
 			alertRecord.Set("value", reqData.Value)
 			alertRecord.Set("min", reqData.Min)
+			if reqData.Name == "Temperature" {
+				alertRecord.Set("thresholds", reqData.Thresholds)
+			}
 
 			if err := txApp.SaveNoValidate(alertRecord); err != nil {
 				return err

--- a/internal/alerts/alerts_api_test.go
+++ b/internal/alerts/alerts_api_test.go
@@ -191,6 +191,31 @@ func TestUserAlertsApi(t *testing.T) {
 			},
 		},
 		{
+			Name:   "POST temperature alert with per-sensor thresholds",
+			Method: http.MethodPost,
+			URL:    "/api/beszel/user-alerts",
+			Headers: map[string]string{
+				"Authorization": user1Token,
+			},
+			ExpectedStatus:  200,
+			ExpectedContent: []string{"\"success\":true"},
+			TestAppFactory:  testAppFactory,
+			Body: jsonReader(map[string]any{
+				"name":       "Temperature",
+				"systems":    []string{system1.Id},
+				"value":      80,
+				"thresholds": map[string]float64{"CPU Package": 85, "NVMe": 70},
+				"min":        10,
+			}),
+			AfterTestFunc: func(t testing.TB, app *pbTests.TestApp, res *http.Response) {
+				alert, err := app.FindFirstRecordByFilter("alerts", "name = 'Temperature' && user = {:user}", dbx.Params{"user": user1.Id})
+				assert.NoError(t, err)
+				var thresholds map[string]float64
+				assert.NoError(t, alert.UnmarshalJSONField("thresholds", &thresholds))
+				assert.Equal(t, map[string]float64{"CPU Package": 85, "NVMe": 70}, thresholds)
+			},
+		},
+		{
 			Name:   "Overwrite: false, should not overwrite existing alert",
 			Method: http.MethodPost,
 			URL:    "/api/beszel/user-alerts",

--- a/internal/alerts/alerts_cache.go
+++ b/internal/alerts/alerts_cache.go
@@ -8,13 +8,14 @@ import (
 
 // CachedAlertData represents the relevant fields of an alert record for status checking and updates.
 type CachedAlertData struct {
-	Id        string
-	SystemID  string
-	UserID    string
-	Name      string
-	Value     float64
-	Triggered bool
-	Min       uint8
+	Id         string
+	SystemID   string
+	UserID     string
+	Name       string
+	Value      float64
+	Thresholds map[string]float64
+	Triggered  bool
+	Min        uint8
 	// Created   types.DateTime
 }
 
@@ -24,6 +25,7 @@ func (a *CachedAlertData) PopulateFromRecord(record *core.Record) {
 	a.UserID = record.GetString("user")
 	a.Name = record.GetString("name")
 	a.Value = record.GetFloat("value")
+	_ = record.UnmarshalJSONField("thresholds", &a.Thresholds)
 	a.Triggered = record.GetBool("triggered")
 	a.Min = uint8(record.GetInt("min"))
 	// a.Created = record.GetDateTime("created")

--- a/internal/alerts/alerts_system.go
+++ b/internal/alerts/alerts_system.go
@@ -27,6 +27,8 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 		name := alertData.Name
 		var val float64
 		unit := "%"
+		threshold := alertData.Value
+		descriptor := ""
 
 		switch name {
 		case "CPU":
@@ -46,10 +48,16 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 			}
 			val = maxUsedPct
 		case "Temperature":
-			if data.Info.DashboardTemp < 1 {
+			var ok bool
+			val, threshold, descriptor, _, ok = selectTemperatureValue(
+				alertData.Thresholds,
+				data.Stats.Temperatures,
+				data.Info.DashboardTemp,
+				alertData.Value,
+			)
+			if !ok {
 				continue
 			}
-			val = data.Info.DashboardTemp
 			unit = "°C"
 		case "LoadAvg1":
 			val = data.Info.LoadAvg[0]
@@ -70,7 +78,6 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 		}
 
 		triggered := alertData.Triggered
-		threshold := alertData.Value
 
 		// Battery alert has inverted logic: trigger when value is BELOW threshold
 		lowAlert := isLowAlert(name)
@@ -99,6 +106,7 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 			threshold:    threshold,
 			triggered:    triggered,
 			min:          min,
+			descriptor:   descriptor,
 		}
 
 		// send alert immediately if min is 1 - no need to sum up values.
@@ -210,12 +218,19 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 			case "Temperature":
 				if alert.mapSums == nil {
 					alert.mapSums = make(map[string]float32, len(stats.Temperatures))
+					alert.mapCounts = make(map[string]uint8, len(stats.Temperatures))
 				}
 				for key, temp := range stats.Temperatures {
+					if len(alert.alertData.Thresholds) > 0 {
+						if _, selected := alert.alertData.Thresholds[key]; !selected {
+							continue
+						}
+					}
 					if _, ok := alert.mapSums[key]; !ok {
 						alert.mapSums[key] = float32(0)
 					}
 					alert.mapSums[key] += temp
+					alert.mapCounts[key]++
 				}
 			case "LoadAvg1":
 				alert.val += stats.LoadAvg[0]
@@ -244,6 +259,7 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 	}
 	// sum up vals for each alert
 	for _, alert := range validAlerts {
+		minCount := float32(alert.min) / 1.2
 		switch alert.name {
 		case "Disk":
 			maxPct := float32(0)
@@ -256,19 +272,30 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 			}
 			alert.val = float64(maxPct / float32(alert.count))
 		case "Temperature":
-			maxTemp := float32(0)
-			for key, value := range alert.mapSums {
-				sumTemp := float32(value) / float32(alert.count)
-				if sumTemp > maxTemp {
-					maxTemp = sumTemp
-					alert.descriptor = fmt.Sprintf("Highest sensor %s", key)
+			averages := make(map[string]float64, len(alert.mapSums))
+			for key, sum := range alert.mapSums {
+				count := alert.mapCounts[key]
+				if count == 0 || float32(count) < minCount {
+					continue
 				}
+				averages[key] = float64(sum) / float64(count)
 			}
-			alert.val = float64(maxTemp)
+			value, threshold, descriptor, sensor, ok := selectTemperatureValue(
+				alert.alertData.Thresholds,
+				averages,
+				0,
+				alert.alertData.Value,
+			)
+			if !ok {
+				continue
+			}
+			alert.val = value
+			alert.threshold = threshold
+			alert.descriptor = descriptor
+			alert.count = alert.mapCounts[sensor]
 		default:
 			alert.val = alert.val / float64(alert.count)
 		}
-		minCount := float32(alert.min) / 1.2
 		// log.Println("alert", alert.name, "val", alert.val, "threshold", alert.threshold, "triggered", alert.triggered)
 		// log.Printf("%s: val %f | count %d | min-count %f | threshold %f\n", alert.name, alert.val, alert.count, minCount, alert.threshold)
 		// pass through alert if count is greater than or equal to minCount
@@ -295,6 +322,51 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 		}
 	}
 	return nil
+}
+
+// selectTemperatureValue returns the temperature reading that determines the
+// aggregate alert state. With per-sensor thresholds, this is the sensor furthest
+// above its own threshold. Otherwise it is the hottest available sensor.
+func selectTemperatureValue(
+	thresholds map[string]float64,
+	temperatures map[string]float64,
+	fallback float64,
+	defaultThreshold float64,
+) (value float64, threshold float64, descriptor string, sensor string, ok bool) {
+	bestMargin := 0.0
+	for key, temp := range temperatures {
+		sensorThreshold := defaultThreshold
+		if len(thresholds) > 0 {
+			var selected bool
+			sensorThreshold, selected = thresholds[key]
+			if !selected {
+				continue
+			}
+		}
+
+		margin := temp - sensorThreshold
+		if !ok || margin > bestMargin || (margin == bestMargin && key < sensor) {
+			value = temp
+			threshold = sensorThreshold
+			sensor = key
+			bestMargin = margin
+			ok = true
+		}
+	}
+
+	if ok {
+		if len(thresholds) > 0 {
+			descriptor = fmt.Sprintf("Temperature sensor %s", sensor)
+		} else {
+			descriptor = fmt.Sprintf("Highest sensor %s", sensor)
+		}
+		return value, threshold, descriptor, sensor, true
+	}
+
+	if len(thresholds) == 0 && fallback >= 1 {
+		return fallback, defaultThreshold, "", "", true
+	}
+	return 0, 0, "", "", false
 }
 
 func (am *AlertManager) sendSystemAlert(alert SystemAlertData) {

--- a/internal/alerts/alerts_system_test.go
+++ b/internal/alerts/alerts_system_test.go
@@ -28,6 +28,16 @@ func createCombinedData[T any](value T, setValue systemAlertValueSetter[T]) *sys
 }
 
 func newSystemAlertTestFixture(t *testing.T, alertName string, min int, threshold float64) *systemAlertTestFixture {
+	return newSystemAlertTestFixtureWithThresholds(t, alertName, min, threshold, nil)
+}
+
+func newSystemAlertTestFixtureWithThresholds(
+	t *testing.T,
+	alertName string,
+	min int,
+	threshold float64,
+	thresholds map[string]float64,
+) *systemAlertTestFixture {
 	t.Helper()
 
 	hub, user := beszelTests.GetHubWithUser(t)
@@ -46,13 +56,17 @@ func newSystemAlertTestFixture(t *testing.T, alertName string, min int, threshol
 	userSettings.Set("settings", `{"emails":["test@example.com"],"webhooks":[]}`)
 	require.NoError(t, hub.Save(userSettings))
 
-	alertRecord, err := beszelTests.CreateRecord(hub, "alerts", map[string]any{
+	alertFields := map[string]any{
 		"name":   alertName,
 		"system": systemRecord.Id,
 		"user":   user.Id,
 		"min":    min,
 		"value":  threshold,
-	})
+	}
+	if thresholds != nil {
+		alertFields["thresholds"] = thresholds
+	}
+	alertRecord, err := beszelTests.CreateRecord(hub, "alerts", alertFields)
 	require.NoError(t, err)
 
 	assert.False(t, alertRecord.GetBool("triggered"), "Alert should not be triggered initially")
@@ -181,6 +195,15 @@ func setTemperatureAlertValue(info *system.Info, stats *system.Stats, value floa
 	}
 }
 
+func setTemperatureAlertValues(info *system.Info, stats *system.Stats, values map[string]float64) {
+	stats.Temperatures = values
+	for _, value := range values {
+		if value > info.DashboardTemp {
+			info.DashboardTemp = value
+		}
+	}
+}
+
 func setLoadAvgAlertValue(info *system.Info, stats *system.Stats, value [3]float64) {
 	info.LoadAvg = value
 	stats.LoadAvg = value
@@ -215,4 +238,61 @@ func TestSystemAlertsTwoMin(t *testing.T) {
 	testMultiMinuteSystemAlert(t, "LoadAvg5", 4, 2, setLoadAvgAlertValue, [3]float64{0, 2, 0}, [3]float64{0, 4.1, 0}, [3]float64{0, 3.5, 0})
 	testMultiMinuteSystemAlert(t, "LoadAvg15", 4, 2, setLoadAvgAlertValue, [3]float64{0, 0, 2}, [3]float64{0, 0, 4.1}, [3]float64{0, 0, 3.5})
 	testMultiMinuteSystemAlert(t, "Battery", 20, 2, setBatteryAlertValue, [2]uint8{21, 0}, [2]uint8{19, 0}, [2]uint8{25, 1})
+}
+
+func TestTemperatureAlertPerSensorThresholdsOneMin(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newSystemAlertTestFixtureWithThresholds(t, "Temperature", 1, 70, map[string]float64{
+			"CPU Package": 80,
+			"NVMe":        60,
+		})
+		defer fixture.cleanup()
+
+		// A hot unselected sensor and selected sensors below their own thresholds do not trigger.
+		submitValue(fixture, t, map[string]float64{"CPU Package": 79, "NVMe": 59, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should ignore unselected sensors")
+		assert.Zero(t, fixture.hub.TestMailer.TotalSend())
+
+		// Either selected sensor can trigger using its individual threshold.
+		submitValue(fixture, t, map[string]float64{"CPU Package": 79, "NVMe": 61, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Second)
+		fixture.assertTriggered(t, true, "Alert should trigger when a selected sensor exceeds its threshold")
+		assert.Equal(t, 1, fixture.hub.TestMailer.TotalSend())
+
+		submitValue(fixture, t, map[string]float64{"CPU Package": 79, "NVMe": 59, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should resolve when selected sensors fall below their thresholds")
+		assert.Equal(t, 2, fixture.hub.TestMailer.TotalSend())
+
+		waitForSystemAlert(time.Minute)
+	})
+}
+
+func TestTemperatureAlertPerSensorThresholdsTwoMin(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fixture := newSystemAlertTestFixtureWithThresholds(t, "Temperature", 2, 70, map[string]float64{
+			"CPU Package": 80,
+			"NVMe":        60,
+		})
+		defer fixture.cleanup()
+
+		submitValue(fixture, t, map[string]float64{"CPU Package": 50, "NVMe": 40, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Minute + time.Second)
+		fixture.assertTriggered(t, false, "Alert should not trigger on the baseline reading")
+
+		submitValue(fixture, t, map[string]float64{"CPU Package": 82, "NVMe": 62, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Minute)
+		fixture.assertTriggered(t, false, "Alert should wait for a complete history window")
+
+		submitValue(fixture, t, map[string]float64{"CPU Package": 82, "NVMe": 62, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Second)
+		fixture.assertTriggered(t, true, "Alert should use per-sensor averages and thresholds")
+		assert.Equal(t, 1, fixture.hub.TestMailer.TotalSend())
+
+		submitValue(fixture, t, map[string]float64{"CPU Package": 70, "NVMe": 50, "GPU": 99}, setTemperatureAlertValues)
+		waitForSystemAlert(time.Second)
+		fixture.assertTriggered(t, false, "Alert should resolve when per-sensor averages recover")
+		assert.Equal(t, 2, fixture.hub.TestMailer.TotalSend())
+	})
 }

--- a/internal/hub/collections_test.go
+++ b/internal/hub/collections_test.go
@@ -50,6 +50,7 @@ func TestCollectionRulesDefault(t *testing.T) {
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.CreateRule)
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.UpdateRule)
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.DeleteRule)
+	assert.IsType(t, &core.JSONField{}, alertsCollection.Fields.GetByName("thresholds"))
 
 	// alerts_history collection
 	alertsHistoryCollection, err := hub.FindCollectionByNameOrId("alerts_history")

--- a/internal/migrations/1_alert_thresholds.go
+++ b/internal/migrations/1_alert_thresholds.go
@@ -1,0 +1,33 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		if collection.Fields.GetByName("thresholds") != nil {
+			return nil
+		}
+		collection.Fields.Add(&core.JSONField{
+			Name:    "thresholds",
+			MaxSize: 10_000,
+		})
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		if collection.Fields.GetByName("thresholds") == nil {
+			return nil
+		}
+		collection.Fields.RemoveByName("thresholds")
+		return app.Save(collection)
+	})
+}

--- a/internal/site/src/components/active-alerts.tsx
+++ b/internal/site/src/components/active-alerts.tsx
@@ -22,7 +22,7 @@ export const ActiveAlerts = () => {
 			for (const alert of alerts[systemId].values()) {
 				if (alert.triggered && alert.name in alertInfo) {
 					activeAlerts.push(alert)
-					alertsKey.push(`${alert.system}${alert.value}${alert.min}`)
+					alertsKey.push(`${alert.system}${alert.value}${JSON.stringify(alert.thresholds)}${alert.min}`)
 				}
 			}
 		}
@@ -49,6 +49,8 @@ export const ActiveAlerts = () => {
 						<div className="grid sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-3">
 							{activeAlerts.map((alert) => {
 								const info = alertInfo[alert.name as keyof typeof alertInfo]
+								const hasSensorThresholds =
+									alert.name === "Temperature" && Object.keys(alert.thresholds ?? {}).length > 0
 								return (
 									<Alert
 										key={alert.id}
@@ -61,6 +63,11 @@ export const ActiveAlerts = () => {
 										<AlertDescription>
 											{alert.name === "Status" ? (
 												<Trans>Connection is down</Trans>
+											) : hasSensorThresholds ? (
+												<Trans>
+													Sensor threshold exceeded in last{" "}
+													<Plural value={alert.min} one="# minute" other="# minutes" />
+												</Trans>
 											) : info.invert ? (
 												<Trans>
 													Below {alert.value}

--- a/internal/site/src/components/alerts/alerts-sheet.tsx
+++ b/internal/site/src/components/alerts/alerts-sheet.tsx
@@ -3,13 +3,14 @@ import { Plural, Trans } from "@lingui/react/macro"
 import { useStore } from "@nanostores/react"
 import { getPagePath } from "@nanostores/router"
 import { ChevronDownIcon, GlobeIcon, ServerIcon } from "lucide-react"
-import { lazy, memo, Suspense, useMemo, useState } from "react"
+import { lazy, memo, Suspense, useEffect, useMemo, useState } from "react"
 import { $router, Link } from "@/components/router"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Input } from "@/components/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { toast } from "@/components/ui/use-toast"
@@ -17,7 +18,7 @@ import { alertInfo } from "@/lib/alerts"
 import { pb } from "@/lib/api"
 import { $alerts, $systems } from "@/lib/stores"
 import { cn, debounce } from "@/lib/utils"
-import type { AlertInfo, AlertRecord, SystemRecord } from "@/types"
+import type { AlertInfo, AlertRecord, SystemRecord, SystemStatsRecord } from "@/types"
 
 const Slider = lazy(() => import("@/components/ui/slider"))
 
@@ -38,12 +39,24 @@ const failedUpdateToast = (error: unknown) => {
 
 /** Create or update alerts for a given name and systems */
 const upsertAlerts = debounce(
-	async ({ name, value, min, systems }: { name: string; value: number; min: number; systems: string[] }) => {
+	async ({
+		name,
+		value,
+		thresholds,
+		min,
+		systems,
+	}: {
+		name: string
+		value: number
+		thresholds?: Record<string, number>
+		min: number
+		systems: string[]
+	}) => {
 		try {
 			await pb.send<{ success: boolean }>(endpoint, {
 				method: "POST",
 				// overwrite is always true because we've done filtering client side
-				body: { name, value, min, systems, overwrite: true },
+				body: { name, value, thresholds, min, systems, overwrite: true },
 			})
 		} catch (error) {
 			failedUpdateToast(error)
@@ -89,10 +102,10 @@ export const AlertDialogContent = memo(function AlertDialogContent({ system }: {
 			// Alert names present on target but absent from source should be deleted
 			const namesToDelete = Array.from(currentTargetAlerts.keys()).filter((name) => !sourceAlerts.has(name))
 			await Promise.all([
-				...Array.from(sourceAlerts.values()).map(({ name, value, min }) =>
+				...Array.from(sourceAlerts.values()).map(({ name, value, thresholds, min }) =>
 					pb.send<{ success: boolean }>(endpoint, {
 						method: "POST",
-						body: { name, value, min, systems: [system.id], overwrite: true },
+						body: { name, value, thresholds, min, systems: [system.id], overwrite: true },
 						requestKey: name,
 					})
 				),
@@ -240,8 +253,38 @@ export function AlertContent({
 	const [checked, setChecked] = useState(global ? false : !!alert)
 	const [min, setMin] = useState(alert?.min || 10)
 	const [value, setValue] = useState(alert?.value || (singleDescription ? 0 : (alertData.start ?? 80)))
+	const [temperatureMode, setTemperatureMode] = useState<"any" | "sensors">(
+		Object.keys(alert?.thresholds ?? {}).length ? "sensors" : "any"
+	)
+	const [sensorThresholds, setSensorThresholds] = useState<Record<string, number>>(alert?.thresholds ?? {})
+	const [temperatureSensors, setTemperatureSensors] = useState(() => Object.keys(alert?.thresholds ?? {}).sort())
+	const [loadingTemperatureSensors, setLoadingTemperatureSensors] = useState(false)
+	const isTemperatureAlert = alertKey === "Temperature"
+	const canConfigureTemperatureSensors = isTemperatureAlert && !global
 
 	const Icon = alertData.icon
+
+	useEffect(() => {
+		if (!canConfigureTemperatureSensors || !checked) return
+		let cancelled = false
+		setLoadingTemperatureSensors(true)
+		pb.collection<SystemStatsRecord>("system_stats")
+			.getList(1, 1, {
+				filter: pb.filter("system={:system} && type={:type}", { system: system.id, type: "1m" }),
+				fields: "stats",
+				sort: "-created",
+			})
+			.then(({ items }) => {
+				if (cancelled) return
+				const sensors = new Set([...Object.keys(sensorThresholds), ...Object.keys(items[0]?.stats?.t ?? {})])
+				setTemperatureSensors([...sensors].sort((a, b) => a.localeCompare(b)))
+			})
+			.catch((error) => console.error("Failed to load temperature sensors", error))
+			.finally(() => !cancelled && setLoadingTemperatureSensors(false))
+		return () => {
+			cancelled = true
+		}
+	}, [canConfigureTemperatureSensors, checked, system.id])
 
 	/** Get system ids to update */
 	function getSystemIds(): string[] {
@@ -261,12 +304,19 @@ export function AlertContent({
 		return systemIds
 	}
 
-	function sendUpsert(min: number, value: number) {
+	function sendUpsert(min: number, value: number, thresholds?: Record<string, number>) {
 		const systems = getSystemIds()
 		systems.length &&
 			upsertAlerts({
 				name: alertKey,
 				value,
+				thresholds:
+					thresholds ??
+					(isTemperatureAlert
+						? canConfigureTemperatureSensors && temperatureMode === "sensors"
+							? sensorThresholds
+							: {}
+						: undefined),
 				min,
 				systems,
 			})
@@ -310,7 +360,41 @@ export function AlertContent({
 			{checked && (
 				<div className="grid sm:grid-cols-2 mt-1.5 gap-5 px-4 pb-5 tabular-nums text-muted-foreground">
 					<Suspense fallback={<div className="h-10" />}>
-						{!singleDescription && (
+						{canConfigureTemperatureSensors && (
+							<div className="col-span-full">
+								<p className="text-sm block h-6">
+									<Trans>Temperature source</Trans>
+								</p>
+								<Select
+									value={temperatureMode}
+									onValueChange={(mode: "any" | "sensors") => {
+										setTemperatureMode(mode)
+										if (mode === "any") {
+											sendUpsert(min, value, {})
+											return
+										}
+										const nextThresholds = Object.keys(sensorThresholds).length
+											? sensorThresholds
+											: Object.fromEntries(temperatureSensors.map((sensor) => [sensor, value]))
+										setSensorThresholds(nextThresholds)
+										if (Object.keys(nextThresholds).length) sendUpsert(min, value, nextThresholds)
+									}}
+								>
+									<SelectTrigger className="h-9">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="any">
+											<Trans>Any sensor</Trans>
+										</SelectItem>
+										<SelectItem value="sensors" disabled={!temperatureSensors.length}>
+											<Trans>Individual sensors</Trans>
+										</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+						)}
+						{!singleDescription && (!canConfigureTemperatureSensors || temperatureMode === "any") && (
 							<div>
 								<p id={`v${name}`} className="text-sm block h-6">
 									{alertData.invert ? (
@@ -361,7 +445,82 @@ export function AlertContent({
 								</div>
 							</div>
 						)}
-						<div className={cn(singleDescription && "col-span-full lowercase")}>
+						{canConfigureTemperatureSensors && temperatureMode === "sensors" && (
+							<div className="col-span-full grid gap-3">
+								{loadingTemperatureSensors && !temperatureSensors.length ? (
+									<p className="text-sm">
+										<Trans>Loading temperature sensors...</Trans>
+									</p>
+								) : (
+									temperatureSensors.map((sensor, index) => {
+										const enabled = Object.hasOwn(sensorThresholds, sensor)
+										const sensorValue = sensorThresholds[sensor] ?? value
+										const sensorId = `temperature-sensor-${index}`
+										const updateSensor = (nextValue: number) => {
+											const nextThresholds = { ...sensorThresholds, [sensor]: nextValue }
+											setSensorThresholds(nextThresholds)
+											sendUpsert(min, value, nextThresholds)
+										}
+										return (
+											<div key={sensor} className="grid gap-2 rounded-md border border-muted-foreground/15 p-3">
+												<div className="flex items-center justify-between gap-3">
+													<label htmlFor={sensorId} className="min-w-0 truncate text-sm font-medium text-foreground">
+														{sensor}
+													</label>
+													<Checkbox
+														id={sensorId}
+														checked={enabled}
+														onCheckedChange={(nextChecked) => {
+															if (nextChecked) {
+																updateSensor(sensorValue)
+																return
+															}
+															const nextThresholds = { ...sensorThresholds }
+															delete nextThresholds[sensor]
+															setSensorThresholds(nextThresholds)
+															if (!Object.keys(nextThresholds).length) setTemperatureMode("any")
+															sendUpsert(min, value, nextThresholds)
+														}}
+													/>
+												</div>
+												<div className="flex gap-3 items-center">
+													<Slider
+														aria-label={sensor}
+														disabled={!enabled}
+														value={[sensorValue]}
+														onValueCommit={(val) => updateSensor(val[0])}
+														step={alertData.step ?? 1}
+														min={alertData.min ?? 1}
+														max={alertData.max ?? 99}
+													/>
+													<Input
+														type="number"
+														disabled={!enabled}
+														value={sensorValue}
+														onChange={(e) => {
+															let nextValue = parseFloat(e.target.value)
+															if (!Number.isNaN(nextValue)) {
+																nextValue = Math.max(alertData.min ?? 1, Math.min(nextValue, alertData.max ?? 99))
+																updateSensor(nextValue)
+															}
+														}}
+														className="w-16 h-8 text-center px-1"
+													/>
+													<span className="sr-only">°C</span>
+												</div>
+											</div>
+										)
+									})
+								)}
+							</div>
+						)}
+						<div
+							className={cn(
+								(singleDescription || (canConfigureTemperatureSensors && temperatureMode === "sensors")) &&
+									"col-span-full",
+								singleDescription && "lowercase"
+							)}
+						>
 							<p id={`t${name}`} className="text-sm block h-6 first-letter:uppercase">
 								{singleDescription && (
 									<>

--- a/internal/site/src/lib/alerts.ts
+++ b/internal/site/src/lib/alerts.ts
@@ -100,7 +100,7 @@ export const alertManager = (() => {
 	let unsub: () => void
 
 	/** Fields to fetch from alerts collection */
-	const fields = "id,name,system,value,min,triggered"
+	const fields = "id,name,system,value,thresholds,min,triggered"
 
 	/** Fetch alerts from collection */
 	async function fetchAlerts(): Promise<AlertRecord[]> {

--- a/internal/site/src/locales/ar/ar.po
+++ b/internal/site/src/locales/ar/ar.po
@@ -179,6 +179,10 @@ msgstr "جميع الحاويات"
 msgid "All Systems"
 msgstr "جميع الأنظمة"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "هل أنت متأكد أنك تريد حذف {name}؟"
@@ -944,6 +948,10 @@ msgstr "صورة"
 msgid "Inactive"
 msgstr "غير نشط"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "الفاصل الزمني"
@@ -998,6 +1006,10 @@ msgstr "متوسط التحميل"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "حالة التحميل"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "أرسل pings صادرة دورية إلى خدمة مراقبة خار
 msgid "Send test heartbeat"
 msgstr "إرسال نبضة قلب اختبارية"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "تم الإرسال"
@@ -1604,6 +1621,10 @@ msgstr "درجة الحرارة"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "درجة الحرارة"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/bg/bg.po
+++ b/internal/site/src/locales/bg/bg.po
@@ -179,6 +179,10 @@ msgstr "Всички контейнери"
 msgid "All Systems"
 msgstr "Всички системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Сигурен ли си, че искаш да изтриеш {name}?"
@@ -944,6 +948,10 @@ msgstr "Образ"
 msgid "Inactive"
 msgstr "Неактивен"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Интервал"
@@ -998,6 +1006,10 @@ msgstr "Средно натоварване"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Състояние на зареждане"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Изпращайте периодични изходящи пингов�
 msgid "Send test heartbeat"
 msgstr "Изпращане на тестов heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Изпратени"
@@ -1604,6 +1621,10 @@ msgstr "Температура"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Температура"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/cs/cs.po
+++ b/internal/site/src/locales/cs/cs.po
@@ -179,6 +179,10 @@ msgstr "Všechny kontejnery"
 msgid "All Systems"
 msgstr "Všechny systémy"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Opravdu chcete odstranit {name}?"
@@ -944,6 +948,10 @@ msgstr "Obraz"
 msgid "Inactive"
 msgstr "Neaktivní"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Prům. zatížení"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Stav načtení"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Odesílejte periodické odchozí pingy na externí monitorovací službu
 msgid "Send test heartbeat"
 msgstr "Odeslat testovací heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Odeslat"
@@ -1604,6 +1621,10 @@ msgstr "Teplota"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Teplota"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/da/da.po
+++ b/internal/site/src/locales/da/da.po
@@ -179,6 +179,10 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle systemer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på, at du vil slette {name}?"
@@ -944,6 +948,10 @@ msgstr "Billede"
 msgid "Inactive"
 msgstr "Inaktiv"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Belastning gns."
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Indlæsningstilstand"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Send periodiske udgående pings til en ekstern overvågningstjeneste, s�
 msgid "Send test heartbeat"
 msgstr "Send test-heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Sendt"
@@ -1604,6 +1621,10 @@ msgstr "Temperatur"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/de/de.po
+++ b/internal/site/src/locales/de/de.po
@@ -179,6 +179,10 @@ msgstr "Alle Container"
 msgid "All Systems"
 msgstr "Alle Systeme"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Möchtest du {name} wirklich löschen?"
@@ -944,6 +948,10 @@ msgstr ""
 msgid "Inactive"
 msgstr "Inaktiv"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervall"
@@ -998,6 +1006,10 @@ msgstr "Systemlast"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Ladezustand"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Senden Sie regelmäßige ausgehende Pings an einen externen Überwachung
 msgid "Send test heartbeat"
 msgstr "Test-Heartbeat senden"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Gesendet"
@@ -1604,6 +1621,10 @@ msgstr "Temperatur"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/en/en.po
+++ b/internal/site/src/locales/en/en.po
@@ -174,6 +174,10 @@ msgstr "All Containers"
 msgid "All Systems"
 msgstr "All Systems"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr "Any sensor"
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Are you sure you want to delete {name}?"
@@ -939,6 +943,10 @@ msgstr "Image"
 msgid "Inactive"
 msgstr "Inactive"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr "Individual sensors"
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Interval"
@@ -993,6 +1001,10 @@ msgstr "Load Avg"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Load state"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr "Loading temperature sensors..."
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1462,6 +1474,11 @@ msgstr "Send periodic outbound pings to an external monitoring service so you ca
 msgid "Send test heartbeat"
 msgstr "Send test heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Sent"
@@ -1599,6 +1616,10 @@ msgstr "Temp"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperature"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr "Temperature source"
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/es/es.po
+++ b/internal/site/src/locales/es/es.po
@@ -179,6 +179,10 @@ msgstr "Todos los contenedores"
 msgid "All Systems"
 msgstr "Todos los sistemas"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "¿Estás seguro de que deseas eliminar {name}?"
@@ -944,6 +948,10 @@ msgstr "Imagen"
 msgid "Inactive"
 msgstr "Inactivo"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervalo"
@@ -998,6 +1006,10 @@ msgstr "Carga media"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Estado de carga"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Envíe pings salientes periódicos a un servicio de monitorización exte
 msgid "Send test heartbeat"
 msgstr "Enviar latido de prueba"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Enviado"
@@ -1604,6 +1621,10 @@ msgstr "Temperatura"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/fa/fa.po
+++ b/internal/site/src/locales/fa/fa.po
@@ -179,6 +179,10 @@ msgstr "همه کانتینرها"
 msgid "All Systems"
 msgstr "همه سیستم‌ها"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "آیا مطمئن هستید که می‌خواهید {name} را حذف کنید؟"
@@ -944,6 +948,10 @@ msgstr "تصویر"
 msgid "Inactive"
 msgstr "غیرفعال"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "بازه زمانی"
@@ -998,6 +1006,10 @@ msgstr "میانگین بار"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "وضعیت بارگذاری"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "پینگ‌های خروجی دوره‌ای را به یک سرویس �
 msgid "Send test heartbeat"
 msgstr "ارسال ضربان قلب آزمایشی"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "ارسال شد"
@@ -1604,6 +1621,10 @@ msgstr "دما"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "دما"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -179,6 +179,10 @@ msgstr "Tous les conteneurs"
 msgid "All Systems"
 msgstr "Tous les systèmes"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {name} ?"
@@ -944,6 +948,10 @@ msgstr ""
 msgid "Inactive"
 msgstr "Inactif"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervalle"
@@ -998,6 +1006,10 @@ msgstr "Charge moy."
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "État de charge"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Envoyez des pings sortants périodiques vers un service de surveillance 
 msgid "Send test heartbeat"
 msgstr "Envoyer un heartbeat de test"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Envoyé"
@@ -1604,6 +1621,10 @@ msgstr "Temp."
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Température"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/he/he.po
+++ b/internal/site/src/locales/he/he.po
@@ -179,6 +179,10 @@ msgstr "כל הקונטיינרים"
 msgid "All Systems"
 msgstr "כל המערכות"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "האם אתה בטוח שברצונך למחוק את {name}?"
@@ -944,6 +948,10 @@ msgstr "תמונה"
 msgid "Inactive"
 msgstr "לא פעיל"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "מרווח"
@@ -998,6 +1006,10 @@ msgstr "ממוצע עומס"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "מצב עומס"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "שלח פינגים יוצאים תקופתיים לשירות ניטו�
 msgid "Send test heartbeat"
 msgstr "שלח פעימת לב לבדיקה"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "נשלח"
@@ -1604,6 +1621,10 @@ msgstr "טמפ'"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "טמפרטורה"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/hr/hr.po
+++ b/internal/site/src/locales/hr/hr.po
@@ -179,6 +179,10 @@ msgstr "Svi spremnici"
 msgid "All Systems"
 msgstr "Svi Sustavi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Jeste li sigurni da želite izbrisati {name}?"
@@ -944,6 +948,10 @@ msgstr "Slika"
 msgid "Inactive"
 msgstr "Neaktivno"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Prosječno Opterećenje"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Stanje učitavanja"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Šaljite povremene odlazne pingove vanjskoj usluzi nadzora kako biste mo
 msgid "Send test heartbeat"
 msgstr "Pošalji testni heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Poslano"
@@ -1604,6 +1621,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/hu/hu.po
+++ b/internal/site/src/locales/hu/hu.po
@@ -179,6 +179,10 @@ msgstr "Minden konténer"
 msgid "All Systems"
 msgstr "Minden rendszer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Biztosan törölni szeretnéd {name}-t?"
@@ -944,6 +948,10 @@ msgstr "Kép"
 msgid "Inactive"
 msgstr "Inaktív"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervallum"
@@ -998,6 +1006,10 @@ msgstr "Terhelési átlag"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Betöltési állapot"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Küldjön időszakos kimenő pingeket egy külső megfigyelő szolgálta
 msgid "Send test heartbeat"
 msgstr "Teszt heartbeat küldése"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Elküldve"
@@ -1604,6 +1621,10 @@ msgstr "Hőmérséklet"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Hőmérséklet"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/id/id.po
+++ b/internal/site/src/locales/id/id.po
@@ -179,6 +179,10 @@ msgstr "Semua Container"
 msgid "All Systems"
 msgstr "Semua Sistem"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Apakah anda yakin ingin menghapus {name}?"
@@ -944,6 +948,10 @@ msgstr "Gambar"
 msgid "Inactive"
 msgstr "Tidak aktif"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Rata-rata Beban"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Beban saat ini"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Kirim ping keluar secara berkala ke layanan pemantauan eksternal sehingg
 msgid "Send test heartbeat"
 msgstr "Kirim tes heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Dikirim"
@@ -1604,6 +1621,10 @@ msgstr "Temperatur"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/it/it.po
+++ b/internal/site/src/locales/it/it.po
@@ -179,6 +179,10 @@ msgstr "Tutti i contenitori"
 msgid "All Systems"
 msgstr "Tutti i Sistemi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Sei sicuro di voler eliminare {name}?"
@@ -944,6 +948,10 @@ msgstr "Immagine"
 msgid "Inactive"
 msgstr "Inattivo"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervallo"
@@ -998,6 +1006,10 @@ msgstr "Carico Medio"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Stato di caricamento"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Invia ping in uscita periodici a un servizio di monitoraggio esterno in 
 msgid "Send test heartbeat"
 msgstr "Invia heartbeat di prova"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Inviato"
@@ -1604,6 +1621,10 @@ msgstr "Temperatura"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/ja/ja.po
+++ b/internal/site/src/locales/ja/ja.po
@@ -179,6 +179,10 @@ msgstr "すべてのコンテナ"
 msgid "All Systems"
 msgstr "すべてのシステム"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}を削除してもよろしいですか？"
@@ -944,6 +948,10 @@ msgstr "イメージ"
 msgid "Inactive"
 msgstr "非アクティブ"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "間隔"
@@ -998,6 +1006,10 @@ msgstr "負荷平均"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "ロード状態"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "外部監視サービスに定期的にアウトバウンド ping を送
 msgid "Send test heartbeat"
 msgstr "テストハートビートを送信"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "送信"
@@ -1604,6 +1621,10 @@ msgstr "温度"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "温度"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/ko/ko.po
+++ b/internal/site/src/locales/ko/ko.po
@@ -179,6 +179,10 @@ msgstr "모든 컨테이너"
 msgid "All Systems"
 msgstr "모든 시스템"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}을(를) 삭제하시겠습니까?"
@@ -944,6 +948,10 @@ msgstr "이미지"
 msgid "Inactive"
 msgstr "비활성"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "간격"
@@ -998,6 +1006,10 @@ msgstr "부하 평균"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "로드 상태"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "외부 모니터링 서비스에 주기적으로 아웃바운드 핑을 
 msgid "Send test heartbeat"
 msgstr "테스트 하트비트 전송"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "보냄"
@@ -1604,6 +1621,10 @@ msgstr "온도"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "온도"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/nl/nl.po
+++ b/internal/site/src/locales/nl/nl.po
@@ -179,6 +179,10 @@ msgstr "Alle containers"
 msgid "All Systems"
 msgstr "Alle systemen"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Weet je zeker dat je {name} wilt verwijderen?"
@@ -944,6 +948,10 @@ msgstr ""
 msgid "Inactive"
 msgstr "Inactief"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Gem. Belasting"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Laadstatus"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Stuur periodieke uitgaande pings naar een externe monitoringservice, zod
 msgid "Send test heartbeat"
 msgstr "Stuur test-heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Verzonden"
@@ -1604,6 +1621,10 @@ msgstr "Temperatuur"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatuur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/no/no.po
+++ b/internal/site/src/locales/no/no.po
@@ -179,6 +179,10 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle Systemer"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på at du vil slette {name}?"
@@ -944,6 +948,10 @@ msgstr ""
 msgid "Inactive"
 msgstr "Inaktiv"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervall"
@@ -998,6 +1006,10 @@ msgstr "Snittbelastning"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Lastetilstand"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Send periodiske utgående pinger til en ekstern overvåkingstjeneste sli
 msgid "Send test heartbeat"
 msgstr "Send test-heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Sendt"
@@ -1604,6 +1621,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/pl/pl.po
+++ b/internal/site/src/locales/pl/pl.po
@@ -179,6 +179,10 @@ msgstr "Wszystkie kontenery"
 msgid "All Systems"
 msgstr "Wszystkie systemy"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Czy na pewno chcesz usunąć {name}?"
@@ -944,6 +948,10 @@ msgstr "Obraz"
 msgid "Inactive"
 msgstr "Nieaktywny"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Interwał"
@@ -998,6 +1006,10 @@ msgstr "Śr. obciążenie"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Stan obciążenia"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Wysyłaj cyklicznie pingi wychodzące do zewnętrznej usługi monitorowa
 msgid "Send test heartbeat"
 msgstr "Wyślij testowy heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Wysłane"
@@ -1604,6 +1621,10 @@ msgstr "Temperatura"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/pt/pt.po
+++ b/internal/site/src/locales/pt/pt.po
@@ -179,6 +179,10 @@ msgstr "Todos os Contêineres"
 msgid "All Systems"
 msgstr "Todos os Sistemas"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Tem certeza de que deseja excluir {name}?"
@@ -944,6 +948,10 @@ msgstr "Imagem"
 msgid "Inactive"
 msgstr "Inativo"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervalo"
@@ -998,6 +1006,10 @@ msgstr "Carga Média"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Estado de carga"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Envie pings de saída periódicos para um serviço de monitorização ex
 msgid "Send test heartbeat"
 msgstr "Enviar heartbeat de teste"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Enviado"
@@ -1604,6 +1621,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/ru/ru.po
+++ b/internal/site/src/locales/ru/ru.po
@@ -179,6 +179,10 @@ msgstr "Все контейнеры"
 msgid "All Systems"
 msgstr "Все системы"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Вы уверены, что хотите удалить {name}?"
@@ -944,6 +948,10 @@ msgstr "Образ"
 msgid "Inactive"
 msgstr "Неактивно"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Интервал"
@@ -998,6 +1006,10 @@ msgstr "Ср. загрузка"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Состояние загрузки"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Отправляйте периодические исходящие п�
 msgid "Send test heartbeat"
 msgstr "Отправить тестовый heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Отправлено"
@@ -1604,6 +1621,10 @@ msgstr "Темп"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Температура"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/sl/sl.po
+++ b/internal/site/src/locales/sl/sl.po
@@ -179,6 +179,10 @@ msgstr "Vsi kontejnerji"
 msgid "All Systems"
 msgstr "Vsi sistemi"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ali ste prepričani, da želite izbrisati {name}?"
@@ -944,6 +948,10 @@ msgstr "Slika"
 msgid "Inactive"
 msgstr "Neaktivno"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr ""
@@ -998,6 +1006,10 @@ msgstr "Povpr. obrem."
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Stanje nalaganja"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Pošiljajte občasne odhodne pinge zunanji storitvi za spremljanje, da b
 msgid "Send test heartbeat"
 msgstr "Pošlji testni srčni utrip"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Poslano"
@@ -1604,6 +1621,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatura"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/sr/sr.po
+++ b/internal/site/src/locales/sr/sr.po
@@ -179,6 +179,10 @@ msgstr "Сви контејнери"
 msgid "All Systems"
 msgstr "Сви системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Да ли сте сигурни да желите да избришете {name}?"
@@ -944,6 +948,10 @@ msgstr "Слика"
 msgid "Inactive"
 msgstr "Неактивно"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Интервал"
@@ -998,6 +1006,10 @@ msgstr "Просечно опт."
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Стање учитавања"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Šaljite periodične odlazne pingove spoljnoj usluzi monitoringa kako bi
 msgid "Send test heartbeat"
 msgstr "Pošalji testni heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Послато"
@@ -1604,6 +1621,10 @@ msgstr "Темп"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Температура"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/sv/sv.po
+++ b/internal/site/src/locales/sv/sv.po
@@ -179,6 +179,10 @@ msgstr "Alla behållare"
 msgid "All Systems"
 msgstr "Alla system"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Är du säker på att du vill ta bort {name}?"
@@ -944,6 +948,10 @@ msgstr "Avbild"
 msgid "Inactive"
 msgstr "Inaktiv"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Intervall"
@@ -998,6 +1006,10 @@ msgstr "Belastning"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Laddningstillstånd"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Skicka periodiska utgående pingar till en extern övervakningstjänst s
 msgid "Send test heartbeat"
 msgstr "Skicka test-heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Skickat"
@@ -1604,6 +1621,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Temperatur"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/tr/tr.po
+++ b/internal/site/src/locales/tr/tr.po
@@ -179,6 +179,10 @@ msgstr "Tüm Konteynerler"
 msgid "All Systems"
 msgstr "Tüm Sistemler"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name} silmek istediğinizden emin misiniz?"
@@ -944,6 +948,10 @@ msgstr "İmaj"
 msgid "Inactive"
 msgstr "Pasif"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Aralık"
@@ -998,6 +1006,10 @@ msgstr "Yük Ort."
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Yükleme durumu"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Beszel'i internete maruz bırakmadan izleyebilmeniz için harici bir izl
 msgid "Send test heartbeat"
 msgstr "Test heartbeat gönder"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Gönderildi"
@@ -1604,6 +1621,10 @@ msgstr "Sıc"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Sıcaklık"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/uk/uk.po
+++ b/internal/site/src/locales/uk/uk.po
@@ -179,6 +179,10 @@ msgstr "Всі контейнери"
 msgid "All Systems"
 msgstr "Всі системи"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ви впевнені, що хочете видалити {name}?"
@@ -944,6 +948,10 @@ msgstr "Образ"
 msgid "Inactive"
 msgstr "Неактивне"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Інтервал"
@@ -998,6 +1006,10 @@ msgstr "Сер. навантаження"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Стан завантаження"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Надсилайте періодичні вихідні пінги на
 msgid "Send test heartbeat"
 msgstr "Надіслати тестовий heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Відправлено"
@@ -1604,6 +1621,10 @@ msgstr "Температура"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Температура"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/vi/vi.po
+++ b/internal/site/src/locales/vi/vi.po
@@ -179,6 +179,10 @@ msgstr "Tất cả container"
 msgid "All Systems"
 msgstr "Tất cả Hệ thống"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Bạn có chắc chắn muốn xóa {name} không?"
@@ -944,6 +948,10 @@ msgstr "Hình ảnh"
 msgid "Inactive"
 msgstr "Không hoạt động"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "Khoảng thời gian"
@@ -998,6 +1006,10 @@ msgstr "Tải TB"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "Trạng thái tải"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "Gửi các ping gửi đi định kỳ đến dịch vụ giám sát bê
 msgid "Send test heartbeat"
 msgstr "Gửi heartbeat thử nghiệm"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "Đã gửi"
@@ -1604,6 +1621,10 @@ msgstr "Nhiệt độ"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "Nhiệt độ"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/zh-CN/zh-CN.po
+++ b/internal/site/src/locales/zh-CN/zh-CN.po
@@ -179,6 +179,10 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有客户端"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您确定要删除 {name} 吗？"
@@ -944,6 +948,10 @@ msgstr "镜像"
 msgid "Inactive"
 msgstr "非活跃"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "间隔"
@@ -998,6 +1006,10 @@ msgstr "负载"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "加载状态"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "定期向外部监控服务发送出站 ping，以便您在不将 Beszel
 msgid "Send test heartbeat"
 msgstr "发送测试 heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "发送"
@@ -1604,6 +1621,10 @@ msgstr "温度"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "温度"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/zh-HK/zh-HK.po
+++ b/internal/site/src/locales/zh-HK/zh-HK.po
@@ -179,6 +179,10 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -944,6 +948,10 @@ msgstr "鏡像"
 msgid "Inactive"
 msgstr "未啟用"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "間隔"
@@ -998,6 +1006,10 @@ msgstr "平均負載"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "載入狀態"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "定期向外部監控服務發送出站 ping，以便您在不將 Beszel
 msgid "Send test heartbeat"
 msgstr "發送測試 heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "發送"
@@ -1604,6 +1621,10 @@ msgstr "溫度"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "溫度"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/locales/zh/zh.po
+++ b/internal/site/src/locales/zh/zh.po
@@ -179,6 +179,10 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Any sensor"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -944,6 +948,10 @@ msgstr "映像檔"
 msgid "Inactive"
 msgstr "未啟用"
 
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Individual sensors"
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Interval"
 msgstr "間隔"
@@ -998,6 +1006,10 @@ msgstr "平均負載"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Load state"
 msgstr "載入狀態"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Loading temperature sensors..."
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Loading..."
@@ -1467,6 +1479,11 @@ msgstr "定期發送 Outbound Ping 至外部監控服務，讓您無需將 Besze
 msgid "Send test heartbeat"
 msgstr "發送測試 Heartbeat"
 
+#. placeholder {0}: alert.min
+#: src/components/active-alerts.tsx
+msgid "Sensor threshold exceeded in last {0, plural, one {# minute} other {# minutes}}"
+msgstr ""
+
 #: src/components/routes/system/charts/network-charts.tsx
 msgid "Sent"
 msgstr "傳送"
@@ -1604,6 +1621,10 @@ msgstr "溫度"
 #: src/lib/alerts.ts
 msgid "Temperature"
 msgstr "溫度"
+
+#: src/components/alerts/alerts-sheet.tsx
+msgid "Temperature source"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Temperature unit"

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -230,6 +230,8 @@ export interface AlertRecord extends RecordModel {
 	name: string
 	triggered: boolean
 	value: number
+	/** Optional per-sensor thresholds for temperature alerts */
+	thresholds?: Record<string, number>
 	min: number
 	// user: string
 }


### PR DESCRIPTION
## What changed

- keeps the existing any-sensor temperature alert behavior as the default
- adds an individual-sensors mode with selectable probe-specific sliders and numeric inputs
- persists an optional per-probe threshold map through the API, cache, and collection schema
- evaluates immediate and multi-minute alerts against each selected probe's own threshold
- identifies the triggering probe in notifications and clarifies per-probe active alerts
- adds migration, API, evaluator, regression, schema, UI, and catalog coverage

## Why

Different temperature probes have different safe operating ranges. A single shared threshold can be too noisy for one sensor while being too permissive for another.

## Validation

- `go test -tags=testing ./internal/alerts -run '^TestTemperatureAlertPerSensorThresholds' -count=1`
- `go test -tags=testing ./internal/alerts -run '^TestUserAlertsApi$' -count=1`
- `go test -tags=testing ./internal/alerts -run '^TestSystemAlertsOneMin$|^TestSystemAlertsTwoMin$' -count=1`
- `go test -tags=testing ./internal/hub -run '^TestCollectionRulesDefault$|^TestCollectionRulesShareAllSystems$' -count=1`
- `bunx biome check src/components/alerts/alerts-sheet.tsx src/components/active-alerts.tsx src/lib/alerts.ts src/types.d.ts --max-diagnostics=100`
- `bunx lingui compile`
- `npm run build`
- `codex review --uncommitted`, no correctness findings

The repository's aggregate alert test run can intermittently hit the existing asynchronous `System.StartUpdater` teardown nil dereference. All affected and neighboring test groups pass independently above.
