### PR TITLE
Warn when critical ATA SMART attributes are nonzero

### DIFF
--- a/agent/smart.go
+++ b/agent/smart.go
@@ -931,6 +931,9 @@ func (sm *SmartManager) parseSmartForSata(output []byte, deviceType string) (boo
 		if parsed, ok := smart.ParseSmartRawValueString(attr.Raw.String); ok {
 			rawValue = parsed
 		}
+		if smartData.SmartStatus == "PASSED" && rawValue > 0 && (attr.ID == 5 || attr.ID == 197 || attr.ID == 198) {
+			smartData.SmartStatus = "WARNING"
+		}
 		smartAttr := &smart.SmartAttribute{
 			ID:         attr.ID,
 			Name:       attr.Name,

--- a/agent/smart_test.go
+++ b/agent/smart_test.go
@@ -4,8 +4,10 @@ package agent
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/henrygd/beszel/internal/entities/smart"
@@ -85,6 +87,52 @@ func TestParseSmartForSata(t *testing.T) {
 	assert.Equal(t, uint64(2048408248320), deviceData.Capacity)
 	if assert.NotEmpty(t, deviceData.Attributes) {
 		assertAttrValue(t, deviceData.Attributes, "Temperature_Celsius", 31)
+	}
+}
+
+func TestParseSmartForSataWarnsForCriticalAttributes(t *testing.T) {
+	for _, attrID := range []int{5, 197, 198} {
+		t.Run("attribute "+strconv.Itoa(attrID), func(t *testing.T) {
+			jsonPayload := []byte(fmt.Sprintf(`{
+				"smartctl": {"exit_status": 0},
+				"device": {"name": "/dev/sda", "type": "sat"},
+				"model_name": "Example",
+				"serial_number": "WARNING%d",
+				"smart_status": {"passed": true},
+				"temperature": {"current": 30},
+				"ata_smart_attributes": {"table": [{"id": %d, "raw": {"value": 1, "string": "1"}}]}
+			}`, attrID, attrID))
+
+			sm := &SmartManager{SmartDataMap: make(map[string]*smart.SmartData)}
+			hasData, _ := sm.parseSmartForSata(jsonPayload, "")
+			require.True(t, hasData)
+			assert.Equal(t, "WARNING", sm.SmartDataMap[fmt.Sprintf("WARNING%d", attrID)].SmartStatus)
+		})
+	}
+}
+
+func TestParseSmartForSataPreservesFailedAndUnknownStatus(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		temperature int
+		want        string
+	}{
+		{name: "failed", temperature: 30, want: "FAILED"},
+		{name: "unknown", want: "UNKNOWN"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			jsonPayload := []byte(fmt.Sprintf(`{
+				"device": {"name": "/dev/sda", "type": "sat"},
+				"serial_number": "PRESERVE%s",
+				"temperature": {"current": %d},
+				"ata_smart_attributes": {"table": [{"id": 197, "raw": {"value": 1, "string": "1"}}]}
+			}`, test.name, test.temperature))
+
+			sm := &SmartManager{SmartDataMap: make(map[string]*smart.SmartData)}
+			hasData, _ := sm.parseSmartForSata(jsonPayload, "")
+			require.True(t, hasData)
+			assert.Equal(t, test.want, sm.SmartDataMap["PRESERVE"+test.name].SmartStatus)
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #2268

## 📃 Description

### Problem
ATA SMART health remained `PASSED` when smartctl's overall assessment passed, even if critical attributes 5 (reallocated sectors), 197 (pending sectors), or 198 (offline uncorrectable sectors) had a nonzero raw value.

### Fix
Set the ATA drive health to `WARNING` after parsing one of those attributes with a nonzero raw value. Existing `FAILED` and `UNKNOWN` statuses remain unchanged.

### User impact
Users receive a degraded SMART health state and its existing alert path for these early disk-failure indicators, without affecting NVMe, SCSI, eMMC, or mdraid devices.

## 📖 Documentation

N/A - no user-facing command or configuration changes.

## 🪵 Changelog

### 🔧 Fixed

- Warn when critical ATA SMART attributes have nonzero raw values.

## 📷 Screenshots

N/A - no UI changes.

## Verification

- `go test -tags testing ./agent -run '^TestParseSmartForSata' -count=1` passed, including the new synthetic smartctl JSON cases for attributes 5, 197, and 198 and the `FAILED`/`UNKNOWN` preservation cases.
- `go test -tags testing ./agent -count=1` reached unrelated Windows-only failures: Unix error-text and path-separator assertions in `TestGetToken`, `TestAddExtraFilesystemFolders`, and `TestAddPartitionExtraFs`.