### PR TITLE
fix(agent): report allocated swap as used

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -343,7 +343,8 @@ func calculateHostMemoryUsage(v *mem.VirtualMemoryStat, htop bool) (used, cacheB
 	if htop {
 		used = saturatingSub(v.Total, v.Free, cacheBuff)
 	}
-	return used, cacheBuff, saturatingSub(v.SwapTotal, v.SwapFree, v.SwapCached)
+	// Cached swap pages still occupy swap slots and are included in `free`'s used value.
+	return used, cacheBuff, saturatingSub(v.SwapTotal, v.SwapFree)
 }
 
 // saturatingSub subtracts each value, returning zero on underflow.

--- a/agent/system_test.go
+++ b/agent/system_test.go
@@ -47,14 +47,14 @@ func TestCalculateHostMemoryUsage(t *testing.T) {
 			memory:    mem.VirtualMemoryStat{Total: 100, Available: 40, Used: 60, Free: 20, Cached: 25, Buffers: 10, Shared: 5, SwapTotal: 20, SwapFree: 8, SwapCached: 2},
 			used:      60,
 			cacheBuff: 30,
-			swapUsed:  10,
+			swapUsed:  12,
 		},
 		{
 			name:      "inconsistent counters saturate",
 			memory:    mem.VirtualMemoryStat{Total: 100, Available: 110, Used: ^uint64(0) - 9, Free: 90, Cached: 5, Buffers: 10, Shared: 20, SwapTotal: 10, SwapFree: 9, SwapCached: 2},
 			used:      0,
 			cacheBuff: 0,
-			swapUsed:  0,
+			swapUsed:  1,
 		},
 		{
 			name:      "htop subtraction saturates",
@@ -62,7 +62,7 @@ func TestCalculateHostMemoryUsage(t *testing.T) {
 			htop:      true,
 			used:      0,
 			cacheBuff: 25,
-			swapUsed:  15,
+			swapUsed:  20,
 		},
 		{
 			name:      "zero cache from shared cancellation does not fall back",


### PR DESCRIPTION
## 📃 Description

### Problem / Context

Linux reports `SwapCached` for pages that have been read back into memory but still occupy slots in swap. The agent currently subtracts those pages from `SwapTotal - SwapFree`, so Beszel reports less used swap than `free`, Glances, and gopsutil's `SwapMemory` metric.

### Fix

- Count every allocated swap slot as used by calculating `SwapTotal - SwapFree` with the existing saturating subtraction.
- Update the host-memory regression cases to cover cached swap pages and inconsistent counters.

### User impact

The swap graph now matches the allocated swap usage reported by standard system tools instead of underreporting whenever cached swap pages are present.

Fixes #2134

## 🪵 Changelog

### 🔧 Fixed

- Swap usage now includes cached pages that still occupy swap space.

## Verification

- Focused `TestCalculateHostMemoryUsage` run with the Windows agent sources: passed.
- `go vet` over the Windows agent production sources: passed.
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -tags='testing no_ui' ./agent`: all Linux agent tests compiled successfully.
- A broader Windows test run reached unrelated existing platform assumptions: `sensors_test.go` reassigns a Linux-only function variable, and data-directory tests expect Unix path behavior.