### PR TITLE
ui: hide gpu indicator for host without gpu

### DIFF
--- a/internal/site/src/components/systems-table/systems-table-columns.tsx
+++ b/internal/site/src/components/systems-table/systems-table-columns.tsx
@@ -196,7 +196,13 @@ export function SystemsTableColumns(viewMode: "table" | "grid"): ColumnDef<Syste
 			accessorFn: ({ info }) => info.g || undefined,
 			id: "gpu",
 			name: () => "GPU",
-			cell: TableCellWithMeter,
+			cell: (info) => {
+				const val = info.getValue() as number | undefined
+				if (val === undefined) {
+					return null
+				}
+				return TableCellWithMeter(info)
+			},
 			Icon: GpuIcon,
 			header: sortableHeader,
 		},


### PR DESCRIPTION
## 📃 Description

Hides the GPU indicator on the system overview page for hosts that lack reported GPU metrics.

## 🪵 Changelog

### ✏️ Changed

- GPU indicators for hosts that lack reported GPU metrics are now hidden on the system overview page.
