### PR TITLE
fix(install): generate /etc/machine-id on systems without /proc

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -796,8 +796,8 @@ set_selinux_context
 # Cleanup
 rm -rf "$TEMP_DIR"
 
-# Make sure /etc/machine-id exists for persistent fingerprint
-if [ ! -f /etc/machine-id ]; then
+# Make sure /etc/machine-id exists and is non-empty for persistent fingerprint
+if [ ! -s /etc/machine-id ]; then
   if [ -r /proc/sys/kernel/random/uuid ]; then
     tr -d '-' < /proc/sys/kernel/random/uuid > /etc/machine-id
   elif command -v uuidgen >/dev/null; then

--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -798,7 +798,14 @@ rm -rf "$TEMP_DIR"
 
 # Make sure /etc/machine-id exists for persistent fingerprint
 if [ ! -f /etc/machine-id ]; then
-  cat /proc/sys/kernel/random/uuid | tr -d '-' > /etc/machine-id
+  if [ -r /proc/sys/kernel/random/uuid ]; then
+    tr -d '-' < /proc/sys/kernel/random/uuid > /etc/machine-id
+  elif command -v uuidgen >/dev/null; then
+    # FreeBSD has no /proc/sys/kernel/random/uuid
+    uuidgen | tr -d '-' > /etc/machine-id
+  else
+    echo "No UUID source found, skipping /etc/machine-id creation"
+  fi
 fi
 
 # Check for NVIDIA GPUs and grant device permissions for systemd service


### PR DESCRIPTION
Fixes [#2148 — pfSense agent install script does not generate machine-id correctly](https://github.com/henrygd/beszel/issues/2148).

## Problem

The installer read a UUID from `/proc`, which FreeBSD-based pfSense and OPNsense systems do not provide. Shell redirection created an empty `/etc/machine-id`, and the file-existence guard then prevented every later installer run from repairing it.

## Fix

Use the readable `/proc` UUID on Linux, fall back to `uuidgen` on FreeBSD, and skip creation when neither source exists. The guard now checks for a non-empty file, so rerunning the installer repairs IDs left empty by earlier failed installs.

## User impact

Fresh pfSense/OPNsense installs receive a persistent fingerprint, and already-affected systems recover on the next installer run instead of remaining stuck with fingerprint mismatches.

## Verification

- `sh -n supplemental/scripts/install-agent.sh` — passed.
- `bash -n supplemental/scripts/install-agent.sh` — passed.
- Extracted installer block exercised with an existing empty ID and a `uuidgen` fallback — produced the expected dashless UUID.
- `git diff --check` — passed.