### PR TITLE
fix(install): detect rc.conf.d override that blocks FreeBSD service start and restart

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -465,9 +465,10 @@ if [ "$UNINSTALL" = true ]; then
     echo "Removing the daily update cron job..."
     rm -f /etc/cron.d/beszel-agent
 
-    # Remove log files
+    # Remove log files. The rc script derives its logfile from $name
+    # (beszel_agent), not from the script filename (beszel-agent).
     echo "Removing log files..."
-    rm -f /var/log/beszel-agent.log
+    rm -f /var/log/beszel_agent.log
 
     # Remove env file and directories
     echo "Removing environment configuration file..."

--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -5,7 +5,7 @@ is_alpine() {
 }
 
 is_openwrt() {
-  grep -qi "OpenWrt" /etc/os-release
+  [ -f /etc/os-release ] && grep -qi "OpenWrt" /etc/os-release
 }
 
 is_freebsd() {
@@ -739,7 +739,7 @@ if [ -f "$BIN_PATH" ]; then
 fi
 
 mv beszel-agent "$BIN_PATH"
-chown beszel:beszel "$BIN_PATH"
+chown "${AGENT_USER}:${AGENT_USER}" "$BIN_PATH"
 chmod 755 "$BIN_PATH"
 
 # Set SELinux context if needed
@@ -802,7 +802,7 @@ EOF
 
   # Create log files with proper permissions
   touch /var/log/beszel-agent.log /var/log/beszel-agent.err
-  chown beszel:beszel /var/log/beszel-agent.log /var/log/beszel-agent.err
+  chown "${AGENT_USER}:${AGENT_USER}" /var/log/beszel-agent.log /var/log/beszel-agent.err
 
   # Start the service
   rc-service beszel-agent restart
@@ -964,6 +964,26 @@ EOF
   echo "Enabling and starting the agent service..."
   sysrc beszel_agent_enable="YES"
   sysrc beszel_agent_user="${AGENT_USER}"
+
+  # sysrc writes to /etc/rc.conf, but rc.subr sources /etc/rc.conf.d/beszel_agent
+  # afterwards, so a stale or third-party file there silently overrides the value
+  # we just set. The service then refuses to start, and rc.subr's own error points
+  # at /etc/rc.conf, which looks correct. Verify the flag actually took effect.
+  # An empty value means this rc.subr does not support "rcvar"; skip the check.
+  rcvar_value=$(service beszel-agent rcvar 2>/dev/null | sed -n 's/^beszel_agent_enable="\(.*\)"$/\1/p')
+  if [ -n "$rcvar_value" ]; then
+    case "$rcvar_value" in
+    [Yy][Ee][Ss] | [Tt][Rr][Uu][Ee] | [Oo][Nn] | 1) ;;
+    *)
+      echo "Error: beszel_agent_enable resolves to \"${rcvar_value}\" even though it was just set to YES in /etc/rc.conf."
+      echo "Another rc configuration file is overriding it. The most likely cause is a leftover:"
+      echo "  /etc/rc.conf.d/beszel_agent"
+      echo "Remove or correct that file, then re-run this installer."
+      exit 1
+      ;;
+    esac
+  fi
+
   service beszel-agent restart
   
   # Check if service started successfully


### PR DESCRIPTION
## TL;DR
This fixes the following error on OPNsense: `Cannot 'restart' beszel_agent. Set beszel_agent_enable to YES in /etc/rc.conf or use 'onerestart' instead of 'restart'.`. It also fixes two places where the agent username and group were still hard coded and adds a filecheck to the openwrt check to prevent a "file not found" error.

## 📃 Description

On FreeBSD the installer enables the service with `sysrc beszel_agent_enable="YES"`, which writes to `/etc/rc.conf`. However, `rc.subr`'s `load_rc_config` sources `/etc/rc.conf.d/$name` *after* `/etc/rc.conf`, and the generated rc script sets `name="beszel_agent"`. Any `/etc/rc.conf.d/beszel_agent` file therefore silently overrides the value the installer just wrote.

When such a file contains `beszel_agent_enable="NO"`, the install fails in a way that is very hard to diagnose:

