### PR TITLE
feat(agent): add Docker volume disk usage

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -190,6 +190,7 @@ func (a *Agent) gatherStats(options common.DataRequestOptions) *system.CombinedD
 		} else {
 			slog.Debug("Containers", "err", err)
 		}
+		data.Stats.DockerVolumes = a.dockerManager.volumeSizes()
 	}
 
 	// skip updating systemd services if cache time is not the default 60sec interval

--- a/agent/docker.go
+++ b/agent/docker.go
@@ -68,6 +68,7 @@ type dockerManager struct {
 	apiStats             *container.ApiStats         // Reusable API stats object
 	excludeContainers    []string                    // Patterns to exclude containers by name
 	usingPodman          bool                        // Whether the Docker Engine API is running on Podman
+	volumeManager        *volumeManager              // Collects volume sizes in the background; nil unless enabled
 
 	// Cache-time-aware tracking for CPU stats (similar to cpu.go)
 	// Maps cache time intervals to container-specific CPU usage tracking
@@ -710,6 +711,10 @@ func newDockerManager(agent *Agent) *dockerManager {
 	// Best-effort startup probe. If the engine is not ready yet, getDockerStats will
 	// retry after the first successful /containers/json request.
 	_, _ = manager.checkDockerVersion()
+
+	if manager.volumeManager = newVolumeManager(userAgentTransport); manager.volumeManager != nil {
+		manager.volumeManager.startWorker()
+	}
 
 	return manager
 }

--- a/agent/docker_volumes.go
+++ b/agent/docker_volumes.go
@@ -1,0 +1,132 @@
+package agent
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/henrygd/beszel/agent/utils"
+)
+
+const (
+	minVolumeInterval = time.Minute
+	volumeTimeout     = 5 * time.Minute
+)
+
+// Docker disk usage from /system/df. Engines that ignore the `type` filter also
+// return images, containers and build cache, which are dropped when decoding.
+type systemDfResponse struct {
+	Volumes []struct {
+		Name      string
+		UsageData struct {
+			Size int64
+		}
+	}
+}
+
+// volumeManager collects Docker volume sizes off the metrics path. /system/df
+// can take many seconds while gatherStats holds the agent lock, so a worker
+// refreshes a snapshot in the background and gatherStats reads the last one.
+type volumeManager struct {
+	client   *http.Client
+	interval time.Duration
+	mu       sync.RWMutex
+	sizes    map[string]float64
+}
+
+// newVolumeManager returns nil unless DOCKER_VOLUME_INTERVAL requests collection.
+// It shares the Docker transport but needs its own client for the longer timeout.
+func newVolumeManager(transport http.RoundTripper) *volumeManager {
+	intervalEnv, exists := utils.GetEnv("DOCKER_VOLUME_INTERVAL")
+	if !exists {
+		return nil
+	}
+	interval, err := time.ParseDuration(intervalEnv)
+	if err != nil {
+		slog.Warn("Invalid DOCKER_VOLUME_INTERVAL", "err", err)
+		return nil
+	}
+	if interval <= 0 {
+		slog.Warn("Invalid DOCKER_VOLUME_INTERVAL", "duration", interval)
+		return nil
+	}
+	interval = max(interval, minVolumeInterval)
+	slog.Info("DOCKER_VOLUME_INTERVAL", "duration", interval)
+
+	return &volumeManager{
+		client: &http.Client{
+			Timeout:   volumeTimeout,
+			Transport: transport,
+		},
+		interval: interval,
+	}
+}
+
+func (vm *volumeManager) startWorker() {
+	go func() {
+		for {
+			vm.refresh()
+			time.Sleep(vm.interval)
+		}
+	}()
+}
+
+// refresh replaces the snapshot with current volume sizes. Failures keep the
+// previous snapshot so the chart doesn't gap out on a transient engine error.
+func (vm *volumeManager) refresh() {
+	resp, err := vm.client.Get("http://localhost/system/df?type=volume")
+	if err != nil {
+		slog.Debug("Docker volumes", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Debug("Docker volumes", "status", resp.Status)
+		return
+	}
+
+	var df systemDfResponse
+	if err := json.NewDecoder(resp.Body).Decode(&df); err != nil {
+		slog.Debug("Docker volumes", "err", err)
+		return
+	}
+
+	sizes := make(map[string]float64, len(df.Volumes))
+	for _, volume := range df.Volumes {
+		// Docker reports -1 when it did not compute usage for a volume
+		if volume.Name == "" || volume.UsageData.Size <= 0 {
+			continue
+		}
+		sizes[volume.Name] = utils.BytesToGigabytes(uint64(volume.UsageData.Size))
+	}
+	slog.Debug("Docker volumes", "data", sizes)
+
+	vm.mu.Lock()
+	defer vm.mu.Unlock()
+	vm.sizes = sizes
+}
+
+// snapshot returns a copy of the latest volume sizes, or nil if there are none.
+func (vm *volumeManager) snapshot() map[string]float64 {
+	vm.mu.RLock()
+	defer vm.mu.RUnlock()
+	if len(vm.sizes) == 0 {
+		return nil
+	}
+	sizes := make(map[string]float64, len(vm.sizes))
+	for name, size := range vm.sizes {
+		sizes[name] = size
+	}
+	return sizes
+}
+
+// volumeSizes returns nil when volume collection is disabled.
+func (dm *dockerManager) volumeSizes() map[string]float64 {
+	if dm == nil || dm.volumeManager == nil {
+		return nil
+	}
+	return dm.volumeManager.snapshot()
+}

--- a/agent/docker_volumes_test.go
+++ b/agent/docker_volumes_test.go
@@ -1,0 +1,184 @@
+//go:build testing
+
+package agent
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newVolumeManagerForTest(server *httptest.Server) *volumeManager {
+	return &volumeManager{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: func(_ context.Context, network, _ string) (net.Conn, error) {
+					return net.Dial(network, server.Listener.Addr().String())
+				},
+			},
+		},
+	}
+}
+
+func TestVolumeManagerRefresh(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		expected map[string]float64
+	}{
+		{
+			name:   "parses volume sizes",
+			status: http.StatusOK,
+			body: `{"Volumes":[
+				{"Name":"immich_data","UsageData":{"Size":2147483648}},
+				{"Name":"pg_data","UsageData":{"Size":1073741824}}
+			]}`,
+			expected: map[string]float64{"immich_data": 2, "pg_data": 1},
+		},
+		{
+			name:   "skips volumes without computed usage",
+			status: http.StatusOK,
+			body: `{"Volumes":[
+				{"Name":"counted","UsageData":{"Size":1073741824}},
+				{"Name":"uncounted","UsageData":{"Size":-1}},
+				{"Name":"empty","UsageData":{"Size":0}},
+				{"Name":"","UsageData":{"Size":1073741824}}
+			]}`,
+			expected: map[string]float64{"counted": 1},
+		},
+		{
+			name:   "ignores fields returned by engines without the type filter",
+			status: http.StatusOK,
+			body: `{
+				"LayersSize":123,
+				"Images":[{"Id":"sha256:abc","Size":456}],
+				"Containers":[{"Id":"def","SizeRw":789}],
+				"BuildCache":[{"ID":"ghi","Size":10}],
+				"Volumes":[{"Name":"vol","UsageData":{"Size":536870912}}]
+			}`,
+			expected: map[string]float64{"vol": 0.5},
+		},
+		{
+			name:     "no volumes yields no snapshot",
+			status:   http.StatusOK,
+			body:     `{"Volumes":[]}`,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/system/df", r.URL.Path)
+				assert.Equal(t, "volume", r.URL.Query().Get("type"))
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			vm := newVolumeManagerForTest(server)
+			vm.refresh()
+
+			assert.Equal(t, tc.expected, vm.snapshot())
+		})
+	}
+}
+
+func TestVolumeManagerRefreshKeepsPreviousSnapshotOnError(t *testing.T) {
+	fail := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if fail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"Volumes":[{"Name":"vol","UsageData":{"Size":1073741824}}]}`))
+	}))
+	defer server.Close()
+
+	vm := newVolumeManagerForTest(server)
+	vm.refresh()
+	require.Equal(t, map[string]float64{"vol": 1}, vm.snapshot())
+
+	fail = true
+	vm.refresh()
+	assert.Equal(t, map[string]float64{"vol": 1}, vm.snapshot())
+}
+
+func TestVolumeManagerRefreshKeepsPreviousSnapshotOnMalformedBody(t *testing.T) {
+	body := `{"Volumes":[{"Name":"vol","UsageData":{"Size":1073741824}}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	vm := newVolumeManagerForTest(server)
+	vm.refresh()
+	require.Equal(t, map[string]float64{"vol": 1}, vm.snapshot())
+
+	body = `{"Volumes":`
+	vm.refresh()
+	assert.Equal(t, map[string]float64{"vol": 1}, vm.snapshot())
+}
+
+func TestVolumeManagerSnapshotIsACopy(t *testing.T) {
+	vm := &volumeManager{sizes: map[string]float64{"vol": 1}}
+
+	snapshot := vm.snapshot()
+	snapshot["vol"] = 99
+	snapshot["other"] = 5
+
+	assert.Equal(t, map[string]float64{"vol": 1}, vm.snapshot())
+}
+
+func TestNewVolumeManager(t *testing.T) {
+	tests := []struct {
+		name             string
+		envValue         string
+		envSet           bool
+		expectNil        bool
+		expectedInterval time.Duration
+	}{
+		{name: "disabled when unset", expectNil: true},
+		{name: "disabled when empty", envValue: "", envSet: true, expectNil: true},
+		{name: "disabled when unparseable", envValue: "soon", envSet: true, expectNil: true},
+		{name: "disabled when zero", envValue: "0s", envSet: true, expectNil: true},
+		{name: "disabled when negative", envValue: "-5m", envSet: true, expectNil: true},
+		{name: "clamped to minimum", envValue: "1s", envSet: true, expectedInterval: minVolumeInterval},
+		{name: "uses configured interval", envValue: "30m", envSet: true, expectedInterval: 30 * time.Minute},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envSet {
+				t.Setenv("DOCKER_VOLUME_INTERVAL", tc.envValue)
+			}
+
+			vm := newVolumeManager(http.DefaultTransport)
+
+			if tc.expectNil {
+				assert.Nil(t, vm)
+				return
+			}
+			require.NotNil(t, vm)
+			assert.Equal(t, tc.expectedInterval, vm.interval)
+			assert.Equal(t, volumeTimeout, vm.client.Timeout)
+		})
+	}
+}
+
+func TestDockerManagerVolumeSizes(t *testing.T) {
+	var nilManager *dockerManager
+	assert.Nil(t, nilManager.volumeSizes())
+
+	assert.Nil(t, (&dockerManager{}).volumeSizes())
+
+	dm := &dockerManager{volumeManager: &volumeManager{sizes: map[string]float64{"vol": 1.5}}}
+	assert.Equal(t, map[string]float64{"vol": 1.5}, dm.volumeSizes())
+}

