### PR TITLE
fix(agent): round load average to two decimals

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -171,9 +171,9 @@ func (a *Agent) getSystemStats(cacheTimeMs uint16) system.Stats {
 
 	// load average
 	if avgstat, err := load.Avg(); err == nil {
-		systemStats.LoadAvg[0] = avgstat.Load1
-		systemStats.LoadAvg[1] = avgstat.Load5
-		systemStats.LoadAvg[2] = avgstat.Load15
+		systemStats.LoadAvg[0] = utils.TwoDecimals(avgstat.Load1)
+		systemStats.LoadAvg[1] = utils.TwoDecimals(avgstat.Load5)
+		systemStats.LoadAvg[2] = utils.TwoDecimals(avgstat.Load15)
 		slog.Debug("Load average", "5m", avgstat.Load5, "15m", avgstat.Load15)
 	} else {
 		slog.Error("Error getting load average", "err", err)


### PR DESCRIPTION
## 📃 Description

Fixes #2071.

`getSystemStats` stores every metric through `utils.TwoDecimals`, except the load averages, which were assigned straight from gopsutil:

```go
systemStats.Cpu = utils.TwoDecimals(cpuMetrics.Total)
systemStats.CpuBreakdown = []float64{utils.TwoDecimals(cpuMetrics.User), ...}
...
systemStats.LoadAvg[0] = avgstat.Load1   // not rounded
```

Linux hides this because `/proc/loadavg` is already two decimal places. Other platforms are not so tidy:

- Windows has no real load average, so gopsutil synthesises one as a decaying EWMA over the `\System\Processor Queue Length` counter. It approaches zero without reaching it, which is where the reporter's `1.3667392689044936e-73` comes from. The value is not wrong, it is just never rounded.
- macOS and BSD divide a fixed point value by `fscale`, giving numbers like `2.55322265625`.

The hub already treats two decimals as the canonical precision here, since `records.go` rounds the load average when averaging records. That left the raw agent records as the only place carrying full precision.

So this is not really Windows specific, it is every platform whose load average does not arrive pre-rounded. Windows is just where it looks alarming.

## 🪵 Changelog

### 🔧 Fixed

- Load average is now rounded to two decimals, consistent with every other metric the agent reports.

## Steps to verify the change

I do not have a Windows box, so I verified on macOS, which has the same unrounded behaviour for the same reason.

Built a small probe from this module calling the same `load.Avg()` the agent calls, cross compiled for darwin/arm64, and ran it natively:

```
before_la: [2.55322265625, 2.7646484375, 2.90234375]
after_la:  [2.55, 2.76, 2.90]
```

`uptime` on the same machine at the same moment:

```
load averages: 2.55 2.76 2.90
```

Also ran:

- `go test -tags="testing no_ui" ./agent/...` — all green, unchanged from before the patch
- `gofmt -l agent/system.go` — clean
- `go vet ./agent/` — clean
- Cross compiled `./internal/cmd/agent` for windows/amd64, linux/amd64, darwin/arm64 and freebsd/amd64

One thing I checked because it looked like a risk: rounding means a genuinely idle Windows host now reports exactly `[0, 0, 0]`, which is close to #982. It does not come back. The `la` field is `cbor:"28,keyasint"` with no `omitempty`, and `json:"la,omitempty"` is a no-op on a `[3]float64`, so the array still serialises.

No test added. `getSystemStats` calls `load.Avg()` directly with no seam to inject a value, and `utils.TwoDecimals` already has its own tests, so a test here would either need a refactor larger than the fix or would only re-test the helper.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [x] I have no unrelated changes in the PR
