### PR TITLE
fix(agent): don't read host CPU and memory totals from a Docker VM

### DIFF
--- a/agent/system.go
+++ b/agent/system.go
@@ -32,7 +32,11 @@ func (a *Agent) refreshSystemDetails() {
 
 	if a.dockerManager != nil {
 		a.systemDetails.Podman = a.dockerManager.IsPodman()
-		hostInfo, _ = a.dockerManager.GetHostInfo()
+		// Docker's host info describes the machine its daemon runs on. On macOS and
+		// Windows that is a Linux VM, so its CPU and memory totals are not this host's.
+		if runtime.GOOS != "darwin" && runtime.GOOS != "windows" {
+			hostInfo, _ = a.dockerManager.GetHostInfo()
+		}
 	}
 
 	a.systemDetails.Hostname, _ = os.Hostname()


### PR DESCRIPTION
## 📃 Description

Closes #2098

`refreshSystemDetails()` seeds `MemoryTotal` and `Threads` from the Docker daemon's `/info` response. That response describes the machine the daemon runs on, which is only this host when Docker shares its kernel. On macOS and Windows it runs inside a Linux VM, so the system-details header reports the VM's memory as the host total — 16 GiB on the reporter's 64 GiB Mac.

The CPU numbers are wrong the same way and for the same reason: `threads` comes from `hostInfo.NCPU`, and the lxc branch immediately below then clamps `cores` down to it, so a VM given fewer CPUs than the Mac has shrinks both values.

The fix only consults Docker's host info where the daemon runs natively. On macOS and Windows the existing fallbacks take over, and those read this host: `mem.VirtualMemory()` for memory and `cpu.Counts(true)` for threads.

Memory percentage, the memory chart and alerts were already correct, since they come from `mem.VirtualMemory()` rather than from Docker.

## 🪵 Changelog

### 🔧 Fixed

- macOS and Windows agents no longer report the Docker VM's memory as the host's total memory
- macOS and Windows agents no longer report the Docker VM's CPU count as the host's cores/threads

## Verification

- `gofmt` clean on the changed file
- `go vet ./agent/...` clean for `GOOS=linux` and `GOOS=darwin`
- `go build ./agent/...` and `go test -c ./agent/` succeed for linux/amd64 and darwin/arm64
- `go test ./internal/...` passes for every package that builds on this Windows host; `internal/hub`, `internal/site` and the two `internal/cmd` packages fail setup here before and after the change, because `agent/sensors_windows.go` embeds a LibreHardwareMonitor artifact this checkout does not build