--- a/internal/entities/system/system.go
+++ b/internal/entities/system/system.go
@@ -54,6 +54,7 @@ type Stats struct {
 	Batteries         map[string]uint8     `json:"bats,omitempty" cbor:"37,keyasint,omitempty"`
 	ZfsPools          map[string]*ZfsPool  `json:"z,omitempty" cbor:"39,keyasint,omitempty"`  // ZFS pool metrics, keyed by pool name
 	DiskIOTotal       [2]uint64            `json:"diot,omitzero" cbor:"38,keyasint,omitzero"` // [total read bytes, total write bytes] cumulative device counters
+	DockerVolumes     map[string]float64   `json:"dv,omitempty" cbor:"40,keyasint,omitempty"` // Docker volume sizes in GB, keyed by volume name
 
 }
 

--- a/internal/records/records.go
+++ b/internal/records/records.go
@@ -197,6 +197,9 @@ func AverageSystemStatsSlice(records []system.Stats) system.Stats {
 	tempCount := float64(0)
 	var fanSums map[string]uint64
 	fanCount := uint64(0)
+	// Counted per volume rather than per record, since a volume created or
+	// removed mid-window is only present in some of the records.
+	var volumeCounts map[string]float64
 	zfsPoolCounts := make(map[string]uint64)
 
 	// Accumulate totals
@@ -295,6 +298,18 @@ func AverageSystemStatsSlice(records []system.Stats) system.Stats {
 			tempCount++
 			for key, value := range stats.Temperatures {
 				sum.Temperatures[key] += value
+			}
+		}
+
+		// Accumulate Docker volume sizes
+		if stats.DockerVolumes != nil {
+			if sum.DockerVolumes == nil {
+				sum.DockerVolumes = make(map[string]float64, len(stats.DockerVolumes))
+				volumeCounts = make(map[string]float64, len(stats.DockerVolumes))
+			}
+			for key, value := range stats.DockerVolumes {
+				sum.DockerVolumes[key] += value
+				volumeCounts[key]++
 			}
 		}
 
@@ -446,6 +461,13 @@ func AverageSystemStatsSlice(records []system.Stats) system.Stats {
 	if sum.Temperatures != nil && tempCount > 0 {
 		for key := range sum.Temperatures {
 			sum.Temperatures[key] = twoDecimals(sum.Temperatures[key] / tempCount)
+		}
+	}
+
+	// Average Docker volume sizes
+	for key, count := range volumeCounts {
+		if count > 0 {
+			sum.DockerVolumes[key] = twoDecimals(sum.DockerVolumes[key] / count)
 		}
 	}
 

--- a/internal/records/records_averaging_test.go
+++ b/internal/records/records_averaging_test.go
@@ -696,6 +696,26 @@ func TestAverageSystemStatsSlice_Zfs(t *testing.T) {
 	}, result.ZfsPools["backup"])
 }
 
