### PR TITLE
Report the configured listen address after install

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -97,6 +97,31 @@ ensure_trailing_slash() {
   fi
 }
 
+# Read the listen address from the active service configuration. Existing
+# service files are kept as they are, so the configured address can differ from
+# $PORT, which falls back to the default when -p is not passed. LISTEN is
+# checked before PORT to match the agent's own precedence, and the value is read
+# as text so host:port and unix socket paths survive.
+configured_address() {
+  if is_alpine || is_openwrt; then
+    address_file=/etc/init.d/beszel-agent
+  elif is_freebsd; then
+    address_file="$AGENT_DIR/env"
+  else
+    address_file=/etc/systemd/system/beszel-agent.service
+  fi
+
+  [ -f "$address_file" ] || return 0
+
+  # matches Environment="LISTEN=x", export LISTEN="x", LISTEN="x" and LISTEN=x
+  address_value=$(sed -n 's/.*LISTEN="\{0,1\}\([^"]*\)"\{0,1\}.*/\1/p' "$address_file" | head -n 1)
+  if [ -z "$address_value" ]; then
+    address_value=$(sed -n 's/.*PORT="\{0,1\}\([^"]*\)"\{0,1\}.*/\1/p' "$address_file" | head -n 1)
+  fi
+
+  echo "$address_value"
+}
+
 # Generate FreeBSD rc service content
 generate_freebsd_rc_service() {
   cat <<'EOF'
@@ -1140,4 +1165,7 @@ EOF
   fi
 fi
 
-printf "\n\033[32mBeszel Agent has been installed successfully! It is now running on $PORT.\033[0m\n"
+RUNNING_ADDRESS=$(configured_address)
+[ -n "$RUNNING_ADDRESS" ] || RUNNING_ADDRESS=$PORT
+
+printf "\n\033[32mBeszel Agent has been installed successfully! It is now running on $RUNNING_ADDRESS.\033[0m\n"


### PR DESCRIPTION
## 📃 Description

The final line of the installer always echoes `$PORT`:

```sh
printf "\n\033[32mBeszel Agent has been installed successfully! It is now running on $PORT.\033[0m\n"
```

`PORT` falls back to `45876` when `-p` isn't passed, and existing service files are kept as they
are, so a plain upgrade on a host with a custom port reports the wrong number:

```
# service file says LISTEN=45999
$ ./install-agent.sh
Upgrading existing installation. Using existing service configuration.
Systemd service file already exists. Skipping creation.
Beszel Agent has been installed successfully! It is now running on 45876.
```

This reads the address from the active service file instead. Two details worth noting:

- `LISTEN` is checked before `PORT`, matching the precedence in `GetAddress` (`agent/server.go`),
  where `PORT` is the legacy fallback. A config carrying both would otherwise report a port the
  agent isn't using — and the systemd examples in the docs use `LISTEN`.
- The value is read as text rather than digits, so `host:port` and unix socket paths are reported
  as configured instead of being mangled or dropped.

If no address is found the message falls back to `$PORT`, so behaviour on a fresh install is
unchanged.

### Testing

- 11 cases against fixtures in all four service formats: plain port, `LISTEN` winning over `PORT`,
  `host:port`, unix socket paths (quoted and unquoted), a `HUB_URL` on the same file not being
  mistaken for the listen port, and a config with no address line falling back.
- On a systemd host: set a custom port and confirmed a flagless upgrade reported it correctly,
  then added `LISTEN` alongside `PORT` and confirmed `LISTEN` was the one reported.

## 🪵 Changelog

### 🔧 Fixed

- The install script now reports the address the agent is actually configured with instead of
  always echoing the `-p` value or its default.
