### PR TITLE
Fixed Password manager login issue

### DIFF
--- a/internal/site/src/components/login/auth-form.tsx
+++ b/internal/site/src/components/login/auth-form.tsx
@@ -72,8 +72,6 @@ export function UserAuthForm({
 	const handleSubmit = useCallback(
 		async (e: React.FormEvent<HTMLFormElement>) => {
 			e.preventDefault()
-			setIsLoading(true)
-			// store email for later use if mfa is enabled
 			let email = ""
 			try {
 				const formData = new FormData(e.target as HTMLFormElement)
@@ -81,15 +79,20 @@ export function UserAuthForm({
 				const Schema = isFirstRun ? RegisterSchema : LoginSchema
 				const result = v.safeParse(Schema, data)
 				if (!result.success) {
-					console.log(result)
-					const errors = {}
+					const errors: Record<string, string> = {}
 					for (const issue of result.issues) {
-						// @ts-expect-error
-						errors[issue.path[0].key] = issue.message
-					}
+						 const key = issue.path?.[0]?.key as string | undefined
+                                                if (key && key !== "website") {
+                                                        errors[key] = issue.message
+                                                }
+                                        }
+                                        if (Object.keys(errors).length === 0) {
+                                                errors["email"] = "Please check your details and try again."
+                                        }
 					setErrors(errors)
 					return
 				}
+				setIsLoading(true)
 				const { password, passwordConfirm } = result.output
 				email = result.output.email
 				if (isFirstRun) {


### PR DESCRIPTION
## 📃 Description

### Improve Error validation handling in Beszel hub.

## 📖 Documentation

Add a link to the PR for [documentation](https://github.com/henrygd/beszel-docs) changes.

## 🪵 Changelog

### ➕ Added

- Moved `setIsLoading(true)` to after validation passes
The button now only enters loading state when the form is valid and an actual API call is about to be made. If validation fails for any reason, the button stays normal and an error is shown immediately.
- Fallback error handling : It ensures the user sees a message if validation issues cannot be mapped to a known field key.
- Honeypot filtering: explicitly ignores the `website` field, which is good because the hidden honeypot field is not user-visible



### ✏️ Changed

- `setIsLoading(true)` : Moved `setIsLoading` until after validation
- Honeypot field errors are ignored.
- A fallback error message was added
If no issue produced a usable field key, the code now sets:
 `[errors["email"] = "Please check your details and try again.`
  That ensures the user still sees a validation failure instead of silently getting no feedback.


### The changes are in:
  - File: "/internal/site/src/components/login/auth-form.tsx

### 🔧 Fixed
The main fix is in UserAuthForm.handleSubmit during validation failure handling.
- It changed the error mapping from unsafe direct indexing of [issue.path[0].key]) to a safe lookup:
const key = issue.path?.[0]?.key as string | undefined
only assign [errors[key] when [key] exists
- It also ignores the hidden honeypot field [website] so bot-detection validation doesn’t surface as a user-facing field error.
- Finally, it adds a fallback error message when no specific field key can be extracted, ensuring the form still shows an error.



Essentially, This makes validation handling safer and more reliable, especially for unexpected `[issue.path]` shapes.
This fixes #1011 

@svenvg93 
@henrygd 
