### PR TITLE
fix(agent): read TOKEN_FILE like KEY_FILE instead of sending the whole file

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -87,7 +87,32 @@ func getToken() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(tokenBytes)), nil
+	return parseTokenFile(string(tokenBytes), tokenFile)
+}
+
+// parseTokenFile extracts the single token from the contents of TOKEN_FILE.
+// Blank lines and # comments are skipped, mirroring how ParseKeys reads KEY_FILE.
+//
+// KEY_FILE holds one key per line, so it is natural to assume TOKEN_FILE takes a
+// list too. It does not: the agent connects to one hub. Previously the whole file
+// was sent as a single token, and the hub rejected the joined value with a bare
+// 400 that named no cause, leaving "WebSocket connection failed err=unexpected
+// status code: 400" as the only clue.
+func parseTokenFile(contents, path string) (string, error) {
+	var token string
+	for line := range strings.Lines(contents) {
+		line = strings.TrimSpace(line)
+		if len(line) == 0 || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if token != "" {
+			return "", fmt.Errorf("%s must contain a single token: the agent connects to one hub, so a token per hub is not supported", path)
+		}
+		token = line
+	}
+	// An empty file keeps returning an empty token, as before: the caller decides
+	// what to do about it.
+	return token, nil
 }
 
 // getOptions returns the WebSocket client options, creating them if necessary.

--- a/agent/client.go
+++ b/agent/client.go
@@ -90,14 +90,9 @@ func getToken() (string, error) {
 	return parseTokenFile(string(tokenBytes), tokenFile)
 }
 
-// parseTokenFile extracts the single token from the contents of TOKEN_FILE.
-// Blank lines and # comments are skipped, mirroring how ParseKeys reads KEY_FILE.
-//
-// KEY_FILE holds one key per line, so it is natural to assume TOKEN_FILE takes a
-// list too. It does not: the agent connects to one hub. Previously the whole file
-// was sent as a single token, and the hub rejected the joined value with a bare
-// 400 that named no cause, leaving "WebSocket connection failed err=unexpected
-// status code: 400" as the only clue.
+// parseTokenFile reads a single token from TOKEN_FILE.
+// Blank lines and comments are ignored. Multiple tokens are rejected because
+// the agent supports only one outbound hub connection.
 func parseTokenFile(contents, path string) (string, error) {
 	var token string
 	for line := range strings.Lines(contents) {
@@ -106,7 +101,7 @@ func parseTokenFile(contents, path string) (string, error) {
 			continue
 		}
 		if token != "" {
-			return "", fmt.Errorf("%s must contain a single token: the agent connects to one hub, so a token per hub is not supported", path)
+			return "", fmt.Errorf("%s must contain a single token", path)
 		}
 		token = line
 	}

--- a/agent/client_test.go
+++ b/agent/client_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ed25519"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -407,6 +408,41 @@ func TestGetToken(t *testing.T) {
 		token, err := getToken()
 		assert.NoError(t, err)
 		assert.Equal(t, expectedToken, token)
+	})
+
+	t.Run("TOKEN_FILE with surrounding blank lines and comments", func(t *testing.T) {
+		expectedToken := "test-token-with-noise"
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("# hub token\n\n"+expectedToken+"\n\n"), 0o600))
+
+		t.Setenv("TOKEN_FILE", tokenFile)
+
+		token, err := getToken()
+		assert.NoError(t, err)
+		assert.Equal(t, expectedToken, token)
+	})
+
+	t.Run("TOKEN_FILE with multiple tokens is rejected", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("11111111-1111-1111-1111-111111111111\n22222222-2222-2222-2222-222222222222\n"), 0o600))
+
+		t.Setenv("TOKEN_FILE", tokenFile)
+
+		token, err := getToken()
+		require.Error(t, err)
+		assert.Empty(t, token)
+		assert.Contains(t, err.Error(), "must contain a single token")
+	})
+
+	t.Run("TOKEN_FILE holding only comments behaves like an empty file", func(t *testing.T) {
+		tokenFile := filepath.Join(t.TempDir(), "token")
+		require.NoError(t, os.WriteFile(tokenFile, []byte("\n# only a comment\n"), 0o600))
+
+		t.Setenv("TOKEN_FILE", tokenFile)
+
+		token, err := getToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "", token)
 	})
 
 	t.Run("token from BESZEL_AGENT_TOKEN_FILE", func(t *testing.T) {


### PR DESCRIPTION
## 📃 Description

Fixes #2040.

`KEY_FILE` is parsed line by line (`ParseKeys` in `agent/server.go`, which also skips blank lines and `#` comments), so it reads naturally as a list — one key per hub. `TOKEN_FILE` looks like its counterpart but isn't: `getToken` trims the whole file and returns it as one token.

Put two tokens in there to add a second hub and the agent sends `"<uuid>\n<uuid>"` as `X-Token`. The hub's `validateAgentHeaders` rejects anything over 64 characters, and `sendResponseError` is called with an empty message for that branch, so the agent loops on:

```
WARN WebSocket connection failed err="unexpected status code: 400"
```

with nothing pointing at the token file. The reporter in #2040 spent a while on this before filing.

This makes `TOKEN_FILE` parsing mirror `KEY_FILE`: blank lines and `#` comments are skipped, and more than one token is reported at startup instead of being concatenated and sent.

Deliberately left alone:

- **An empty file still returns an empty token.** `TestGetToken/handles_empty_token_file` asserts that explicitly, so it stays.
- **Multiple tokens error out rather than silently taking the first one.** Picking one is a design call that's yours to make — if you'd rather it took the first entry, that's a one-line change.
- **The hub side is untouched.** The empty 400 body may well be deliberate for an unauthenticated endpoint, so this only fixes the agent side.

The error is non-fatal: `ConnectionManager.Start` logs `newWebSocketClient` failures as a warning and carries on, so the SSH path behaves exactly as it does today.

### Verification

Run in a `golang:1.26` container (`go test -tags=testing ./agent/...`):

- The three new subtests pass, and so does the rest of `TestGetToken`.
- Reverting just the `parseTokenFile` call (back to `strings.TrimSpace`) turns exactly those three red and leaves the existing subtests green.
- Restoring gives a green run again, with the file identical to before the revert.
- `TestDirectoryIsWritable/non-writable_directory` fails in that container both with and without this change — it's the container running as root, not this PR.
- `go vet ./agent/...` is clean; `gofmt -l agent/` doesn't list either changed file.

## 🪵 Changelog

### 🔧 Fixed

- `TOKEN_FILE` containing comments or blank lines no longer produces an invalid token.
- A `TOKEN_FILE` with more than one token now fails with a clear message at startup instead of an unexplained `400` from the hub.

### ✏️ Changed

- `TOKEN_FILE` is parsed line by line, consistent with `KEY_FILE`.
