### PR TITLE
fix(agent): discover fans on legacy hwmon parent devices

### DIFF
--- a/agent/fans.go
+++ b/agent/fans.go
@@ -72,14 +72,30 @@ func discoverHwmonFans(root string) ([]fanSensor, error) {
 	var sensors []fanSensor
 	for _, entry := range entries {
 		chipDir := filepath.Join(root, entry.Name())
-		chipName := utils.ReadStringFile(filepath.Join(chipDir, "name"))
+		sensorDir := chipDir
+		inputs, _ := filepath.Glob(filepath.Join(sensorDir, "fan*_input"))
+
+		// Some legacy hwmon drivers (notably applesmc) register a hwmon class
+		// device but create fan attributes on the parent platform device. In
+		// sysfs that parent is exposed through hwmonN/device.
+		if len(inputs) == 0 {
+			deviceDir := filepath.Join(chipDir, "device")
+			if deviceInputs, _ := filepath.Glob(filepath.Join(deviceDir, "fan*_input")); len(deviceInputs) > 0 {
+				sensorDir = deviceDir
+				inputs = deviceInputs
+			}
+		}
+
+		chipName := utils.ReadStringFile(filepath.Join(sensorDir, "name"))
+		if chipName == "" {
+			chipName = utils.ReadStringFile(filepath.Join(chipDir, "name"))
+		}
 		if chipName == "" {
 			chipName = entry.Name()
 		}
-		inputs, _ := filepath.Glob(filepath.Join(chipDir, "fan*_input"))
 		for _, inputPath := range inputs {
 			base := strings.TrimSuffix(filepath.Base(inputPath), "_input")
-			label := utils.ReadStringFile(filepath.Join(chipDir, base+"_label"))
+			label := utils.ReadStringFile(filepath.Join(sensorDir, base+"_label"))
 			key := chipName + "_" + base
 			if label != "" {
 				key = chipName + "_" + label

--- a/agent/fans_test.go
+++ b/agent/fans_test.go
@@ -50,6 +50,24 @@ func TestReadHwmonFans(t *testing.T) {
 	}, fans)
 }
 
+// TestReadHwmonFansLegacyParent verifies legacy hwmon layouts such as applesmc,
+// where the hwmon class node exists but fan attributes live on hwmonN/device.
+func TestReadHwmonFansLegacyParent(t *testing.T) {
+	root := t.TempDir()
+	deviceDir := filepath.Join(root, "devices", "applesmc.768")
+	writeFile(t, filepath.Join(deviceDir, "name"), "applesmc\n")
+	writeFile(t, filepath.Join(deviceDir, "fan1_input"), "1202\n")
+	writeFile(t, filepath.Join(deviceDir, "fan1_label"), "Exhaust\n")
+
+	chipDir := filepath.Join(root, "hwmon1")
+	require.NoError(t, os.MkdirAll(chipDir, 0o755))
+	require.NoError(t, os.Symlink(deviceDir, filepath.Join(chipDir, "device")))
+
+	fans, err := readHwmonFans(root)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]uint16{"applesmc_Exhaust": 1202}, fans)
+}
+
 // TestReadHwmonFansMissingRoot returns an error rather than panicking when the
 // hwmon root doesn't exist (e.g. running on a kernel without hwmon support).
 func TestReadHwmonFansMissingRoot(t *testing.T) {


### PR DESCRIPTION
## 📃 Description

Fix Linux fan discovery for legacy hwmon drivers that register a hwmon class device but expose `fan*_input`, labels, and the chip name on the parent device instead of directly under `/sys/class/hwmon/hwmonN`.

This affects `applesmc` on Intel Macs. Beszel 0.18.8 sees the hwmon device, but misses the fan because the RPM file is exposed on the parent platform device.

The change keeps the existing discovery path as-is and only falls back to `hwmonN/device` when no `fan*_input` files are present in `hwmonN` itself. Labels and chip names are then read from the same directory as the discovered fan inputs.

Tested on real hardware:

- MacBook Air 13-inch Mid 2013 (`MacBookAir6,2`)
- Ubuntu Server 26.04 LTS
- Linux 7.0.0-29-generic
- `applesmc`

Before the fix, Beszel showed no fan data even though Linux reported the fan at `/sys/devices/platform/applesmc.768/fan1_input`.

After the fix, the agent reports the sensor as `applesmc_Exhaust` and the fan chart updates correctly in the Beszel UI.

A regression test covering this legacy `applesmc` layout is included.

## 🪵 Changelog

### 🔧 Fixed

- Discover fan sensors exposed on legacy hwmon parent devices such as `applesmc`.
- Read fan labels and chip names from the same sysfs directory used for the discovered fan inputs.
- Add test coverage for the legacy `applesmc` hwmon layout.

## 📷 Screenshots

No UI code changes. The fix was verified end-to-end on a real 2013 MacBook Air, where the `applesmc_Exhaust` fan appears and reports live RPM in the existing Fans chart.

<img width="499" height="333" alt="image" src="https://github.com/user-attachments/assets/0dbeb77b-db3f-48a7-8550-7c481a7a14bd" />