```
Enabling and starting the agent service...
beszel_agent_enable: NO -> YES
beszel_agent_user: daemon -> daemon
Cannot 'restart' beszel_agent. Set beszel_agent_enable to YES in /etc/rc.conf or use 'onerestart' instead of 'restart'.
Error: The Beszel Agent service failed to start. Checking logs...
2026/08/13 13:54:09 WARN Connection closed err="connection closed, code=1001, reason="
...
```

Two things make this misleading. `rc.subr` advises setting the flag in `/etc/rc.conf`, which the installer has already done — so the suggested fix appears to be satisfied already. And the installer's own handler then tails `/var/log/beszel_agent.log`, which shows unrelated entries from earlier runs and points away from the real cause.

Worth noting that only `start`/`restart` are gated this way. `stop`, `status`, and `rcvar` are exempt from the `checkyesno` test in `run_rc_command`, so the failure surfaces solely at the restart step while everything before it appears to succeed.

This PR adds a check after `sysrc` that confirms the flag actually resolved, and aborts with a message naming the likely override:

```
Enabling and starting the agent service...
beszel_agent_enable: NO -> YES
beszel_agent_user: daemon -> daemon
Error: beszel_agent_enable resolves to "NO" even though it was just set to YES in /etc/rc.conf.
Another rc configuration file is overriding it. The most likely cause is a leftover:
  /etc/rc.conf.d/beszel_agent
Remove or correct that file, then re-run this installer.
```

The check parses `service beszel-agent rcvar` and accepts exactly the values `rc.subr`'s own `checkyesno` accepts (`YES`/`TRUE`/`ON`/`1`, case-insensitive). If `rcvar` produces no value — an older `rc.subr` without support for it — the check is skipped rather than failing closed.

The installer deliberately does not delete or rewrite `/etc/rc.conf.d/beszel_agent`. That file is not owned by Beszel and may belong to another packaging of the agent, so it is reported rather than removed.

Two unrelated fixes visible in the same install log are included:

- `chown beszel:beszel "$BIN_PATH"` was hardcoded, ignoring `$AGENT_USER`. On OPNsense and pfSense the agent runs as `daemon` and no `beszel` user exists, so every install printed `chown: beszel: illegal group name` and left the binary owned by `root:wheel`.
- `is_openwrt()` grepped `/etc/os-release` unconditionally. It is called from several platform `if`/`elif` chains that every platform evaluates, so FreeBSD installs printed `grep: /etc/os-release: No such file or directory` to stderr twice per run.

### Testing

Tested on OPNsense 26.7.2_2-amd64, where the issue was originally found.

- **Install with a conflicting `/etc/rc.conf.d/beszel_agent` present** — aborts with the new message immediately after the `sysrc` lines, before the generic failure path is reached.
- **Install with the file removed** — completes normally, service starts on the first attempt, and none of `Cannot 'restart'`, `chown: beszel: illegal group name`, or the `grep: /etc/os-release` lines appear.
- **Uninstall** — unaffected; stops the running service and removes cleanly.
- **Reboot** — agent starts automatically.

## 🪵 Changelog

### ➕ Added

- Verification that `beszel_agent_enable` actually resolves to a truthy value after `sysrc`, using `service beszel-agent rcvar` and `rc.subr`'s own accepted values.
- An explicit error naming `/etc/rc.conf.d/beszel_agent` as the likely override when the enable flag does not take effect.

### ✏️ Changed

- A FreeBSD install that cannot enable the service now aborts at the point of failure with a specific cause, instead of continuing and reporting a generic "service failed to start" alongside unrelated log output.

### 🔧 Fixed

- `chown` on the agent binary now uses `$AGENT_USER` instead of a hardcoded `beszel` user, fixing `chown: beszel: illegal group name` on OPNsense and pfSense, where the agent runs as `daemon`. The Alpine log-file `chown` was made consistent for the same reason.
- `is_openwrt()` no longer greps `/etc/os-release` when the file does not exist, removing spurious `grep: No such file or directory` errors from FreeBSD installs. Behaviour on OpenWrt is unchanged.
- The uninstall script was also failing to remove the log file since the log file is named `beszel_agent.log` and not `beszel-agent.log`
