### PR TITLE
fix(install): add beszel to operator group on FreeBSD for SMART device access

### DIFF
--- a/supplemental/scripts/install-agent.sh
+++ b/supplemental/scripts/install-agent.sh
@@ -678,6 +678,11 @@ elif is_freebsd; then
       echo "Adding beszel to wheel group for self-updates"
       pw group mod wheel -m beszel
     fi
+    # Add the user to the operator group for device access (SMART, /dev/xpt0, /dev/nvme*)
+    if pw group show operator >/dev/null 2>&1; then
+      echo "Adding beszel to operator group for device access"
+      pw group mod operator -m beszel
+    fi
   fi
 
 else


### PR DESCRIPTION
On FreeBSD, the beszel agent needs to be a member of the `operator` group to access SMART-capable devices via `smartctl` (e.g. `/dev/nvme*`, `/dev/xpt0*`). The install script already added the user to `wheel` for self-updates, but that does not grant device access. This change adds the beszel user to `operator` when that group exists, mirroring the existing Linux `disk` group handling.

Closes #1431