+func TestAverageSystemStatsSlice_DockerVolumes(t *testing.T) {
+	input := []system.Stats{
+		{
+			DockerVolumes: map[string]float64{"pg_data": 10},
+		},
+		{},
+		{
+			// backup only exists in this record, so it must be averaged over the
+			// records that actually reported it rather than the whole window.
+			DockerVolumes: map[string]float64{"pg_data": 20, "backup": 5},
+		},
+	}
+
+	result := records.AverageSystemStatsSlice(input)
+
+	require.Len(t, result.DockerVolumes, 2)
+	assert.Equal(t, 15.0, result.DockerVolumes["pg_data"])
+	assert.Equal(t, 5.0, result.DockerVolumes["backup"])
+}
+
 // Tests with 10 records matching the common real-world case (10 x 1m -> 1 x 10m).
 func TestAverageSystemStatsSlice_TenRecords(t *testing.T) {
 	input := make([]system.Stats, 10)

--- a/internal/site/src/components/routes/system.tsx
+++ b/internal/site/src/components/routes/system.tsx
@@ -7,7 +7,7 @@ import InfoBar from "./system/info-bar"
 import { useSystemData } from "./system/use-system-data"
 import { CpuChart, ContainerCpuChart } from "./system/charts/cpu-charts"
 import { MemoryChart, ContainerMemoryChart, SwapChart } from "./system/charts/memory-charts"
-import { RootDiskCharts, ExtraFsCharts } from "./system/charts/disk-charts"
+import { RootDiskCharts, ExtraFsCharts, DockerVolumeChart } from "./system/charts/disk-charts"
 import { ZfsCharts } from "./system/charts/zfs-charts"
 import { BandwidthChart, ContainerNetworkChart } from "./system/charts/network-charts"
 import { TemperatureChart, FanChart, BatteryChart } from "./system/charts/sensor-charts"
@@ -65,11 +65,12 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 	const hasSystemd = system.info.sv
 	const hasGpu = hasGpuData || hasGpuPowerData
 	const hasZfs = Object.keys(systemStats.at(-1)?.stats?.z ?? {}).length > 0
+	const hasDockerVolumes = Object.keys(systemStats.at(-1)?.stats?.dv ?? {}).length > 0
 
 	// keep tabsRef in sync for keyboard navigation
 	const tabs = ["core", "disk"]
 	if (hasGpu) tabs.push("gpu")
-	if (hasContainers) tabs.push("containers")
+	if (hasContainers || hasDockerVolumes) tabs.push("containers")
 	if (hasSystemd) tabs.push("services")
 	tabsRef.current = tabs
 
@@ -118,6 +119,8 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 							networkConfig={containerChartConfigs.network}
 						/>
 					)}
