### PR TITLE
feat(agent): monitor Intel Arc (xe) GPUs via nvtop

### DIFF
--- a/agent/gpu.go
+++ b/agent/gpu.go
@@ -122,6 +122,7 @@ type gpuCapabilities struct {
 	hasAmdSysfs     bool
 	hasTegrastats   bool
 	hasIntelGpuTop  bool
+	hasXe           bool
 	hasNvtop        bool
 	hasMacmon       bool
 	hasPowermetrics bool
@@ -444,6 +445,7 @@ func (gm *GPUManager) storeSnapshot(id string, gpu *system.GPUData, cacheKey uin
 func (gm *GPUManager) discoverGpuCapabilities() gpuCapabilities {
 	caps := gpuCapabilities{
 		hasAmdSysfs: gm.hasAmdSysfs(),
+		hasXe:       gm.hasXe(),
 	}
 	if _, err := exec.LookPath(nvidiaSmiCmd); err == nil {
 		caps.hasNvidiaSmi = true
@@ -705,7 +707,7 @@ func (gm *GPUManager) resolveLegacyCollectorPriority(caps gpuCapabilities) []col
 		priorities = append(priorities, collectorSourceAmdSysfs)
 	}
 
-	if caps.hasIntelGpuTop {
+	if caps.hasIntelGpuTop && !caps.hasXe {
 		priorities = append(priorities, collectorSourceIntelGpuTop)
 	}
 

--- a/agent/gpu_nvtop.go
+++ b/agent/gpu_nvtop.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -48,9 +49,14 @@ func (gm *GPUManager) updateNvtopSnapshots(snapshots []nvtopSnapshot) bool {
 
 	valid := false
 	usedIDs := make(map[string]struct{}, len(snapshots))
+	var xeName string
 	for i, sample := range snapshots {
+		// nvtop leaves device_name unset on xe devices.
 		if sample.DeviceName == "" {
-			continue
+			if xeName == "" {
+				xeName = xeGpuName()
+			}
+			sample.DeviceName = xeName
 		}
 		indexID := "n" + strconv.Itoa(i)
 		id := indexID
@@ -157,4 +163,39 @@ func (gm *GPUManager) startNvtopCollector(interval string, onFailure func()) {
 			}
 		}
 	}()
+}
+
+// xeDevicePath returns the sysfs device path of the first xe GPU, or "".
+func xeDevicePath() string {
+	cards, err := filepath.Glob("/sys/class/drm/card*")
+	if err != nil {
+		return ""
+	}
+	for _, card := range cards {
+		if strings.Contains(filepath.Base(card), "-") {
+			continue
+		}
+		if uevent, err := utils.ReadStringFileLimited(filepath.Join(card, "device", "uevent"), 4096); err == nil && strings.Contains(uevent, "DRIVER=xe") {
+			return filepath.Join(card, "device")
+		}
+	}
+	return ""
+}
+
+func (gm *GPUManager) hasXe() bool {
+	return xeDevicePath() != ""
+}
+
+// xeGpuName names an xe GPU from its PCI device id; nvtop leaves device_name unset on xe.
+func xeGpuName() string {
+	devicePath := xeDevicePath()
+	if devicePath == "" {
+		return "GPU"
+	}
+	id, err := utils.ReadStringFileLimited(filepath.Join(devicePath, "device"), 64)
+	if err != nil {
+		return "GPU"
+	}
+	id = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(id, "0x")))
+	return "Intel GPU (" + id + ")"
 }

--- a/internal/dockerfile_agent_intel
+++ b/internal/dockerfile_agent_intel
@@ -20,7 +20,7 @@ FROM alpine:3.23
 
 COPY --from=builder /agent /agent
 
-RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing igt-gpu-tools smartmontools
+RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing igt-gpu-tools nvtop smartmontools
 
 # Ensure data persistence across container recreations
 VOLUME ["/var/lib/beszel-agent"]


### PR DESCRIPTION
## Problem

Xe kernel driver is not supported by `intel_gpu_top`, so such GPUs report no data at all. An alternative, nvtop is not included in docker builds.

## Solution

- Detect xe devices via `DRIVER=xe` in `/sys/class/drm/card*/device/uevent`.
- Skip `intel_gpu_top` when an xe device is present and let the existing `nvtop` collector handle the GPU (nvtop >= 3.2 supports the xe driver).
- Add `nvtop` to the Intel agent image.

Behavior is unchanged when `GPU_COLLECTOR` is set explicitly. Auto-detection on xe systems now resolves to nvtop, equivalent to `GPU_COLLECTOR=nvtop`.

## Testing

- `go build`, `go test -tags='testing no_ui' ./agent/...`
- Cross-compiled the agent for darwin/arm64, freebsd/amd64, windows/amd64.
- Live-tested on an Arc Pro B50: with `pid: host`

## Notes

- nvtop reports aggregate GPU usage/temp/power/memory, not per-engine utilization.
- For Intel GPU utilization to show up, the agent container needs the host PID namespace (`pid: host`). Without it, nvtop reports 0% usage (temperature, power, and VRAM still work).
- On mixed systems (xe + NVIDIA/AMD), the primary vendor collector runs and nvtop does not, so the xe card may not be reported (nvtop is last-resort).
