### PR TITLE
fix(agent): treat a backwards container CPU counter as a new baseline

### DIFF
--- a/agent/docker_test.go
+++ b/agent/docker_test.go
@@ -1003,6 +1003,44 @@ func TestCpuPercentageCalculationWithRealData(t *testing.T) {
 	assert.InDelta(t, expectedPct, actualPct, 0.01)
 }
 
+func TestCpuPercentageHandlesCounterRollback(t *testing.T) {
+	// If a stats response is processed after a newer one for the same container,
+	// or an accounting counter resets, the current total can be lower than the
+	// stored previous value. Unsigned subtraction wraps to ~2^64 instead of
+	// going negative, so the percentage explodes, validateCpuPercentage rejects
+	// the sample, and the whole collection is discarded - network stats too.
+	stats := &container.ApiStats{
+		CPUStats: container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 1_000_000},
+			SystemUsage: 20_000_000,
+		},
+	}
+
+	// Container counter went backwards.
+	assert.Equal(t, 0.0, stats.CalculateCpuPercentLinux(2_000_000, 10_000_000))
+	// System counter went backwards.
+	assert.Equal(t, 0.0, stats.CalculateCpuPercentLinux(500_000, 30_000_000))
+	// A normal forward sample is unaffected: 500000 / 10000000 * 100 = 5%.
+	assert.InDelta(t, 5.0, stats.CalculateCpuPercentLinux(500_000, 10_000_000), 0.001)
+}
+
+func TestCpuPercentageWindowsHandlesCounterRollback(t *testing.T) {
+	now := time.Now()
+	stats := &container.ApiStats{
+		Read:     now,
+		NumProcs: 4,
+		CPUStats: container.CPUStats{
+			CPUUsage: container.CPUUsage{TotalUsage: 1_000_000},
+		},
+	}
+	prevRead := now.Add(-time.Second)
+
+	// Container counter went backwards.
+	assert.Equal(t, 0.0, stats.CalculateCpuPercentWindows(2_000_000, prevRead))
+	// A normal forward sample is unaffected.
+	assert.Greater(t, stats.CalculateCpuPercentWindows(500_000, prevRead), 0.0)
+}
+
 func TestNetworkStatsCalculationWithRealData(t *testing.T) {
 	// Create synthetic test data to avoid timing issues
 	apiStats1 := &container.ApiStats{

--- a/internal/entities/container/container.go
+++ b/internal/entities/container/container.go
@@ -52,6 +52,17 @@ type HostInfo struct {
 }
 
 func (s *ApiStats) CalculateCpuPercentLinux(prevCpuContainer uint64, prevCpuSystem uint64) float64 {
+	// A counter can read lower than the stored previous value when a stats
+	// response is processed after a newer one for the same container, or when an
+	// accounting counter resets. Unsigned subtraction wraps to ~2^64 instead of
+	// going negative: on the container counter that surfaces as an absurd
+	// percentage the caller rejects, discarding the whole sample; on the system
+	// counter it inflates the divisor and silently reports near-zero CPU.
+	// Treat either direction as a new baseline.
+	if s.CPUStats.CPUUsage.TotalUsage < prevCpuContainer || s.CPUStats.SystemUsage < prevCpuSystem {
+		return 0.0
+	}
+
 	cpuDelta := s.CPUStats.CPUUsage.TotalUsage - prevCpuContainer
 	systemDelta := s.CPUStats.SystemUsage - prevCpuSystem
 
@@ -70,7 +81,11 @@ func (s *ApiStats) CalculateCpuPercentWindows(prevCpuUsage uint64, prevRead time
 	possIntervals /= 100                // Convert to number of 100ns intervals
 	possIntervals *= uint64(s.NumProcs) // Multiple by the number of processors
 
-	// Intervals used
+	// Intervals used. Same rollback guard as the Linux path: an out-of-order or
+	// reset counter would wrap the subtraction to ~2^64.
+	if s.CPUStats.CPUUsage.TotalUsage < prevCpuUsage {
+		return 0.0
+	}
 	intervalsUsed := s.CPUStats.CPUUsage.TotalUsage - prevCpuUsage
 
 	// Percentage avoiding divide-by-zero


### PR DESCRIPTION
## 📃 Description

Fixes #2149.

`CalculateCpuPercentLinux` subtracts the stored previous counters from the current ones without checking direction:

```go
cpuDelta := s.CPUStats.CPUUsage.TotalUsage - prevCpuContainer
systemDelta := s.CPUStats.SystemUsage - prevCpuSystem
```

Both operands are `uint64`. When a stats response is processed after a newer one for the same container/cache interval, or an accounting counter resets, the current total reads lower than the stored previous value and the subtraction wraps to ~2^64 instead of going negative. That matches the ordering hypothesis in the issue, and Docker 29.x returning empty `precpu_stats` for one-shot requests means the agent is relying entirely on its own per-cache-time previous-value maps, so the two sides can disagree.

**There are two failure modes, and only one of them is visible.**

*Container counter rolls back* — the reported one. The percentage explodes, `validateCpuPercentage` rejects it, and `getContainerStats` returns early, so the entire collection is discarded — the container's network stats along with the CPU sample:

```
cpu pct greater than 100: 1.15292150348562e+13
```

*System counter rolls back* — quieter and worse. The wrapped value lands in the **divisor**, so the percentage collapses toward zero, passes `validateCpuPercentage`, and is stored as a healthy sample. Measured on a synthetic rollback: **2.7e-12 %** recorded instead of an error. A busy container silently reports idle for that interval, and nothing is logged.

`CalculateCpuPercentWindows` has the same unguarded subtraction on `intervalsUsed` and is fixed the same way.

## 🪵 Changelog

### 🔧 Fixed

- Container CPU percentage no longer produces an absurd value when a container counter reads lower than the previous sample; the collection is treated as a new baseline (0% for one sample) instead of being discarded together with the container's network stats.
- Container CPU percentage no longer silently reports near-zero when the *system* counter reads lower than the previous sample. This path was not rejected by the existing >100% guard, so it was being stored as real data.
- Same rollback guard applied to the Windows CPU path, which had the identical unguarded subtraction.

## Implementation notes

The guard returns `0.0`, which is what the function already does for the first-run case (`prevCpuContainer == 0`) — a sample with no usable baseline. The suggestion in the issue was the same. Nothing else in the calculation changes, and a normal forward sample takes exactly the same path it did before.

## Verification

Run on Linux (Ubuntu 24.04) in `golang:1.26`, `go test -tags testing`:

**1. Red before the fix.** The two new tests were written first and fail against current `main` with the exact wrap values:

```
--- FAIL: TestCpuPercentageHandlesCounterRollback
    expected: 0
    actual  : 1.8446744073708553e+14      <- container counter rollback
    expected: 0
    actual  : 2.7105054312152305e-12      <- system counter rollback
--- FAIL: TestCpuPercentageWindowsHandlesCounterRollback
    expected: 0
    actual  : 4.611686018427138e+13
```

The container-rollback value is the same order of magnitude as the `1.15292150348562e+13` in the issue report.

**2. Green after the fix.** `TestCpuPercentageHandlesCounterRollback`, `TestCpuPercentageWindowsHandlesCounterRollback`, and the pre-existing `TestCpuPercentageCalculationWithRealData` all pass. Each new test also asserts that a normal forward sample is unaffected (the Linux one checks an exact 5%).

**3. No regression across the suite.** `go test -tags testing ./...` before and after the change: package-level verdicts diff to empty, and the `--- FAIL` list is identical (`TestGetDataDir`, `TestTestDataDirs`). Those two, plus nine `[setup failed]` packages, fail the same way on unmodified `main` in this environment — `internal/site/dist` is not present without a frontend build, which is what `internal/site/embed.go` needs. Exit status 1 before and after, for the same reasons.

**4. `gofmt -l`** on both changed files: no output. **`go vet -tags testing`** on `./internal/entities/container/` and `./agent/`: exit 0. **`go build`** on both packages: OK.

## Related

- Searched open and closed PRs; no duplicate. #2131 (open) is the only other open PR touching `internal/entities/container/container.go`, but it *adds* `CalculateCpuPercentPodman` rather than changing the Linux path, so there is no overlap. Worth noting for whoever reviews that one: the new Podman function does `s.CPUStats.CPUUsage.TotalUsage - prevCpuContainer` with the same lack of a direction check, so it would want the same guard.
- #1975 (hub, memory usage reported in millions of TB) may be the same class of unsigned-delta defect on a different path. Not investigated here.

## 📷 Screenshots

No UI changes.
