### PR TITLE
Adjust containers table height properties

### DIFF
--- a/internal/site/src/components/containers-table/containers-table.tsx
+++ b/internal/site/src/components/containers-table/containers-table.tsx
@@ -237,7 +237,7 @@ const AllContainersTable = memo(function AllContainersTable({
 	return (
 		<div
 			className={cn(
-				"h-min max-h-[calc(100dvh-17rem)] max-w-full relative overflow-auto border rounded-md",
+				"h-min max-w-full relative overflow-auto border rounded-md",
 				// don't set min height if there are less than 2 rows, do set if we need to display the empty state
 				(!rows.length || rows.length > 2) && "min-h-50"
 			)}


### PR DESCRIPTION
Remove max height restriction from containers table.

## 📃 Description

This PR just removes the restriction on the height of the containers-table. It's a bit annoying the double scroll (main page + container list)

## 📷 Screenshots

#### Current version:
<img width="1571" height="836" alt="Screenshot 2026-08-12 at 16 45 48" src="https://github.com/user-attachments/assets/c7926178-fc4f-4e94-ad5a-933e921a42a9" />

#### Proposed version after this PR
<img width="1555" height="919" alt="Screenshot 2026-08-12 at 16 46 06" src="https://github.com/user-attachments/assets/9ed408b4-d49b-4a80-9a7e-6588c2e93865" />
