### PR TITLE
fix(hub): guard SSH client against concurrent close race

### DIFF
--- a/internal/hub/systems/system.go
+++ b/internal/hub/systems/system.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -38,6 +39,7 @@ type System struct {
 	Port           string                  `db:"port"`
 	Status         string                  `db:"status"`
 	manager        *SystemManager          // Manager that this system belongs to
+	clientMu       sync.Mutex              // Guards client against concurrent close/replace
 	client         *ssh.Client             // SSH client for fetching data
 	sshTransport   *transport.SSHTransport // SSH transport for requests
 	data           *system.CombinedData    // system data from agent
@@ -434,7 +436,7 @@ func (sys *System) request(ctx context.Context, action common.WebSocketAction, r
 	err := sys.sshTransport.RequestWithRetry(ctx, action, req, dest, 1)
 	// Keep legacy SSH client/version fields in sync for other code paths.
 	if sys.sshTransport != nil {
-		sys.client = sys.sshTransport.GetClient()
+		sys.setClient(sys.sshTransport.GetClient())
 		sys.agentVersion = sys.sshTransport.GetAgentVersion()
 	}
 	return err
@@ -476,8 +478,8 @@ func (sys *System) ensureSSHTransport() error {
 		})
 	}
 	// Sync client state with transport
-	if sys.client != nil {
-		sys.sshTransport.SetClient(sys.client)
+	if client := sys.getClient(); client != nil {
+		sys.sshTransport.SetClient(client)
 		sys.sshTransport.SetAgentVersion(sys.agentVersion)
 	}
 	return nil
@@ -625,7 +627,7 @@ func (sys *System) fetchDataViaSSH(options common.DataRequestOptions) (*system.C
 // The operation can request a retry by returning true as the first return value.
 func (sys *System) runSSHOperation(timeout time.Duration, retries int, operation func(*ssh.Session) (bool, error)) error {
 	for attempt := 0; attempt <= retries; attempt++ {
-		if sys.client == nil || sys.Status == down {
+		if sys.getClient() == nil || sys.Status == down {
 			if err := sys.createSSHClient(); err != nil {
 				return err
 			}
@@ -721,12 +723,12 @@ func (s *System) createSSHClient() error {
 	} else {
 		host = net.JoinHostPort(host, s.Port)
 	}
-	var err error
-	s.client, err = dialSSHWithKeepAlive(network, host, s.manager.sshConfig)
+	client, err := dialSSHWithKeepAlive(network, host, s.manager.sshConfig)
 	if err != nil {
 		return err
 	}
-	s.agentVersion, _ = extractAgentVersion(string(s.client.Conn.ServerVersion()))
+	s.setClient(client)
+	s.agentVersion, _ = extractAgentVersion(string(client.Conn.ServerVersion()))
 	s.manager.resetFailedSmartFetchState(s.Id)
 	return nil
 }
@@ -762,7 +764,11 @@ func dialSSHWithKeepAlive(network, addr string, config *ssh.ClientConfig) (*ssh.
 // createSessionWithTimeout creates a new SSH session with a timeout to avoid hanging
 // in case of network issues
 func (sys *System) createSessionWithTimeout(timeout time.Duration) (*ssh.Session, error) {
-	if sys.client == nil {
+	// Capture a stable local reference so a concurrent closeSSHConnection
+	// replacing/nil-ing sys.client can't yank it out from under the goroutine
+	// below (see #2157).
+	client := sys.getClient()
+	if client == nil {
 		return nil, fmt.Errorf("client not initialized")
 	}
 
@@ -773,7 +779,7 @@ func (sys *System) createSessionWithTimeout(timeout time.Duration) (*ssh.Session
 	errChan := make(chan error, 1)
 
 	go func() {
-		if session, err := sys.client.NewSession(); err != nil {
+		if session, err := client.NewSession(); err != nil {
 			errChan <- err
 		} else {
 			sessionChan <- session
@@ -790,14 +796,33 @@ func (sys *System) createSessionWithTimeout(timeout time.Duration) (*ssh.Session
 	}
 }
 
+// getClient returns the current SSH client, if any, guarding against
+// concurrent replacement/close.
+func (sys *System) getClient() *ssh.Client {
+	sys.clientMu.Lock()
+	defer sys.clientMu.Unlock()
+	return sys.client
+}
+
+// setClient replaces the current SSH client, guarding against concurrent
+// close.
+func (sys *System) setClient(client *ssh.Client) {
+	sys.clientMu.Lock()
+	defer sys.clientMu.Unlock()
+	sys.client = client
+}
+
 // closeSSHConnection closes the SSH connection but keeps the system in the manager
 func (sys *System) closeSSHConnection() {
 	if sys.sshTransport != nil {
 		sys.sshTransport.Close()
 	}
-	if sys.client != nil {
-		sys.client.Close()
-		sys.client = nil
+	sys.clientMu.Lock()
+	client := sys.client
+	sys.client = nil
+	sys.clientMu.Unlock()
+	if client != nil {
+		client.Close()
 	}
 }
 

--- a/internal/hub/systems/system_client_race_test.go
+++ b/internal/hub/systems/system_client_race_test.go
@@ -1,0 +1,127 @@
+//go:build testing
+
+package systems
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+// newTestSSHClient returns a live *ssh.Client backed by an in-process SSH
+// server listening on loopback TCP, so tests can exercise real
+// NewSession()/Close() concurrency instead of a nil stand-in. (net.Pipe is
+// unsuitable here: the SSH version exchange writes from both ends before
+// either reads, which deadlocks on its unbuffered synchronous conn.)
+func newTestSSHClient(t *testing.T) *ssh.Client {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(signer)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { ln.Close() })
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		sconn, chans, reqs, err := ssh.NewServerConn(conn, serverConfig)
+		if err != nil {
+			return
+		}
+		defer sconn.Close()
+		go ssh.DiscardRequests(reqs)
+		for newChan := range chans {
+			ch, chReqs, err := newChan.Accept()
+			if err != nil {
+				continue
+			}
+			go ssh.DiscardRequests(chReqs)
+			go ch.Close()
+		}
+	}()
+
+	clientConfig := &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	client, err := ssh.Dial("tcp", ln.Addr().String(), clientConfig)
+	require.NoError(t, err)
+	return client
+}
+
+// TestSystemClientRace guards against the TOCTOU race from issue #2157: a
+// concurrent closeSSHConnection nil-ing sys.client while
+// createSessionWithTimeout is reading it must never panic, and (run with
+// -race) must never be reported as a data race.
+func TestSystemClientRace(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		sys := &System{ctx: context.Background()}
+		sys.setClient(newTestSSHClient(t))
+
+		var wg sync.WaitGroup
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			_, _ = sys.createSessionWithTimeout(2 * time.Second)
+		}()
+		go func() {
+			defer wg.Done()
+			sys.closeSSHConnection()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = sys.getClient()
+		}()
+		wg.Wait()
+	}
+}
+
+// TestSystemClientRace_MultipleReaders further stresses concurrent readers
+// of sys.client racing against a close, mirroring runSSHOperation's
+// nil-check followed by createSessionWithTimeout's own read.
+func TestSystemClientRace_MultipleReaders(t *testing.T) {
+	sys := &System{ctx: context.Background()}
+	sys.setClient(newTestSSHClient(t))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	defer close(stop)
+
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if sys.getClient() == nil {
+					return
+				}
+				_, _ = sys.createSessionWithTimeout(100 * time.Millisecond)
+			}
+		}()
+	}
+
+	sys.closeSSHConnection()
+	wg.Wait()
+}


### PR DESCRIPTION
## 📃 Description

Fixes a nil pointer dereference panic in the hub caused by a time-of-check/time-of-use race on the SSH client. `createSessionWithTimeout` checked `sys.client == nil` and then, in a separate goroutine, read `sys.client` again to call `.NewSession()`. Meanwhile `closeSSHConnection()` — triggered independently from a different goroutine when a system is paused or deleted — could close and nil out `sys.client` in between those two reads, causing `ssh.(*Client).NewSession` to panic on a nil receiver and crash the hub process.

The fix adds a mutex guarding the `client` field and routes all reads/writes through new `getClient`/`setClient` helpers, and has `createSessionWithTimeout` capture a stable local reference before spawning its goroutine so the check-then-use is race-free.

## 📖 Documentation

N/A — internal bug fix, no user-facing behavior or docs changes.

## 🪵 Changelog

### 🔧 Fixed

- Fixed a race condition where a concurrent SSH connection close (e.g. pausing or deleting a system while it was mid-update) could nil out the SSH client between a nil-check and its use, causing the hub to panic with a nil pointer dereference in `createSessionWithTimeout` (closes #2157).

## 📷 Screenshots

N/A — backend-only concurrency fix, no UI changes.
