### PR TITLE
fix(agent): strip invalid UTF-8 from battery names

### DIFF
--- a/agent/battery/battery.go
+++ b/agent/battery/battery.go
@@ -33,7 +33,10 @@ var errNoBatteries = errors.New("no readable batteries")
 func normalizeBatteries(batteries []Battery) []Battery {
 	nameCounts := make(map[string]int, len(batteries))
 	for i := range batteries {
-		name := strings.TrimSpace(batteries[i].Name)
+		// Names come from firmware (e.g. sysfs model_name) and are not guaranteed to
+		// be valid UTF-8. Invalid bytes are rejected when the hub decodes the CBOR
+		// payload, which drops every metric for the system, so strip them here.
+		name := strings.ToValidUTF8(strings.TrimSpace(batteries[i].Name), "")
 		if name == "" {
 			name = "Battery " + strconv.Itoa(i+1)
 		}

--- a/agent/battery/battery.go
+++ b/agent/battery/battery.go
@@ -36,7 +36,7 @@ func normalizeBatteries(batteries []Battery) []Battery {
 		// Names come from firmware (e.g. sysfs model_name) and are not guaranteed to
 		// be valid UTF-8. Invalid bytes are rejected when the hub decodes the CBOR
 		// payload, which drops every metric for the system, so strip them here.
-		name := strings.ToValidUTF8(strings.TrimSpace(batteries[i].Name), "")
+		name := strings.TrimSpace(strings.ToValidUTF8(batteries[i].Name, ""))
 		if name == "" {
 			name = "Battery " + strconv.Itoa(i+1)
 		}

--- a/agent/battery/battery_test.go
+++ b/agent/battery/battery_test.go
@@ -2,6 +2,7 @@ package battery
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,4 +33,16 @@ func TestPrimarySelection(t *testing.T) {
 func TestNormalizeBatteriesFallbackNames(t *testing.T) {
 	bats := normalizeBatteries([]Battery{{}, {}, {Name: "Mouse"}, {Name: "Mouse"}})
 	assert.Equal(t, []string{"Battery 1", "Battery 2", "Mouse", "Mouse (2)"}, []string{bats[0].Name, bats[1].Name, bats[2].Name, bats[3].Name})
+}
+
+func TestNormalizeBatteriesStripsInvalidUTF8(t *testing.T) {
+	// Firmware occasionally reports names that are not valid UTF-8 (a ThinkPad
+	// reporting "LNV-5B11K63024@\xd0" in model_name is a real example).
+	bats := normalizeBatteries([]Battery{{Name: "LNV-5B11K63024@\xd0"}, {Name: "\xff\xfe"}})
+	assert.Equal(t, "LNV-5B11K63024@", bats[0].Name)
+	// A name made up entirely of invalid bytes falls back to the generic name.
+	assert.Equal(t, "Battery 2", bats[1].Name)
+	for _, b := range bats {
+		assert.True(t, utf8.ValidString(b.Name))
+	}
 }


### PR DESCRIPTION
## 📃 Description

Fixes #2240.

Battery names come from firmware and are not guaranteed to be valid UTF-8. On a ThinkPad here,
`/sys/class/power_supply/BAT0/model_name` ends in a lone `0xD0`:

```
# od -c /sys/class/power_supply/BAT0/model_name
0000000   L   N   V   -   5   B   1   1   K   6   3   0   2   4   @ 320
0000020  \n
```

Since 0.18.8 that string is used verbatim as a key in `SystemStats.Batteries`. `fxamacker/cbor`'s
encoder does not validate UTF-8, so the agent sends it without complaint, but the decoder defaults
to `UTF8RejectInvalid`, so the hub cannot decode the payload. The result is that the system records
no stats at all and stays down permanently — downgrading the agent was the only way out.

This sanitizes the name in `normalizeBatteries()`, which is the shared normalization step for the
Linux, Windows and Darwin collectors, so a single line covers all of them. A name consisting only
of invalid bytes becomes empty and falls through to the existing `Battery N` fallback, so that case
stays sane too.

The added test fails before the change and passes after it.

Verified on the machine that triggers the bug: with the patched agent it came back up 45 seconds
after restart, having been down for 11 hours, and the battery is now reported as
`"bats":{"LNV-5B11K63024@":99}`.

The hub-side half of #2240 — `fetchDataViaSSH` decoding an already-drained stream a second time and
therefore logging `EOF` instead of the real decode error — is deliberately not touched here, since
that is your retry logic and there is more than one reasonable way to fix it. Happy to send a
follow-up if you would like it addressed.

## 🪵 Changelog

### 🔧 Fixed

- Battery names containing invalid UTF-8 no longer stop the hub from decoding the agent's payload.