+
+					<DockerVolumeChart systemData={systemData} />
 
 					<SwapChart chartData={chartData} grid={grid} dataEmpty={dataEmpty} systemStats={systemStats} />
 
@@ -231,32 +234,37 @@ export default memo(function SystemDetail({ id }: { id: string }) {
 					</TabsContent>
 				)}
 
-				{hasContainers && (
+				{(hasContainers || hasDockerVolumes) && (
 					<TabsContent value="containers" forceMount className={activeTab === "containers" ? "contents" : "hidden"}>
 						{mountedTabs.has("containers") && (
 							<>
 								<div className="grid xl:grid-cols-2 gap-4">
-									<ContainerCpuChart
-										chartData={chartData}
-										grid={grid}
-										dataEmpty={dataEmpty}
-										isPodman={isPodman}
-										cpuConfig={containerChartConfigs.cpu}
-									/>
-									<ContainerMemoryChart
-										chartData={chartData}
-										grid={grid}
-										dataEmpty={dataEmpty}
-										isPodman={isPodman}
-										memoryConfig={containerChartConfigs.memory}
-									/>
-									<ContainerNetworkChart
-										chartData={chartData}
-										grid={grid}
-										dataEmpty={dataEmpty}
-										isPodman={isPodman}
-										networkConfig={containerChartConfigs.network}
-									/>
+									{hasContainers && (
+										<>
+											<ContainerCpuChart
+												chartData={chartData}
+												grid={grid}
+												dataEmpty={dataEmpty}
+												isPodman={isPodman}
+												cpuConfig={containerChartConfigs.cpu}
+											/>
+											<ContainerMemoryChart
+												chartData={chartData}
+												grid={grid}
+												dataEmpty={dataEmpty}
+												isPodman={isPodman}
+												memoryConfig={containerChartConfigs.memory}
+											/>
+											<ContainerNetworkChart
+												chartData={chartData}
+												grid={grid}
+												dataEmpty={dataEmpty}
+												isPodman={isPodman}
+												networkConfig={containerChartConfigs.network}
+											/>
+										</>
+									)}
+									<DockerVolumeChart systemData={systemData} />
 								</div>
 								{hasContainersTable && <ContainersTable systemId={system.id} />}
 							</>

--- a/internal/site/src/components/routes/system/charts/disk-charts.tsx
+++ b/internal/site/src/components/routes/system/charts/disk-charts.tsx
@@ -330,11 +330,12 @@ export function DockerVolumeChart({ systemData }: { systemData: SystemData }) {
 		}
 		const sorted = Object.keys(sizeSums).sort((a, b) => sizeSums[b] - sizeSums[a])
 		const colorMap = {} as Record<string, string>
-		const dataKeys = {} as Record<string, (d: SystemStatsRecord) => number>
+		const dataKeys = {} as Record<string, (d: SystemStatsRecord) => number | null>
 		for (let i = 0; i < sorted.length; i++) {
 			const key = sorted[i]
 			colorMap[key] = `hsl(${((i * 360) / sorted.length) % 360}, var(--chart-saturation), var(--chart-lightness))`
-			dataKeys[key] = (d: SystemStatsRecord) => d.stats?.dv?.[key] ?? 0
+			// we set null instead of 0 so records from before collection was enabled leave a gap
+			dataKeys[key] = (d: SystemStatsRecord) => d.stats?.dv?.[key] ?? null
 		}
 		return { colorMap, dataKeys, sortedKeys: sorted }
 	}, [volumeNamesKey])

--- a/internal/site/src/components/routes/system/charts/disk-charts.tsx
+++ b/internal/site/src/components/routes/system/charts/disk-charts.tsx
@@ -1,14 +1,16 @@
 import { t } from "@lingui/core/macro"
+import { useMemo, useRef } from "react"
 import AreaChartDefault from "@/components/charts/area-chart"
 import { decimalString, formatBytes, toFixedFloat } from "@/lib/utils"
 import type { SystemStatsRecord } from "@/types"
-import { ChartCard, SelectAvgMax } from "../chart-card"
+import { ChartCard, FilterBar, SelectAvgMax } from "../chart-card"
 import { Unit } from "@/lib/enums"
 import { pinnedAxisDomain } from "@/components/ui/chart"
 import DiskIoSheet from "../disk-io-sheet"
+import { dockerOrPodman } from "../chart-data"
 import type { SystemData } from "../use-system-data"
 import { useStore } from "@nanostores/react"
-import { $userSettings } from "@/lib/stores"
+import { $dockerVolumeFilter, $userSettings } from "@/lib/stores"
 
 // Helpers for indexed dios/diosm access
 const dios =
@@ -294,5 +296,104 @@ export function ExtraFsCharts({ systemData }: { systemData: SystemData }) {
 				)
 			})}
 		</div>
+	)
+}
+
+export function DockerVolumeChart({ systemData }: { systemData: SystemData }) {
+	const { chartData, grid, dataEmpty, isPodman } = systemData
+	const { systemStats } = chartData
+
+	const filter = useStore($dockerVolumeFilter)
+
+	const statsRef = useRef(systemStats)
+	statsRef.current = systemStats
+
+	// Derive volume names from the most recent record that has them
+	let volumeNamesKey = ""
+	for (let i = systemStats.length - 1; i >= 0; i--) {
+		const dv = systemStats[i].stats?.dv
+		if (dv) {
+			volumeNamesKey = Object.keys(dv).sort().join("\0")
+			break
+		}
+	}
+
+	// Only recompute colors and dataKey functions when the volume names change
+	const { colorMap, dataKeys, sortedKeys } = useMemo(() => {
+		const sizeSums = {} as Record<string, number>
+		for (const data of statsRef.current) {
+			const dv = data.stats?.dv
+			if (!dv) continue
+			for (const key of Object.keys(dv)) {
+				sizeSums[key] = (sizeSums[key] ?? 0) + dv[key]
+			}
+		}
+		const sorted = Object.keys(sizeSums).sort((a, b) => sizeSums[b] - sizeSums[a])
+		const colorMap = {} as Record<string, string>
+		const dataKeys = {} as Record<string, (d: SystemStatsRecord) => number>
+		for (let i = 0; i < sorted.length; i++) {
+			const key = sorted[i]
+			colorMap[key] = `hsl(${((i * 360) / sorted.length) % 360}, var(--chart-saturation), var(--chart-lightness))`
+			dataKeys[key] = (d: SystemStatsRecord) => d.stats?.dv?.[key] ?? 0
+		}
+		return { colorMap, dataKeys, sortedKeys: sorted }
+	}, [volumeNamesKey])
+
+	const dataPoints = useMemo(() => {
+		const filterTerms = filter
+			? filter
+					.toLowerCase()
+					.split(" ")
+					.filter((term) => term.length > 0)
+			: []
+		return sortedKeys.map((key) => {
+			const filtered = filterTerms.length > 0 && !filterTerms.some((term) => key.toLowerCase().includes(term))
+			return {
+				label: key,
+				dataKey: dataKeys[key],
+				color: colorMap[key],
+				opacity: filtered ? 0.05 : 0.4,
+				strokeOpacity: filtered ? 0.1 : 1,
+				activeDot: !filtered,
+				stackId: "a",
+			}
+		})
+	}, [sortedKeys, filter, dataKeys, colorMap])
+
+	if (dataPoints.length === 0) {
+		return null
+	}
+
+	const legend = dataPoints.length < 12
+
+	return (
+		<ChartCard
+			empty={dataEmpty}
+			grid={grid}
+			title={dockerOrPodman(t`Docker Volume Usage`, isPodman)}
+			description={t`Disk usage of volumes`}
+			cornerEl={<FilterBar store={$dockerVolumeFilter} />}
+			legend={legend}
+		>
+			<AreaChartDefault
+				chartData={chartData}
+				dataPoints={dataPoints}
+				domain={pinnedAxisDomain()}
+				legend={legend}
+				showTotal={true}
+				reverseStackOrder={true}
+				filter={filter}
+				truncate={true}
+				itemSorter={(a, b) => b.value - a.value}
+				tickFormatter={(val) => {
+					const { value, unit } = formatBytes(val * 1024, false, Unit.Bytes, true)
+					return `${toFixedFloat(value, value >= 10 ? 0 : 1)} ${unit}`
+				}}
+				contentFormatter={({ value }) => {
+					const { value: convertedValue, unit } = formatBytes(value * 1024, false, Unit.Bytes, true)
+					return `${decimalString(convertedValue)} ${unit}`
+				}}
+			/>
+		</ChartCard>
 	)
 }

