### PR TITLE
feat(agent): add arm64 support for nvidia agent

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -41,7 +41,7 @@ jobs:
           # henrygd/beszel-agent-nvidia
           - image: henrygd/beszel-agent-nvidia
             dockerfile: ./internal/dockerfile_agent_nvidia
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             registry: docker.io
             username_secret: DOCKERHUB_USERNAME
             password_secret: DOCKERHUB_TOKEN
@@ -96,7 +96,7 @@ jobs:
           # ghcr.io/henrygd/beszel-agent-nvidia
           - image: ghcr.io/${{ github.repository }}/beszel-agent-nvidia
             dockerfile: ./internal/dockerfile_agent_nvidia
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
             registry: ghcr.io
             username: ${{ github.actor }}
             password_secret: GITHUB_TOKEN


### PR DESCRIPTION
## Description

Add arm64 support for agent's image builds. Enables running on NVIDIA DGX Spark and other ARM64 based GPU platforms.

## Changes

- Added to the platform matrix for both Docker Hub and ghcr.io nvidia agent entries

## Verification

Deployed [the image](https://github.com/rajkumaar23/beszel/pkgs/container/beszel%2Fbeszel-agent-nvidia) built from [my fork](https://github.com/rajkumaar23/beszel) locally onto my DGX Spark:

<img width="2032" height="1162" alt="Screenshot 2026-08-09 at 10 19 18 PM" src="https://github.com/user-attachments/assets/99459a71-4444-4c9b-ab8a-ffc487711e29" />

