### PR TITLE
feat(alerts): add CPU state notifications

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -48,6 +48,7 @@ type SystemAlertFsStats struct {
 // Values pulled from system_stats.stats that are relevant to alerts.
 type SystemAlertStats struct {
 	Cpu          float64                       `json:"cpu"`
+	CpuBreakdown []float64                     `json:"cpub"`
 	Mem          float64                       `json:"mp"`
 	Disk         float64                       `json:"dp"`
 	Bandwidth    [2]uint64                     `json:"b"`

--- a/internal/alerts/alerts_system.go
+++ b/internal/alerts/alerts_system.go
@@ -13,6 +13,29 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 )
 
+var cpuStateAlerts = map[string]struct {
+	index int
+	label string
+}{
+	"CPUIOWait": {2, "CPU I/O Wait"},
+	"CPUSteal":  {3, "CPU Steal Time"},
+}
+
+func cpuStateAlertValue(name string, breakdown []float64) (float64, bool) {
+	state, ok := cpuStateAlerts[name]
+	if !ok || len(breakdown) < 5 {
+		return 0, false
+	}
+	var total float64
+	for _, value := range breakdown {
+		total += value
+	}
+	if total <= 0 {
+		return 0, false
+	}
+	return breakdown[state.index], true
+}
+
 func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *system.CombinedData) error {
 	alerts := am.alertsCache.GetAlertsExcludingNames(systemRecord.Id, "Status")
 	if len(alerts) == 0 {
@@ -67,6 +90,11 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 				continue
 			}
 			val = float64(data.Stats.Battery[0])
+		default:
+			var ok bool
+			if val, ok = cpuStateAlertValue(name, data.Stats.CpuBreakdown); !ok {
+				continue
+			}
 		}
 
 		triggered := alertData.Triggered
@@ -241,13 +269,20 @@ func (am *AlertManager) HandleSystemAlerts(systemRecord *core.Record, data *syst
 				}
 				alert.val += float64(stats.Battery[0])
 			default:
-				continue
+				value, ok := cpuStateAlertValue(alert.name, stats.CpuBreakdown)
+				if !ok {
+					continue
+				}
+				alert.val += value
 			}
 			alert.count++
 		}
 	}
 	// sum up vals for each alert
 	for _, alert := range validAlerts {
+		if alert.count == 0 {
+			continue
+		}
 		switch alert.name {
 		case "Disk":
 			maxPct := float32(0)
@@ -309,6 +344,9 @@ func (am *AlertManager) sendSystemAlert(alert SystemAlertData) {
 	// log.Printf("Sending alert %s: val %f | count %d | threshold %f\n", alert.name, alert.val, alert.count, alert.threshold)
 	systemName := alert.systemRecord.GetString("name")
 
+	if state, ok := cpuStateAlerts[alert.name]; ok {
+		alert.name = state.label
+	}
 	// change Disk to Disk usage
 	if alert.name == "Disk" {
 		alert.name += " usage"
@@ -320,7 +358,7 @@ func (am *AlertManager) sendSystemAlert(alert SystemAlertData) {
 
 	// make title alert name lowercase if not CPU or GPU
 	titleAlertName := alert.name
-	if titleAlertName != "CPU" && titleAlertName != "GPU" {
+	if titleAlertName != "CPU" && titleAlertName != "GPU" && !strings.HasPrefix(titleAlertName, "CPU") {
 		titleAlertName = strings.ToLower(titleAlertName)
 	}
 

--- a/internal/alerts/alerts_system_test.go
+++ b/internal/alerts/alerts_system_test.go
@@ -146,6 +146,20 @@ func setCPUAlertValue(info *system.Info, stats *system.Stats, value float64) {
 	stats.Cpu = value
 }
 
+func setCPUStateAlertValue(_ *system.Info, stats *system.Stats, value []float64) {
+	stats.CpuBreakdown = value
+}
+
+var cpuStateAlertTests = []struct {
+	name     string
+	trigger  []float64
+	resolve  []float64
+	baseline []float64
+}{
+	{"CPUIOWait", []float64{0, 0, 51, 0, 49}, []float64{0, 0, 48, 0, 52}, []float64{0, 0, 10, 0, 90}},
+	{"CPUSteal", []float64{0, 0, 0, 51, 49}, []float64{0, 0, 0, 48, 52}, []float64{0, 0, 0, 10, 90}},
+}
+
 func setMemoryAlertValue(info *system.Info, stats *system.Stats, value float64) {
 	info.MemPct = value
 	stats.MemPct = value
@@ -191,6 +205,11 @@ func setBatteryAlertValue(info *system.Info, stats *system.Stats, value [2]uint8
 
 func TestSystemAlertsOneMin(t *testing.T) {
 	testOneMinuteSystemAlert(t, "CPU", 50, setCPUAlertValue, 51, 49)
+	for _, test := range cpuStateAlertTests {
+		t.Run(test.name, func(t *testing.T) {
+			testOneMinuteSystemAlert(t, test.name, 50, setCPUStateAlertValue, test.trigger, test.resolve)
+		})
+	}
 	testOneMinuteSystemAlert(t, "Memory", 50, setMemoryAlertValue, 51, 49)
 	testOneMinuteSystemAlert(t, "Disk", 50, setDiskAlertValue, 51, 49)
 	testOneMinuteSystemAlert(t, "Bandwidth", 50, setBandwidthAlertValue, [2]uint64{megabytesToBytes(26), megabytesToBytes(25)}, [2]uint64{megabytesToBytes(25), megabytesToBytes(24)})
@@ -204,6 +223,11 @@ func TestSystemAlertsOneMin(t *testing.T) {
 
 func TestSystemAlertsTwoMin(t *testing.T) {
 	testMultiMinuteSystemAlert(t, "CPU", 50, 2, setCPUAlertValue, 10, 51, 48)
+	for _, test := range cpuStateAlertTests {
+		t.Run(test.name, func(t *testing.T) {
+			testMultiMinuteSystemAlert(t, test.name, 50, 2, setCPUStateAlertValue, test.baseline, test.trigger, test.resolve)
+		})
+	}
 	testMultiMinuteSystemAlert(t, "Memory", 50, 2, setMemoryAlertValue, 10, 51, 48)
 	testMultiMinuteSystemAlert(t, "Disk", 50, 2, setDiskAlertValue, 10, 51, 48)
 	testMultiMinuteSystemAlert(t, "Bandwidth", 50, 2, setBandwidthAlertValue, [2]uint64{megabytesToBytes(10), megabytesToBytes(10)}, [2]uint64{megabytesToBytes(26), megabytesToBytes(25)}, [2]uint64{megabytesToBytes(10), megabytesToBytes(10)})
@@ -213,4 +237,18 @@ func TestSystemAlertsTwoMin(t *testing.T) {
 	testMultiMinuteSystemAlert(t, "LoadAvg5", 4, 2, setLoadAvgAlertValue, [3]float64{0, 2, 0}, [3]float64{0, 4.1, 0}, [3]float64{0, 3.5, 0})
 	testMultiMinuteSystemAlert(t, "LoadAvg15", 4, 2, setLoadAvgAlertValue, [3]float64{0, 0, 2}, [3]float64{0, 0, 4.1}, [3]float64{0, 0, 3.5})
 	testMultiMinuteSystemAlert(t, "Battery", 20, 2, setBatteryAlertValue, [2]uint8{21, 0}, [2]uint8{19, 0}, [2]uint8{25, 1})
+}
+
+func TestCPUStateAlertWithoutBreakdown(t *testing.T) {
+	fixture := newSystemAlertTestFixture(t, "CPUSteal", 1, 1)
+	defer fixture.cleanup()
+
+	synctest.Test(t, func(t *testing.T) {
+		submitValue(fixture, t, []float64(nil), setCPUStateAlertValue)
+		submitValue(fixture, t, []float64{0, 0, 0, 0, 0}, setCPUStateAlertValue)
+		waitForSystemAlert(time.Second)
+
+		fixture.assertTriggered(t, false, "Alert should ignore missing CPU breakdown data")
+		assert.Zero(t, fixture.hub.TestMailer.TotalSend(), "No email should be sent without CPU breakdown data")
+	})
 }

--- a/internal/hub/collections_test.go
+++ b/internal/hub/collections_test.go
@@ -50,6 +50,13 @@ func TestCollectionRulesDefault(t *testing.T) {
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.CreateRule)
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.UpdateRule)
 	assert.Equal(t, isUserMatchesUser, *alertsCollection.DeleteRule)
+	alertNames := alertsCollection.Fields.GetByName("name").(*core.SelectField).Values
+	for _, name := range []string{"CPUIOWait", "CPUSteal"} {
+		assert.Contains(t, alertNames, name)
+	}
+	for _, name := range []string{"CPUSystem", "CPUUser", "CPUIdle", "CPUOther"} {
+		assert.NotContains(t, alertNames, name)
+	}
 
 	// alerts_history collection
 	alertsHistoryCollection, err := hub.FindCollectionByNameOrId("alerts_history")

--- a/internal/migrations/1787356800_cpu_state_alerts.go
+++ b/internal/migrations/1787356800_cpu_state_alerts.go
@@ -1,0 +1,36 @@
+package migrations
+
+import (
+	"slices"
+
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+var cpuStateAlertNames = []string{"CPUIOWait", "CPUSteal"}
+
+func init() {
+	m.Register(func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		field := collection.Fields.GetByName("name").(*core.SelectField)
+		for _, name := range cpuStateAlertNames {
+			if !slices.Contains(field.Values, name) {
+				field.Values = append(field.Values, name)
+			}
+		}
+		return app.Save(collection)
+	}, func(app core.App) error {
+		collection, err := app.FindCollectionByNameOrId("alerts")
+		if err != nil {
+			return err
+		}
+		field := collection.Fields.GetByName("name").(*core.SelectField)
+		field.Values = slices.DeleteFunc(field.Values, func(name string) bool {
+			return slices.Contains(cpuStateAlertNames, name)
+		})
+		return app.Save(collection)
+	})
+}

--- a/internal/site/src/components/active-alerts.tsx
+++ b/internal/site/src/components/active-alerts.tsx
@@ -22,7 +22,7 @@ export const ActiveAlerts = () => {
 			for (const alert of alerts[systemId].values()) {
 				if (alert.triggered && alert.name in alertInfo) {
 					activeAlerts.push(alert)
-					alertsKey.push(`${alert.system}${alert.value}${alert.min}`)
+					alertsKey.push(`${alert.id}${alert.value}${alert.min}`)
 				}
 			}
 		}

--- a/internal/site/src/lib/alerts.ts
+++ b/internal/site/src/lib/alerts.ts
@@ -23,6 +23,18 @@ export const alertInfo: Record<string, AlertInfo> = {
 		icon: CpuIcon,
 		desc: () => t`Triggers when CPU usage exceeds a threshold`,
 	},
+	CPUIOWait: {
+		name: () => t`CPU I/O Wait`,
+		unit: "%",
+		icon: CpuIcon,
+		desc: () => t`Triggers when CPU I/O wait exceeds a threshold`,
+	},
+	CPUSteal: {
+		name: () => t`CPU Steal Time`,
+		unit: "%",
+		icon: CpuIcon,
+		desc: () => t`Triggers when CPU steal time exceeds a threshold`,
+	},
 	Memory: {
 		name: () => t`Memory Usage`,
 		unit: "%",

--- a/internal/site/src/locales/ar/ar.po
+++ b/internal/site/src/locales/ar/ar.po
@@ -507,9 +507,17 @@ msgstr "المعالج"
 msgid "CPU Cores"
 msgstr "نوى المعالج"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "انتظار الإدخال/الإخراج للمعالج (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "ذروة المعالج"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "وقت المعالج المسروق (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "يتم التفعيل عندما تنخفض شحنة البطارية أ
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "يتم التفعيل عندما يتجاوز الجمع بين الصعود/الهبوط عتبة معينة"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "يُفعّل عندما يتجاوز وقت انتظار الإدخال/الإخراج للمعالج الحد"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "يُفعّل عندما يتجاوز الوقت المسروق من المعالج الحد"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/bg/bg.po
+++ b/internal/site/src/locales/bg/bg.po
@@ -507,9 +507,17 @@ msgstr "Процесор"
 msgid "CPU Cores"
 msgstr "CPU ядра"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Изчакване на CPU за вход/изход (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Пик на CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Отнето време на CPU (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Задейства се, когато зарядът на батерия
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Задейства се, когато комбинираното качване/сваляне надвиши зададен праг"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Задейства се, когато изчакването на CPU за вход/изход надвиши прага"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Задейства се, когато отнетото време на CPU надвиши прага"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/cs/cs.po
+++ b/internal/site/src/locales/cs/cs.po
@@ -507,9 +507,17 @@ msgstr "Procesor"
 msgid "CPU Cores"
 msgstr "CPU jádra"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Čekání CPU na I/O (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Špička CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Ukradený čas CPU (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Spustí se, když úroveň nabití baterie klesne pod prahovou hodnotu"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Spustí se, když kombinace up/down překročí prahovou hodnotu"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Spustí se, když čekání CPU na I/O překročí prahovou hodnotu"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Spustí se, když ukradený čas CPU překročí prahovou hodnotu"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/da/da.po
+++ b/internal/site/src/locales/da/da.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU-kerner"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU-I/O-ventetid (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU Peak"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU-tid taget af hypervisoren (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Udløses når batteriniveauet falder under en tærskel"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Udløses når de kombinerede op/ned overstiger en tærskel"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Udløses, når CPU-I/O-ventetiden overstiger en tærskelværdi"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Udløses, når CPU-steal-tiden overstiger en tærskelværdi"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/de/de.po
+++ b/internal/site/src/locales/de/de.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU-Kerne"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU-I/O-Wartezeit (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU-Spitze"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Vom Hypervisor entzogene CPU-Zeit (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Löst aus, wenn der Batterieladestand unter einen Schwellenwert fällt"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Löst aus, wenn die kombinierte Up- und Downloadrate einen Schwellenwert überschreitet"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Wird ausgelöst, wenn die CPU-I/O-Wartezeit einen Schwellenwert überschreitet"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Wird ausgelöst, wenn die CPU-Steal-Zeit einen Schwellenwert überschreitet"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/en/en.po
+++ b/internal/site/src/locales/en/en.po
@@ -502,9 +502,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU Cores"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O Wait"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU Peak"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU Steal Time"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1747,6 +1755,14 @@ msgstr "Triggers when battery charge drops below a threshold"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Triggers when combined up/down exceeds a threshold"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Triggers when CPU I/O wait exceeds a threshold"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Triggers when CPU steal time exceeds a threshold"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/es/es.po
+++ b/internal/site/src/locales/es/es.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "Núcleos de CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Espera de E/S de CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Pico de CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Tiempo de CPU sustraído (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Se activa cuando la carga de la batería baja de un umbral"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Se activa cuando la suma de subida/bajada supera un umbral"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Se activa cuando la espera de E/S de CPU supera un umbral"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Se activa cuando el tiempo robado de CPU supera un umbral"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/fa/fa.po
+++ b/internal/site/src/locales/fa/fa.po
@@ -507,9 +507,17 @@ msgstr "پردازنده"
 msgid "CPU Cores"
 msgstr "هسته‌های CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "زمان انتظار ورودی/خروجی CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "حداکثر CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "زمان ربوده‌شده CPU (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "زمانی که شارژ باتری زیر آستانه قرار می‌
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "هنگامی که مجموع بالا/پایین از یک آستانه فراتر رود، فعال می‌شود"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "زمانی فعال می‌شود که انتظار ورودی/خروجی CPU از آستانه عبور کند"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "زمانی فعال می‌شود که زمان ربوده‌شده CPU از آستانه عبور کند"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "Cœurs CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Attente E/S du CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Pic CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Temps CPU volé (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Déclenchement lorsque la charge de la batterie descend en dessous d'un 
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Déclenchement lorsque le montant/descendant combinée dépasse un seuil"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Se déclenche lorsque l’attente E/S du CPU dépasse un seuil"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Se déclenche lorsque le temps CPU volé dépasse un seuil"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/he/he.po
+++ b/internal/site/src/locales/he/he.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "ליבות CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "זמן המתנת קלט/פלט של המעבד (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "שיא CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "זמן מעבד גנוב (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "מופעל כאשר טעינת הסוללה יורדת מתחת לסף"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "מופעל כאשר השילוב של למעלה/למטה עולה על סף"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "מופעל כאשר זמן המתנת הקלט/פלט של המעבד חורג מהסף"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "מופעל כאשר זמן המעבד הגנוב חורג מהסף"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/hr/hr.po
+++ b/internal/site/src/locales/hr/hr.po
@@ -507,9 +507,17 @@ msgstr "Procesor"
 msgid "CPU Cores"
 msgstr "CPU jezgre"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU čekanje na U/I (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU vrhunac"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Ukradeno CPU vrijeme (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Pokreće se kada razina baterije padne ispod praga"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Pokreće se kada kumulativna propusnost gore/dolje premaši prag"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Aktivira se kada CPU čekanje na U/I prijeđe prag"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Aktivira se kada ukradeno CPU vrijeme prijeđe prag"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/hu/hu.po
+++ b/internal/site/src/locales/hu/hu.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU magok"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O-várakozási idő (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU csúcs"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "A hipervizor által elvett CPU-idő (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Riaszt, ha az akkumulátor töltöttségi szintje egy küszöbérték al
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Riaszt, ha a sávszélesség-használat túllép egy küszöbértéket"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Akkor aktiválódik, ha a CPU I/O-várakozási ideje meghaladja a küszöbértéket"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Akkor aktiválódik, ha a CPU steal ideje meghaladja a küszöbértéket"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/id/id.po
+++ b/internal/site/src/locales/id/id.po
@@ -507,9 +507,17 @@ msgstr ""
 msgid "CPU Cores"
 msgstr "Inti CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Waktu tunggu I/O CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Puncak CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Waktu CPU yang diambil hypervisor (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Dipicu ketika baterai turun di bawah ambang batas"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Dipicu ketika up atau down melebihi ambang batas"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Terpicu saat waktu tunggu I/O CPU melebihi ambang batas"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Terpicu saat waktu steal CPU melebihi ambang batas"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/it/it.po
+++ b/internal/site/src/locales/it/it.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "Core CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Attesa I/O della CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Picco CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Tempo CPU sottratto (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Attiva quando la carica della batteria scende sotto una soglia"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Attiva quando il combinato up/down supera una soglia"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Si attiva quando l’attesa I/O CPU supera una soglia"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Si attiva quando il tempo CPU sottratto supera una soglia"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/ja/ja.po
+++ b/internal/site/src/locales/ja/ja.po
@@ -507,9 +507,17 @@ msgstr ""
 msgid "CPU Cores"
 msgstr "CPU コア"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O 待機時間 (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPUピーク"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU スティール時間 (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "バッテリーの充電量がしきい値を下回ったときにトリ
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "上り/下りの合計がしきい値を超えたときにトリガーされます"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "CPU の I/O 待機時間がしきい値を超えたときに発生します"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "CPU のスティール時間がしきい値を超えたときに発生します"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/ko/ko.po
+++ b/internal/site/src/locales/ko/ko.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU 코어"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O 대기 시간 (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU 최대값"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU 스틸 시간 (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "배터리 충전량이 임계값 아래로 떨어질 때 트리거됩니
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "업로드와 다운로드 대역폭의 합이 임계값을 초과할 때 트리거됩니다."
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "CPU I/O 대기 시간이 임계값을 초과하면 트리거됩니다"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "CPU 스틸 시간이 임계값을 초과하면 트리거됩니다"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/nl/nl.po
+++ b/internal/site/src/locales/nl/nl.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU-kernen"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU-I/O-wachttijd (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU-piek"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Door de hypervisor afgenomen CPU-tijd (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Triggert wanneer de batterijlading onder een drempelwaarde daalt"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Triggert wanneer de gecombineerde up/down een drempelwaarde overschrijdt"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Wordt geactiveerd wanneer de CPU-I/O-wachttijd een drempelwaarde overschrijdt"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Wordt geactiveerd wanneer de CPU-steal-tijd een drempelwaarde overschrijdt"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/no/no.po
+++ b/internal/site/src/locales/no/no.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU-kjerner"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O-ventetid (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU-topp"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU-tid tatt av hypervisoren (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Utløses når batterilading faller under en terskel"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Slår inn når kombinert opp/ned overskrider en grenseverdi"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Utløses når CPU I/O-ventetiden overskrider en terskelverdi"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Utløses når CPU steal-tiden overskrider en terskelverdi"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/pl/pl.po
+++ b/internal/site/src/locales/pl/pl.po
@@ -507,9 +507,17 @@ msgstr "Procesor"
 msgid "CPU Cores"
 msgstr "Rdzenie CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Czas oczekiwania CPU na I/O (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Szczyt CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Czas CPU odebrany przez hiperwizor (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Uruchamia się, gdy poziom baterii spadnie poniżej wybranej wartości"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Wyzwalane, gdy łączna wartość w górę/w dół przekroczy próg"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Wyzwala się, gdy czas oczekiwania CPU na I/O przekroczy próg"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Wyzwala się, gdy czas skradziony CPU przekroczy próg"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/pt/pt.po
+++ b/internal/site/src/locales/pt/pt.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "Núcleos de CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Espera de E/S da CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Pico de CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Tempo de CPU retirado (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Dispara quando a carga da bateria cai abaixo de um limite"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Dispara quando a soma de subida/descida excede um limite"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Dispara quando a espera de E/S da CPU excede um limite"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Dispara quando o tempo roubado da CPU excede um limite"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/ru/ru.po
+++ b/internal/site/src/locales/ru/ru.po
@@ -507,9 +507,17 @@ msgstr "ЦП"
 msgid "CPU Cores"
 msgstr "Ядра CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Ожидание ввода-вывода CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Пик CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Недоступное время CPU (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Срабатывает, когда заряд батареи опуск�
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Срабатывает, когда комбинированный вход/выход превышает порог"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Срабатывает, когда доля времени ожидания CPU операций ввода-вывода превышает порог"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Срабатывает, когда доля времени CPU, недоступного виртуальной машине из-за гипервизора, превышает порог"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/sl/sl.po
+++ b/internal/site/src/locales/sl/sl.po
@@ -507,9 +507,17 @@ msgstr "CPE"
 msgid "CPU Cores"
 msgstr "CPU jedra"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Čakanje CPU na V/I (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Vrhunec CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Čas CPU, ki ga odvzame hipervizor (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Sproži se, ko napolnjenost baterije pade pod prag"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Sproži, ko kombinacija gor/dol preseže prag"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Sproži se, ko čakanje CPU na V/I preseže prag"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Sproži se, ko ukradeni čas CPU preseže prag"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/sr/sr.po
+++ b/internal/site/src/locales/sr/sr.po
@@ -507,9 +507,17 @@ msgstr "Процесор"
 msgid "CPU Cores"
 msgstr "CPU језгра"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Чекање процесора на У/И (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU врхунац"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Време процесора које одузима хипервизор (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Pokreće se kada nivo baterije padne ispod praga"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Окида се када комбиновано горе/доле премаши праг"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Активира се када чекање процесора на У/И пређе праг"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Активира се када украдено време процесора пређе праг"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/sv/sv.po
+++ b/internal/site/src/locales/sv/sv.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU-kärnor"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O-väntetid (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU-topp"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU-tid tagen av hypervisorn (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Utlöses när batteriladdningen sjunker under ett tröskelvärde"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Utlöses när kombinerad upp/ner överskrider ett tröskelvärde"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Utlöses när CPU I/O-väntetiden överskrider ett tröskelvärde"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Utlöses när CPU steal-tiden överskrider ett tröskelvärde"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/tr/tr.po
+++ b/internal/site/src/locales/tr/tr.po
@@ -507,9 +507,17 @@ msgstr "İşlemci"
 msgid "CPU Cores"
 msgstr "CPU Çekirdekleri"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU G/Ç Bekleme Süresi (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU Tepe Değeri"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Hipervizörün Aldığı CPU Süresi (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Pil şarjı bir eşiğin altına düştüğünde tetiklenir"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Birleştirilmiş yukarı/aşağı bir eşiği aştığında tetiklenir"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "CPU G/Ç bekleme süresi eşik değerini aştığında tetiklenir"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "CPU steal süresi eşik değerini aştığında tetiklenir"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/uk/uk.po
+++ b/internal/site/src/locales/uk/uk.po
@@ -507,9 +507,17 @@ msgstr "ЦП"
 msgid "CPU Cores"
 msgstr "Ядра ЦП"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Час очікування введення/виведення CPU (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Пік ЦП"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Час CPU, відібраний гіпервізором (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Спрацьовує, коли заряд батареї опускає�
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Спрацьовує, коли відправлення/отримання сумарно перевищує поріг"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Спрацьовує, коли час очікування введення/виведення CPU перевищує порогове значення"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Спрацьовує, коли викрадений час CPU перевищує порогове значення"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/vi/vi.po
+++ b/internal/site/src/locales/vi/vi.po
@@ -507,9 +507,17 @@ msgstr ""
 msgid "CPU Cores"
 msgstr "Nhân CPU"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "Thời gian CPU chờ I/O (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "Đỉnh CPU"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "Thời gian CPU bị hypervisor chiếm dụng (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "Kích hoạt khi mức pin giảm xuống dưới ngưỡng"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "Kích hoạt khi kết hợp lên/xuống vượt quá ngưỡng"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "Kích hoạt khi thời gian CPU chờ I/O vượt ngưỡng"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "Kích hoạt khi thời gian CPU bị chiếm dụng vượt ngưỡng"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/zh-CN/zh-CN.po
+++ b/internal/site/src/locales/zh-CN/zh-CN.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU 核心"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O 等待时间 (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU 峰值"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU 被虚拟机监控程序占用的时间 (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "当电池电量降至阈值以下时触发"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "当网络的上/下行速度超过阈值时触发"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "当 CPU I/O 等待时间超过阈值时触发"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "当 CPU 窃取时间超过阈值时触发"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/zh-HK/zh-HK.po
+++ b/internal/site/src/locales/zh-HK/zh-HK.po
@@ -507,9 +507,17 @@ msgstr "處理器"
 msgid "CPU Cores"
 msgstr "CPU 核心"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O 等待時間 (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU 峰值"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU 被虛擬機監控程式佔用的時間 (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "當電池電量降至閾值以下時觸發"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "當組合的上/下超過閾值時觸發"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "當 CPU I/O 等待時間超過閾值時觸發"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "當 CPU 竊取時間超過閾值時觸發"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"

--- a/internal/site/src/locales/zh/zh.po
+++ b/internal/site/src/locales/zh/zh.po
@@ -507,9 +507,17 @@ msgstr "CPU"
 msgid "CPU Cores"
 msgstr "CPU 核心"
 
+#: src/lib/alerts.ts
+msgid "CPU I/O Wait"
+msgstr "CPU I/O 等待時間 (IOWait)"
+
 #: src/components/systemd-table/systemd-table-columns.tsx
 msgid "CPU Peak"
 msgstr "CPU 峰值"
+
+#: src/lib/alerts.ts
+msgid "CPU Steal Time"
+msgstr "CPU 被虛擬機監控程式占用的時間 (Steal)"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "CPU time"
@@ -1752,6 +1760,14 @@ msgstr "當電池電量降至閾值以下時觸發"
 #: src/lib/alerts.ts
 msgid "Triggers when combined up/down exceeds a threshold"
 msgstr "當總流量超過閾值時觸發"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU I/O wait exceeds a threshold"
+msgstr "當 CPU I/O 等待時間超過閾值時觸發"
+
+#: src/lib/alerts.ts
+msgid "Triggers when CPU steal time exceeds a threshold"
+msgstr "當 CPU 竊取時間超過閾值時觸發"
 
 #: src/lib/alerts.ts
 msgid "Triggers when CPU usage exceeds a threshold"


### PR DESCRIPTION
## 📃 Description

Adds configurable threshold alerts for CPU I/O wait and CPU steal time using the CPU breakdown metrics already collected by the agent and displayed in the CPU Time Breakdown chart.

The new alert types use the same threshold and duration behavior as existing system alerts. For durations longer than one minute, values are averaged over historical system statistics. Missing or empty CPU breakdown data is ignored to prevent false notifications.

This includes the PocketBase schema migration, Hub alert evaluation, web UI entries, translations for all supported locales, and tests for immediate and averaged trigger/resolution behavior.

CPU breakdown metrics require agent version 0.15.3 or newer.

## 🪵 Changelog

### ➕ Added

- Configurable CPU I/O wait (`IOWait`) threshold alerts.
- Configurable CPU steal time (`Steal`) threshold alerts.
- Localized names and descriptions for the new alert types.

## 📷 Screenshots

### Alert configuration

<img width="620" height="271" alt="Screenshot_4" src="https://github.com/user-attachments/assets/f7ea6cb6-7a95-49d2-99e5-a1b2cc0bc8eb" />