### PR TITLE
chore(helm): update app version to 0.19.0

### DIFF
--- a/supplemental/helm/beszel-agent/Chart.yaml
+++ b/supplemental/helm/beszel-agent/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 description: Installs beszel-agent in kubernetes
 home: https://github.com/henrygd/beszel/tree/main/supplemental/helm/beszel-agent
 name: beszel-agent
-appVersion: "0.18.8"
+appVersion: "0.19.0"
 # Bump this version when publishing chart changes.
-version: 0.1.5
+version: 0.1.6
 sources:
   - https://github.com/henrygd/beszel/tree/main/supplemental/helm/beszel-agent
   - https://www.beszel.dev/

--- a/supplemental/helm/beszel-agent/README.md
+++ b/supplemental/helm/beszel-agent/README.md
@@ -80,7 +80,7 @@ Essential parameters to configure:
 | `secret.sshKey` | `ssh-key` | Key name in the secret for the SSH public key |
 | `secret.tokenKey` | `token` | Key name in the secret for the authentication token |
 | `image.repository` | `henrygd/beszel-agent` | Container image |
-| `image.tag` | Chart AppVersion (0.18.8) | Image version |
+| `image.tag` | Chart AppVersion (0.19.0) | Image version |
 | `hostNetwork` | `false` | Use host network for network monitoring |
 | `tolerations` | Allows all taints | Tolerations for running on tainted nodes |
 
@@ -385,7 +385,7 @@ helm upgrade beszel-agent ./beszel-agent \
 
 # Change image version
 helm upgrade beszel-agent ./beszel-agent \
-  --set image.tag="0.18.8"
+  --set image.tag="0.19.0"
 ```
 
 ### Restart All Agents
@@ -522,7 +522,7 @@ kubectl get secret beszel-agent -o jsonpath='{.data.ssh-key}' | base64 -d
 ## Chart Information
 
 - **Chart Version**: 0.1.0
-- **App Version**: 0.18.8
+- **App Version**: 0.19.0
 - **Kubernetes Version**: 1.19+
 - **Maintainer**: cloudwithdan (nikoloskid@pm.me)
 

--- a/supplemental/helm/beszel-hub/Chart.yaml
+++ b/supplemental/helm/beszel-hub/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 description: Installs beszel-hub in kubernetes
 home: https://github.com/henrygd/beszel/tree/main/supplemental/helm/beszel-hub
 name: beszel-hub
-appVersion: "0.18.8"
+appVersion: "0.19.0"
 # Bump this version when publishing chart changes.
-version: 0.1.5
+version: 0.1.6
 sources:
   - https://github.com/henrygd/beszel/tree/main/supplemental/helm/beszel-hub
   - https://www.beszel.dev/

--- a/supplemental/helm/beszel-hub/README.md
+++ b/supplemental/helm/beszel-hub/README.md
@@ -47,7 +47,7 @@ Key configuration options in `values.yaml`:
 |-----------|---------|-------------|
 | `replicaCount` | `1` | Number of Beszel Hub replicas |
 | `image.repository` | `henrygd/beszel` | Container image repository |
-| `image.tag` | Chart AppVersion (0.18.8) | Container image tag |
+| `image.tag` | Chart AppVersion (0.19.0) | Container image tag |
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `service.port` | `8090` | Service port |
 | `persistentVolumeClaim.enabled` | `true` | Enable persistent volume |
@@ -169,7 +169,7 @@ tolerations:
 ```yaml
 replicaCount: 3
 image:
-  tag: "0.18.8"
+  tag: "0.19.0"
 service:
   type: LoadBalancer
 ingress:
@@ -330,7 +330,7 @@ By default, Beszel Hub uses a PersistentVolumeClaim for data storage. Ensure you
 ## Chart Information
 
 - **Chart Version**: 0.1.0
-- **App Version**: 0.18.8
+- **App Version**: 0.19.0
 - **Kubernetes Version**: 1.19+
 - **Maintainer**: cloudwithdan (nikoloskid@pm.me)
 


### PR DESCRIPTION
Updates the Helm charts for [Beszel 0.19.0](https://github.com/henrygd/beszel/releases/tag/v0.19.0) and bumps their chart patch versions. Merging this pull request publishes the updated charts to GHCR.