### PR TITLE
fix(agent): avoid reconnect loops during slow collection

### DIFF
--- a/agent/client.go
+++ b/agent/client.go
@@ -25,7 +25,9 @@ import (
 )
 
 const (
-	wsDeadline = 70 * time.Second
+	// Keep the connection alive long enough for a slow collection cycle to
+	// finish before the hub considers the agent disconnected.
+	wsDeadline = 120 * time.Second
 )
 
 type caCertFileError struct {

--- a/agent/client_test.go
+++ b/agent/client_test.go
@@ -700,3 +700,11 @@ func TestGetToken(t *testing.T) {
 		assert.Equal(t, expectedToken, token, "Whitespace should be stripped from token file content")
 	})
 }
+
+func TestWebSocketDeadlineCoversSlowCollection(t *testing.T) {
+	const minimumDeadline = 120 * time.Second
+
+	if wsDeadline < minimumDeadline {
+		t.Fatalf("WebSocket deadline %s is shorter than the slow-collection window of %s", wsDeadline, minimumDeadline)
+	}
+}


### PR DESCRIPTION
## 📃 Description

Closes #2294

The agent currently resets its WebSocket deadline to 70 seconds, while the hub default collection interval is 60 seconds. A slow collection can exceed that window and make the agent reconnect even though the hub is still servicing it.

This change extends the deadline to 120 seconds and adds a regression test that keeps the slow-collection window from being reduced below two minutes.

## 📖 Documentation

No documentation changes are needed.

## 🪵 Changelog

### 🔧 Fixed

- Prevent reconnect loops when a collection cycle takes longer than 70 seconds.

## 📷 Screenshots

N/A

## Verification

- `go test -tags=testing ./agent -run "Test(WebSocketClient|ConnectionManager|WebSocketDeadline)" -count=1`
- `go test -tags="testing no_ui" ./agent -skip TestDirectoryIsWritable -count=1`
- `go vet -tags=testing ./agent`
- `go build -o /tmp/beszel-agent ./internal/cmd/agent`
- `gofmt` and `git diff --check`

The full agent suite was also compared before and after this change; both runs retain the same container-only `TestDirectoryIsWritable/non-writable_directory` failure because the test container runs as root. No additional failure was introduced.