--- a/internal/site/src/lib/stores.ts
+++ b/internal/site/src/lib/stores.ts
@@ -67,6 +67,9 @@ export const $temperatureFilter = atom("")
 /** Fan-speed chart filter */
 export const $fanFilter = atom("")
 
+/** Docker volume chart filter */
+export const $dockerVolumeFilter = atom("")
+
 /** Fallback copy to clipboard dialog content */
 export const $copyContent = atom("")
 

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -153,6 +153,8 @@ export interface SystemStats {
 	efs?: Record<string, ExtraFsStats>
 	/** ZFS pool metrics */
 	z?: Record<string, ZfsPool>
+	/** Docker volume sizes (GB), keyed by volume name */
+	dv?: Record<string, number>
 	/** GPU data */
 	g?: Record<string, GPUData>
 	/** battery percent and state */


### PR DESCRIPTION
## 📃 Description

As I needed a way of monitoring and showing the size of docker volumes, as per requested in #860 I'm opening this PR.

Adds a "Docker Volume Usage" chart showing the size of each Docker volume next to the existing container CPU, memory and network charts (Closes #860).

Sizes come from the Docker API's `/system/df` endpoint. That call can be slow especially on large volumes, so the collection is off by default and enabled with a new agent env var `DOCKER_VOLUME_INTERVAL` (a duration, minimum 1m). Agents that don't set it send nothing and do no extra work.

Collection runs in a background worker so the slow call never blocks gatherStats, and a failed request keeps the previous snapshot. 

Data is stored on `system.Stats` as `dv`, a map of volume name to size in GB, and averaged per volume.

A nice to have follow-up could be adding Alerts on volume size 😃 

## 📖 Documentation

[Docs PR here](https://github.com/henrygd/beszel-docs/pull/78)

## 🪵 Changelog

### ➕ Added

- Docker volume usage chart, data collection is enabled with the `DOCKER_VOLUME_INTERVAL` agent environment variable

## 📷 Screenshots
<img width="1681" height="380" alt="image" src="https://github.com/user-attachments/assets/5ef5e023-5d12-49cf-8646-eca1a1a333c7" />
