### PR TITLE
feat(hub): add external uptime monitors (http, tls, dns, ping)

### DIFF
--- a/docs/superpowers/plans/2026-09-04-uptime-monitors-pr1.md
+++ b/docs/superpowers/plans/2026-09-04-uptime-monitors-pr1.md
@@ -1,0 +1,357 @@
+# Uptime Monitors PR1 — Plan d'exécution TDD avec sub-agents (juste ce qu'il faut)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implémenter les monitors externes PR1 (http, keyword, tls, dns, ping, hub-only) en TDD strict, en déléguant aux sub-agents uniquement les tâches bornées et indépendantes.
+
+**Architecture:** Nouveau package `internal/hub/monitors/` (types + 4 checkers + SSRF + scheduler/manager), 2 collections PocketBase (`monitors`, `monitor_checks`), routes REST, notifs via `AlertManager` existant, UI React au style Beszel. Zéro touche à `agent/`, `entities/`, `common/`, WS/SSH/CBOR.
+
+**Tech Stack:** Go 1.27.1, PocketBase v0.40.2 (SQLite), std `net/http` + `crypto/tls`, `github.com/miekg/dns`, `github.com/prometheus-community/pro-bing` (package `probing`), React 19 + Vite + Tailwind + recharts + valibot + Lingui.
+
+## Global Constraints
+
+- Branche `feat/uptime-monitors`, fork `origin`, `upstream = henrygd/beszel`. Petits commits conventionnels (1 checker/commit). Rebase `upstream/main` avant PR.
+- `interval` défaut 60, min 20, max 86400 (s). `timeout` défaut 10 (s), **toujours < interval** (validation). `max_retries` défaut 2, 0–10. DOWN au (max_retries+1)e échec.
+- `warn_days` 21, `crit_days` 7 (`crit < warn`). Corps réponse HTTP max 2 Mo, body config max 1 Mo, headers custom ≤ 20, `max_redirects` 1–20 (défaut 10). `User-Agent: Beszel-Monitor`.
+- Seules deps ajoutées : `miekg/dns`, `prometheus-community/pro-bing`. Pas de lib cron, pas de client HTTP tiers.
+- Secrets (`password`, `token`) chiffrés, redacted `••••••` en lecture API, jamais loggés. `allow_private_network=false` par défaut.
+- 1 transaction par cycle de check. Concurrence globale ≤ 10 (`MONITORS_MAX_CONCURRENT`, max 50). Test manuel : 1/10 s par monitor, 10/min par user, **sans écriture** d'historique. Historique : défaut 200, max 1000.
+- Chaque tâche TDD suit RED (test qui échoue pour la bonne raison) → GREEN (code minimal) → REFACTOR. `gofmt -l` propre, `go vet ./...` OK avant chaque commit. Tests avec `-count=1`.
+- Spec : `docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-spec.md`. Todo : `2026-09-04-uptime-monitors-pr1-todo.md`.
+
+---
+
+## File Structure
+
+```
+internal/hub/monitors/
+  models.go          Task 1 — Monitor, MonitorType, CheckResult, StatusUp/Down/Warn, Validate() error
+  models_test.go     Task 1
+  ssrf.go            Task 2 — IsPrivateIP, DialContext SSRF-safe, redirect re-validation
+  ssrf_test.go       Task 2
+  checker_http.go    Task 3 — CheckHTTP(ctx, Monitor) CheckResult (stdlib)
+  checker_http_test.go
+  checker_tls.go     Task 4 — CheckTLS(ctx, Monitor) CheckResult (stdlib)
+  checker_tls_test.go
+  checker_dns.go     Task 5 — CheckDNS(ctx, Monitor) CheckResult (miekg/dns)
+  checker_dns_test.go
+  checker_ping.go    Task 6 — CheckPing(ctx, Monitor) CheckResult (pro-bing)
+  checker_ping_test.go
+  manager.go         Task 7 — Manager, cache, hooks PB, RunCheck dispatch
+  scheduler.go       Task 7 — 1 goroutine/monitor, ticker, jitter, sémaphore
+  scheduler_test.go  Task 7
+  api.go             Task 9 — 7 routes REST
+  api_test.go        Task 9
+internal/migrations/<ts>_monitors.go   Task 8 — m.Register + revert
+internal/hub/collections.go            Task 8 — règles monitors + monitor_checks
+internal/records/                      Task 8 — rétention monitor_checks
+internal/alerts/                       Task 10 — transitions → SendAlert + history
+internal/site/src/...                  Task 11 — routes, dialog, lib, i18n
+internal/hub/config/config.go          Task 12 — monitors: YAML
+```
+
+## Routage sub-agents (uniquement lorsque nécessaire)
+
+- **Subagent (frais, contexte isolé) : Tasks 2, 3, 4, 5, 6.** Fonctions pures, 1–2 fichiers, contrats figés ci-dessous, tests avec serveurs locaux (`httptest`, DNS fake, CA de test). Aucune dépendance DB/hub — le subagent n'a besoin que de sa tâche.
+- **Inline (session principale) : Tasks 0, 1, 7, 8, 9, 10, 11, 12, 13.** Fondations d'interfaces (1), concurrence/état partagé (7), DB et migrations (8), wiring auth/hub (9, 10), UI/YAML/docs (11–13) — transverses, nécessitent le contexte global.
+- **Review après chaque tâche subagent** : agent `code-reviewer` (conformité spec + qualité). Fix loop ≤ 5 rounds, puis arbitrage. **Final review** whole-branch une fois, sur le modèle le plus capable, puis UNE vague de fix + une re-review cadrée.
+
+---
+
+### Task 0: Vérification environnement (inline — déjà partiellement fait)
+
+**Files:** aucun (contrôles uniquement)
+
+**Interfaces:** Consumes: rien. Produces: feu vert outillage.
+
+- [ ] **Step 1: Vérifier Go et l'arbre**
+
+```bash
+go version && gofmt -l internal/ docs/ && go vet ./internal/hub/... && git status -sb
+```
+
+Expected: `go1.27.1`, aucune sortie `gofmt -l`, vet sans erreur nouvelle, branche `feat/uptime-monitors`.
+
+- [ ] **Step 2: Ajouter les 2 dépendances**
+
+```bash
+go get github.com/miekg/dns github.com/prometheus-community/pro-bing && go build ./... 
+```
+
+Expected: `go.mod`/`go.sum` à jour, build OK. Si le fetch réseau échoue : STOP, demander (pas de bricolage, pas de paquet système — consigne Arch).
+
+---
+
+### Task 1: Types + validation (inline — fondation, tous en dépendent)
+
+**Files:**
+- Create: `internal/hub/monitors/models.go`
+- Test: `internal/hub/monitors/models_test.go`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces (contrats verbatim pour Tasks 2–7, 9) :
+  - `type MonitorType string` + `TypeHTTP, TypeKeyword, TypePing, TypeDNS, TypeTLS`
+  - `StatusUp, StatusDown, StatusWarn = "up", "down", "warn"`
+  - `type Monitor struct { Name string; Type MonitorType; Target string; IntervalSeconds int; TimeoutSeconds int; MaxRetries int; UpsideDown bool; Config map[string]any }`
+  - `type CheckResult struct { Status string; LatencyMs float64; Code *int; Message string; Details map[string]any; CertDays *float64 }`
+  - `func (m Monitor) Validate() error` (interval 20–86400, timeout < interval, max_retries 0–10, target non vide, type connu)
+  - `func CheckHTTP/CheckTLS/CheckDNS/CheckPing(ctx context.Context, m Monitor) CheckResult`
+  - `func RunCheck(ctx context.Context, m Monitor) CheckResult` (dispatch, Task 7)
+
+- [ ] **Step 1: Écrire le test qui échoue**
+
+```go
+func TestValidate_TimeoutMustBeLessThanInterval(t *testing.T) {
+	m := Monitor{Name: "t", Type: TypeHTTP, Target: "https://example.com", IntervalSeconds: 60, TimeoutSeconds: 60, MaxRetries: 2}
+	if err := m.Validate(); err == nil {
+		t.Fatal("expected error when timeout >= interval")
+	}
+}
+```
+
+- [ ] **Step 2: Lancer et vérifier l'échec**
+
+Run: `go test ./internal/hub/monitors/ -run TestValidate_TimeoutMustBeLessThanInterval -v -count=1`
+Expected: FAIL (`undefined: Monitor` — le type n'existe pas encore, c'est la bonne raison).
+
+- [ ] **Step 3: Implémentation minimale**
+
+```go
+package monitors
+
+type MonitorType string
+
+const (
+	TypeHTTP    MonitorType = "http"
+	TypeKeyword MonitorType = "keyword"
+	TypePing    MonitorType = "ping"
+	TypeDNS     MonitorType = "dns"
+	TypeTLS     MonitorType = "tls"
+)
+
+const (StatusUp = "up"; StatusDown = "down"; StatusWarn = "warn")
+
+type Monitor struct {
+	Name string; Type MonitorType; Target string
+	IntervalSeconds int; TimeoutSeconds int; MaxRetries int
+	UpsideDown bool; Config map[string]any
+}
+
+type CheckResult struct {
+	Status string; LatencyMs float64; Code *int
+	Message string; Details map[string]any; CertDays *float64
+}
+
+func (m Monitor) Validate() error {
+	switch m.Type {
+	case TypeHTTP, TypeKeyword, TypePing, TypeDNS, TypeTLS:
+	default:
+		return fmt.Errorf("unknown monitor type %q", m.Type)
+	}
+	if m.Target == "" {
+		return errors.New("target is required")
+	}
+	if m.IntervalSeconds < 20 || m.IntervalSeconds > 86400 {
+		return fmt.Errorf("interval must be 20..86400 seconds")
+	}
+	if m.TimeoutSeconds <= 0 || m.TimeoutSeconds >= m.IntervalSeconds {
+		return fmt.Errorf("timeout must be > 0 and < interval")
+	}
+	if m.MaxRetries < 0 || m.MaxRetries > 10 {
+		return fmt.Errorf("max_retries must be 0..10")
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Vérifier le vert + tout le package**
+
+Run: `go test ./internal/hub/monitors/ -v -count=1`
+Expected: PASS, sortie propre.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/hub/monitors/models.go internal/hub/monitors/models_test.go
+git commit -m "feat(monitors): add monitor types and validation"
+```
+
+---
+
+### Task 2: Garde SSRF (SUBAGENT — fonction pure, bornée)
+
+**Files:**
+- Create: `internal/hub/monitors/ssrf.go`
+- Test: `internal/hub/monitors/ssrf_test.go`
+
+**Interfaces:**
+- Consumes: rien (net std uniquement).
+- Produces (pour Tasks 3–6) : `func IsPrivateIP(ip net.IP) bool`, `func GuardDialContext(ctx, network, addr) (net.Conn, error)` (résout, vérifie chaque IP, bloque réseau privé sauf `allow_private_network=true`), helper `func ParsePortOrDefault(hostport string, def int) (string, int, error)`.
+
+Brief subagent : contrat ci-dessus + liste des plages bloquées (loopback 127/8 + ::1, 10/8, 172.16/12, 192.168/16, 169.254/16, IPv6 link-local fe80::/10 + unique-local fc00::/7, 0.0.0.0) + env `MONITORS_ALLOW_PRIVATE_NETWORK`. TDD : tests table-driven (publique OK, chaque plage KO, override env OK), `httptest` + redirect public→privé KO.
+
+- [ ] **Step 1: Test qui échoue** (ex. `TestIsPrivateIP_BlocksLoopback` sur `127.0.0.1` et `::1`).
+- [ ] **Step 2: Run, FAIL attendu** (`undefined: IsPrivateIP`).
+- [ ] **Step 3: Implémentation minimale** (table CIDR + `ip.IsLoopback/IsLinkLocal/Unicast` + check).
+- [ ] **Step 4: Vert + matrice complète** (toutes plages + override env + dialer).
+- [ ] **Step 5: Commit** `feat(monitors): add SSRF guard for outbound checks`.
+- [ ] **Step 6: Review** code-reviewer (spec §10.1 + qualité). Fix loop si findings.
+
+---
+
+### Task 3: Checker HTTP + keyword (SUBAGENT — std uniquement)
+
+**Files:**
+- Create: `internal/hub/monitors/checker_http.go`
+- Test: `internal/hub/monitors/checker_http_test.go`
+
+**Interfaces:**
+- Consumes: `Monitor`, `CheckResult`, `GuardDialContext` (Task 2), `CheckTLS` réutilisé pour `check_cert_expiry` (Task 4 — si Task 4 non mergée, le subagent stubbe l'appel derrière une variable `tlsExpiryHook` remplaçable, pas de duplication).
+- Produces: `func CheckHTTP(ctx context.Context, m Monitor) CheckResult`.
+
+Brief subagent : config §6.1 spec (method, `accepted_status_codes` syntaxe Kuma avec parser maison, redirects ≤10 revalidés SSRF, headers ≤20 hors Host/Content-Length, UA défaut, body ≤1 Mo, auth none/basic/bearer sans log, keyword/invert sur 2 Mo + `truncated`, `ignore_tls_errors` → `tls_insecure:true`). Transport : Dial 5 s, TLSHandshake 5 s, header timeout = timeout, `MaxIdleConns: 0`. TDD avec `httptest` : 200 OK, 500 KO, code accepté custom `200-299,401`, redirect, keyword found/not-found/invert, timeout, corps >2 Mo tronqué.
+
+- [ ] **Step 1: Test `TestCheckHTTP_Accepts200`** (serveur 200 → `StatusUp`).
+- [ ] **Step 2: Run, FAIL** (`undefined: CheckHTTP`).
+- [ ] **Step 3: Implémentation minimale** (GET + 2xx = up).
+- [ ] **Step 4: Vert.** Puis itérer : un test par comportement (codes custom, redirect, keyword, timeout, troncation, auth, TLS insecure flag) — chaque itération RED→GREEN.
+- [ ] **Step 5: Commit** `feat(monitors): add HTTP and keyword checker`.
+- [ ] **Step 6: Review** + fix loop.
+
+---
+
+### Task 4: Checker TLS (SUBAGENT — std `crypto/tls`)
+
+**Files:**
+- Create: `internal/hub/monitors/checker_tls.go`
+- Test: `internal/hub/monitors/checker_tls_test.go`
+
+**Interfaces:**
+- Consumes: `Monitor`, `CheckResult`.
+- Produces: `func CheckTLS(ctx context.Context, m Monitor) CheckResult` (+ `func CertDaysLeft(chain []*x509.Certificate, now time.Time) float64` testable sans réseau).
+
+Brief subagent : SNI = host (override `server_name`), port 443 défaut, `VerifyHostname` sauf `ignore_tls_errors`, seuils warn 21 / crit 7, UP/warn/down, `cert_days` 2 décimales, details `{not_after, issuer, dns_names[≤5], error?}`. TDD : CA de test (`crypto/x509` + `httptest.NewTLSServer` ou certs générés en test) — valide UP, proche expiry warn, expiré down, hostname mismatch down.
+
+- [ ] Steps RED→GREEN par cas, puis commit `feat(monitors): add TLS certificate checker`, puis review + fix loop.
+
+---
+
+### Task 5: Checker DNS (SUBAGENT — `miekg/dns`, API Context7 figée)
+
+**Files:**
+- Create: `internal/hub/monitors/checker_dns.go`
+- Test: `internal/hub/monitors/checker_dns_test.go`
+
+**Interfaces:**
+- Consumes: `Monitor`, `CheckResult`.
+- Produces: `func CheckDNS(ctx context.Context, m Monitor) CheckResult`.
+
+Brief subagent : `c := new(dns.Client); c.Net = "udp"|"tcp"; c.Timeout/DialTimeout/ReadTimeout/WriteTimeout; c.Exchange(m, "IP:port")` ; 10 qtypes ; `expected_answer` + `contains|exact` insensible casse ; answers ≤5 ; RCODE en `code` ; resolver custom = IP ; PTR exige IP cible. TDD avec serveur DNS fake (`miekg/dns` côté serveur dans le test) : NOERROR+match, mismatch, NXDOMAIN, SERVFAIL, timeout.
+
+- [ ] Steps RED→GREEN par cas, puis commit `feat(monitors): add DNS checker`, puis review + fix loop.
+
+---
+
+### Task 6: Checker ping (SUBAGENT — `pro-bing`, API Context7 figée)
+
+**Files:**
+- Create: `internal/hub/monitors/checker_ping.go`
+- Test: `internal/hub/monitors/checker_ping_test.go`
+
+**Interfaces:**
+- Consumes: `Monitor`, `CheckResult`.
+- Produces: `func CheckPing(ctx context.Context, m Monitor) CheckResult`.
+
+Brief subagent : `probing.NewPinger(host)`, `SetPrivileged(false)` d'abord puis fallback `true`, `Count/Size/Timeout/Interval` depuis config, `RunWithContext(ctx)`, `Statistics()` → `PacketsRecv ≥ 1` = succès, `latency = AvgRtt`, details `{min,avg,max,loss,received,sent}`, message `missing NET_RAW capability` si aucun mode. TDD : 127.0.0.1 (skip si pas de capa, unprivileged d'abord), host injoignable (loss 100 % typé, pas de faux up).
+
+- [ ] Steps RED→GREEN, puis commit `feat(monitors): add ping checker`, puis review + fix loop.
+
+---
+
+### Task 7: Scheduler + manager (inline — concurrence, état partagé)
+
+**Files:**
+- Create: `internal/hub/monitors/manager.go`, `scheduler.go`, `scheduler_test.go`
+
+**Interfaces:**
+- Consumes: `Monitor`, `CheckHTTP/CheckTLS/CheckDNS/CheckPing`, `Validate`.
+- Produces: `func RunCheck(ctx, m) CheckResult` (switch sur `m.Type`), `type Manager` (cache `store.Store`, hooks, sémaphore `MONITORS_MAX_CONCURRENT` défaut 10/max 50, `consecutive_failures`, skip overlap, jitter 0–5 s + stagger).
+
+TDD : machine d'état en test pur (fausse fonction check injectée) — retries, DOWN au (max+1)e, reset au succès, `upside_down`, warn, `resend_after`. Puis scheduler réel (ticker court en test, skip overlap vérifié). Commit `feat(monitors): add scheduler and manager`. Pas de subagent : état partagé + patterns `SystemManager` à matcher au plus près.
+
+---
+
+### Task 8: Persistance (inline — DB, migrations)
+
+**Files:**
+- Create: `internal/migrations/<ts>_monitors.go`
+- Modify: `internal/hub/collections.go`, `internal/records/*.go`
+
+**Interfaces:** Consumes: schéma §4 spec. Produces: collections + index + rétention.
+
+TDD : test de migration up/down sur base vierge (pattern `hub_test_helpers.go`), test de règles (readonly bloqué), test de rétention (vieux `monitor_checks` purgés, downsample). Une seule transaction par cycle (`RunInTransaction`). Commit `feat(monitors): add PocketBase collections and retention`.
+
+---
+
+### Task 9: API REST (inline — wiring auth/hub)
+
+**Files:**
+- Create: `internal/hub/monitors/api.go`, `api_test.go`
+- Modify: `internal/hub/api.go` (montage routes)
+
+**Interfaces:** Consumes: Manager, collections. Produces: 7 routes §7 spec.
+
+TDD : création 201, 400 par champ (timeout ≥ interval…), secrets redacted `•••`, accès refusé non-membre, rate-limit test (1/10 s), historique paginé. Commit `feat(monitors): add monitors API`.
+
+---
+
+### Task 10: Alerting transitions (inline — hooks `AlertManager`)
+
+**Files:** Modify: `internal/alerts/` (nouveau `alerts_monitors.go` + history).
+
+TDD : scénario UP→DOWN→UP avec `SendAlert` capturé (pas d'envoi réel), quiet hours respectées, `alert_id = "monitor:<id>"`, résolution à pause/suppression. Commit `feat(monitors): notify monitor transitions`.
+
+---
+
+### Task 11: UI (inline — style Beszel, pas de test auto imposé au subagent)
+
+**Files:** `components/routes/monitors.tsx`, `components/routes/monitor.tsx`, `components/monitors/monitor-dialog.tsx`, `lib/monitors.ts`, `types.d.ts`, nav, `home.tsx`, locales FR+EN.
+
+Pas de subagent : fidélité visuelle Beszel exige l'œil du contexte global. DONE = `vite build` OK + screenshots liste/détail/dialog. Commit `feat(monitors): add monitors UI`.
+
+---
+
+### Task 12: Config YAML (inline — petit, couplé à Task 8)
+
+**Files:** Modify: `internal/hub/config/config.go`, `config-yaml.tsx`.
+
+TDD : sync `monitors:` (match `name+target`, ne supprime jamais l'UI, users par email). Commit `feat(monitors): support monitors in config.yml`.
+
+---
+
+### Task 13: Charge + benchmark + docs + PR (inline — preuves)
+
+- [ ] Charge SQLite (`testing.Short`-gated) : 50 monitors @60 s / 24 h simulées — taille DB, zéro `database is locked`, p99 < 1 s.
+- [ ] Benchmark RSS + p99 @50/200 vs Kuma → chiffres dans la PR.
+- [ ] Docs : README, CHANGELOG, `supplemental/guides/monitors.md`.
+- [ ] `gofmt -l` propre, `go vet ./...`, `go test ./internal/...` vert (zéro régression).
+- [ ] Rebase `upstream/main`, push fork, `gh pr create --repo henrygd/beszel` (corps §14 spec).
+
+---
+
+## Self-Review (faite à l'écriture)
+
+- **Couverture spec** : §4 modèle → Tasks 1+8 ; §5 scheduler → 7 ; §6 checkers → 3–6 ; §7 API → 9 ; §8 états/notifs → 7+10 ; §9 SQLite → 8+13 ; §10 sécu → 2+5(tasks)+13(grep) ; §11 UI → 11 ; §12 YAML → 12 ; §13 tests → chaque task ; §14 PR → 13. `agent` réservé PR2 : champ présent dès la migration Task 8, toujours null (validation).
+- **Placeholders** : aucun TBD/TODO ; chaque step a son code ou sa commande exacte ; pas de renvoi « comme Task N » sans contenu.
+- **Cohérence types** : `Monitor/CheckResult/StatusUp…/Validate/CheckXxx/RunCheck/IsPrivateIP/GuardDialContext` nommés identiquement partout ; `alert_id = "monitor:<id>"` ; redaction `••••••`.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-09-04-uptime-monitors-pr1.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task (Tasks 2–6), review between tasks, fast iteration; Tasks 0–1, 7–13 inline.
+
+**2. Inline Execution** - Execute all tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-spec.md
+++ b/docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-spec.md
@@ -1,0 +1,461 @@
+# SPEC — Monitors externes type Uptime Kuma pour Beszel
+
+## PR1 : exécution via le hub uniquement (mergeable upstream)
+
+> **Fichier** : `docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-spec.md`
+> **Branche** : `feat/uptime-monitors` (fork `delta-whiplash/beszel`, `origin` = fork,
+> `upstream` = `henrygd/beszel`).
+> **Règle d'or** : PR1 100 % hub-only. Zéro modification de `agent/`,
+> `internal/entities/`, `internal/common/`, du protocole WS/SSH/CBOR.
+> La PR2 (exécution distribuée via les agents) est branchée AU-DESSUS de la PR1
+> et ne démarre qu'une fois la PR1 masterisée, testée, éprouvée, sécurisée,
+> conforme et belle.
+>
+> **Docs de référence vérifiées via Context7** :
+> PocketBase Go (`/websites/pocketbase_io` : `core.NewBaseCollection`,
+> `m.Register` avec revert, `core.NewRecord` + `app.Save`, `AddIndex`),
+> `miekg/dns` (`Client{Net, Timeout, DialTimeout}` + `Exchange(m, "IP:port")`),
+> `prometheus-community/pro-bing` (`probing.NewPinger`, `SetPrivileged(false)`, `Count/Size/
+> Timeout/Interval`, `RunWithContext`, `Statistics()` avec MinRtt/AvgRtt/MaxRtt/
+> PacketLoss).
+
+---
+
+## 1. Contexte et objectif
+
+Beszel (`henrygd/beszel`, v0.19.0) est un monorepo Go + React embarqué :
+`agent/` collecte les métriques système (pull via `gatherStats`, cache 60 s),
+`internal/hub/` tourne sur PocketBase v0.40.2 (SQLite embarqué),
+`internal/alerts/` gère seuils + envoi (emails + webhooks shoutrrr + quiet hours +
+`alerts_history`), `internal/site/` est le frontend React 19 + Vite + Tailwind.
+
+Il n'existe aujourd'hui **aucun monitor externe** : `internal/hub/heartbeat/` est
+sortant uniquement (POST vers BetterStack/Kuma/Healthchecks), `HandleStatusAlerts`
+couvre la joignabilité agent, aucune collection `monitors`, aucun scheduler de
+checks, aucun code ping/DNS/HTTP/SSL réutilisable.
+
+**Objectif** : remplacer Uptime Kuma pour 4 types de checks — HTTP(s)+keyword,
+certificat SSL/TLS, DNS, ping ICMP — en Go, intégré natif à Beszel : même nav,
+mêmes notifs, mêmes graphs, même config déclarative, mêmes standards de code.
+On ne doit pas avoir l'impression d'une autre application.
+
+---
+
+## 2. Périmètre
+
+### 2.1 Dans la PR1
+
+- 4 checkers exécutés **côté hub** : `http` (+ variante `keyword`), `tls`, `dns`, `ping`.
+- Scheduler hub : worker pool, ticker par monitor, jitter, anti-overlap, timeouts.
+- Persistance PocketBase : collections `monitors` + `monitor_checks`, rétention +
+  downsampling, index.
+- API hub : CRUD monitors + lecture historique + test manuel + résumé.
+- Notifications sur **transitions** via pipeline existant (`AlertManager.SendAlert`).
+  Aucun nouveau provider de notification.
+- UI : page Monitors dédiée au style Beszel + résumé sur home + formulaire par type.
+- Config déclarative : clé `monitors:` dans `config.yml`.
+- Docs : README, CHANGELOG, guide, benchmark vs Kuma.
+- Tests Go + build site vérifié. `gofmt` + `go vet` propres.
+
+### 2.2 Hors PR1 (reportés explicitement, pas oubliés)
+
+- Exécution depuis les agents (PR2). Le schéma réserve un champ `agent` nullable
+  pour éviter toute migration cassante, mais aucun code agent en PR1.
+- Monitor TCP/port générique, NTLM, proxy par monitor, mTLS client, maintenance
+  windows, status pages publiques, canaux de notif par monitor (canaux globaux
+  existants en PR1), fédération multi-hub.
+
+---
+
+## 3. Architecture PR1
+
+```text
+  UI React (internal/site/)          Hub Go (internal/hub/)
+  ─────────────────────────          ──────────────────────
+  components/routes/                 monitors/  (NOUVEAU package)
+   monitors.tsx (liste)               manager.go    CRUD + cache + hooks PB
+   monitor/[id].tsx (détail)          scheduler.go  1 goroutine/monitor
+  components/monitors/                checker_http.go  std net/http
+   monitor-dialog.tsx                 checker_tls.go   std crypto/tls
+  lib/monitors.ts                     checker_dns.go   miekg/dns
+                                      checker_ping.go  prometheus-community/pro-bing
+                                      ssrf.go          garde-fou réseau
+                                      api.go           routes REST
+                                      models.go        types + validation
+                                        │
+                                        ▼
+                                     internal/alerts (EXISTANT)
+                                     SendAlert → emails, shoutrrr,
+                                     quiet_hours, alerts_history
+                                        │
+                                     internal/records (ÉTENDU)
+                                     rétention monitor_checks
+```
+
+Câblage : constructeur + démarrage dans `internal/hub/hub.go` (`StartHub`, à côté
+de `sm.Initialize()` et du heartbeat), routes dans `internal/hub/api.go`
+(`se.Router.Group("/api/beszel")`, pattern existant lignes 88-140).
+Migration dédiée `internal/migrations/<timestamp>_monitors.go` via `m.Register`
+(avec fonction revert, pattern Context7). Ne jamais éditer le snapshot
+`0_collections_snapshot_0_19_0.go` à la main. Règles via `setCollectionAuthSettings`
+dans `internal/hub/collections.go`, calquées sur `systems`.
+
+---
+
+## 4. Modèle de données
+
+### 4.1 Collection `monitors` (base : `core.NewBaseCollection("monitors")`)
+
+| Champ | Type PB | Défaut / contrainte | Notes |
+|---|---|---|---|
+| `name` | Text, requis, max 100 | — | Unicité par utilisateur contrôlée applicativement |
+| `type` | Select, requis | valeurs `http\|keyword\|ping\|dns\|tls` | `keyword` = HTTP + recherche texte |
+| `target` | Text, requis, max 500 | — | URL (http/tls) ou hostname (ping/dns), validé par type (§6) |
+| `interval` | Number, requis | 60, min 20, max 86400 (s) | Période entre checks |
+| `timeout` | Number, requis | 10 (s), **strictement < interval** (validation API) | Timeout global par tentative |
+| `max_retries` | Number | 2, min 0, max 10 | Échecs consécutifs avant DOWN (DOWN au (max_retries+1)e échec ; 0 = DOWN immédiat) |
+| `upside_down` | Bool | false | Inverse UP/DOWN (tester un blocage voulu) |
+| `paused` | Bool | false | Pas de check, pas de notif, statut `paused` |
+| `notify` | Bool | true | false = historisé mais silencieux |
+| `resend_after` | Number | 0 (= jamais), min 0, max 1440 (min) | Renotifie un DOWN persistant tous les N minutes |
+| `users` | Relation `users` multiple, requis | — | Même pattern que `systems.users[]` |
+| `agent` | Relation `systems` simple, nullable | null, **RÉSERVÉ PR2, toujours null en PR1** | Évite une migration cassante en PR2 |
+| `config` | JSON | `{}` | Config typée par `type` (§6), validée côté API |
+| `status` | Select | `pending` ; valeurs `up\|down\|warn\|paused\|pending` | `warn` = TLS sous seuil warn mais au-dessus du seuil crit |
+| `last_check` | Date | — | Dernière tentative |
+| `last_latency_ms` | Number | — | Dernière latence |
+| `uptime_24h` | Number | — | Cache recalculé périodiquement (§8), jamais à chaque check |
+| `cert_days` | Number, nullable | — | Jours restants (http https / tls), null sinon |
+| `consecutive_failures` | Number | 0, non éditable via API publique | Compteur interne persisté (reprise au boot sans renotif) |
+
+Règles (même pattern que `systems` dans `collections.go`) :
+list/view = `@request.auth.id != "" && users.id ?= @request.auth.id`
+(ou `@request.auth.id != ""` si `SHARE_ALL_SYSTEMS=true`) ;
+create/update/delete = règle de lecture + `&& @request.auth.role != "readonly"`.
+
+### 4.2 Collection `monitor_checks` (base, écriture serveur uniquement)
+
+| Champ | Type | Notes |
+|---|---|---|
+| `monitor` | Relation `monitors`, requis, `CascadeDelete: true` | Suppression monitor → purge historique |
+| `status` | Select `up\|down\|warn`, requis | Après application de `upside_down` |
+| `latency_ms` | Number | RTT total de la tentative |
+| `code` | Number, nullable | Status HTTP / RCODE DNS, null pour ping/tls |
+| `message` | Text, max 500 | Résumé d'erreur ou d'état |
+| `details` | JSON, nullable | Tronqué par type (§6) |
+| `cert_days` | Number, nullable | Recopié pour les graphs d'expiry |
+| `created` | Autodate onCreate | Index `(monitor, created)` via `AddIndex` (pattern Context7) |
+
+Règles : list/view = membre du monitor parent (via `monitor.users.id ?=
+@request.auth.id`) ou SHARE_ALL ; create/update/delete = null (jamais via API
+publique, écriture serveur avec `SaveNoValidate` dans la transaction du cycle).
+
+---
+
+## 5. Scheduler
+
+Fichiers `internal/hub/monitors/manager.go`, `scheduler.go`. Standards repris de
+`systems/system_manager.go` et `systems/system.go` (`StartUpdater`, ticker 60 s,
+jitter `getJitter`, stagger `delta = min(interval/n, 2000ms)`, `waitForContext`).
+
+- `Manager` : construit dans `NewHub`-like, `Initialize()` charge les monitors non
+  pausés (`status != 'paused'`), cache mémoire (`store.Store[string, *Monitor]`
+  comme `SystemManager`), hooks PB `monitors` create/update/delete → start/stop/
+  reconfigure sans restart. `OnTerminate` → cancel + waitgroup.
+- 1 goroutine par monitor : jitter initial aléatoire 0–5 s + stagger au boot,
+  `time.Ticker(interval)`, check immédiat au (re)démarrage si non pausé.
+- Anti-overlap : flag atomique par monitor ; si un run est en cours au tick, skip
+  + compteur `skipped_runs` en log debug (pas d'historique).
+- Chaque run : `ctx, cancel := context.WithTimeout(timeout)`, `recover()` sur panic
+  checker → échec `checker panic: …`. `timeout < interval` garanti par validation.
+- `retry_interval` : en PR1 égal à `interval` (pas de ticker accéléré en état
+  indécis — choix assumé, borne la charge, documenté).
+- Concurrence globale bornée : sémaphore (défaut 10 runs simultanés, env
+  `MONITORS_MAX_CONCURRENT`, plafond 50) pour protéger le hub et SQLite.
+- Tous les paramètres ticker/env documentés dans le guide.
+
+---
+
+## 6. Checkers — spec par type
+
+Champs communs (cf. §4.1) : `interval` (60, ≥20), `timeout` (10, < interval),
+`max_retries` (2), `upside_down`, `paused`, `notify`, `resend_after`.
+
+### 6.1 HTTP(s) + variante Keyword — `checker_http.go`, std uniquement
+
+Config `config` JSON :
+
+| Clé | Défaut | Validation / notes |
+|---|---|---|
+| `method` | `GET` | Enum GET/POST/PUT/PATCH/DELETE/HEAD/OPTIONS |
+| `accepted_status_codes` | `200-299` | Syntaxe Kuma : `200-299,401`, `200,201,204`. Parser maison + tests table-driven (plages, listes, espaces, ordre indifférent, `200-299` inclusif) |
+| `follow_redirects` / `max_redirects` | true / 10 (1–20) | `CheckRedirect` custom : cap + re-validation SSRF à chaque hop (§10), stocke `final_url` |
+| `headers` | `{}` | Map ≤20 entrées, clés ≤100 car. ; interdites : `Host`, `Content-Length` ; `User-Agent: Beszel-Monitor` par défaut |
+| `body` / `content_type` | `""` / auto | Envoyé si méthode à corps ; body ≤1 Mo côté validation config |
+| `auth_type` | `none` | `none\|basic\|bearer` ; basic = `username`+`password`, bearer = `token` ; secrets chiffrés (§10.3), jamais loggés ni renvoyés |
+| `ignore_tls_errors` | false | `InsecureSkipVerify` ; si true → `tls_insecure:true` dans details + bandeau warning UI explicite |
+| `keyword` / `invert_keyword` | `""` / false | Type `keyword` : UP si le corps contient (ou ne contient pas si invert) le mot-clé ; substring case-sensitive, documenté |
+| `check_cert_expiry` | true si schéma https | Réutilise le checker TLS (§6.2) sur la connexion établie |
+| `warn_days` / `crit_days` | 21 / 7 | Cf. §6.2 ; `crit_days < warn_days` validé |
+
+Transport : `http.Transport{DialContext: &net.Dialer{Timeout: 5s} custom SSRF
+(§10), TLSHandshakeTimeout: 5s, ResponseHeaderTimeout: timeout, MaxIdleConns: 0}` ;
+`http.Client{Timeout: timeout, CheckRedirect: custom}`.
+Corps lu via `io.LimitReader` 2 Mo : au-delà, tronqué + `truncated:true`
+(le match keyword porte sur les 2 premiers Mo — documenté).
+Succès = TCP+TLS OK **et** status accepté **et** (si keyword) match **et**
+(si https + check_cert_expiry) cert au-dessus du seuil crit.
+Résultat : `latency_ms`, `code`, `cert_days` si https, details `{final_url,
+keyword_found?, tls_insecure?, truncated?}`.
+
+### 6.2 TLS / certificat — `checker_tls.go`, std `crypto/tls` + `crypto/x509`
+
+- `target` = URL ou `host[:port]` ; `host` requis (SNI = host sauf override
+  `server_name`), `port` défaut 443 (1–65535).
+- `tls.DialWithDialer` + `VerifyHostname(host)` complet sauf `ignore_tls_errors`
+  (alors handshake seul + warning, expiry toujours évaluée).
+- Statuts : UP si `days > warn_days` ; **warn** si `crit_days < days ≤ warn_days`
+  (notif warn une fois à l'entrée, puis à la sortie) ; **down** si `days ≤
+  crit_days`, cert expiré, hostname mismatch, chaîne invalide.
+- `cert_days` float 2 décimales ; details `{not_after (RFC3339), issuer,
+  dns_names[≤5], error?}`.
+
+### 6.3 DNS — `checker_dns.go`, dep `github.com/miekg/dns`
+
+Justification (pas de std) : `net.Resolver` couvre mal MX/NS/SOA/SRV/CAA/PTR avec
+resolver:port + protocole explicites. API vérifiée Context7 :
+`c := new(dns.Client); c.Net = "udp"|"tcp"; c.Timeout / DialTimeout / ReadTimeout /
+WriteTimeout` puis `c.Exchange(m, "IP:port")`, `m.SetQuestion("example.com.",
+dns.TypeA)`.
+Config : `qtype` (défaut A ; enum A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, CAA, PTR),
+`resolver` (vide = resolver système ; sinon IP ou `IP:port`, port défaut 53),
+`protocol` (`udp` défaut, option `tcp`), `query_timeout` (défaut 5 s, ≤ timeout
+global), `expected_answer` (vide = pas de comparaison) + `match_mode`
+(`contains` défaut | `exact`, insensible à la casse, point final normalisé).
+Succès = RCODE NOERROR + ≥1 réponse **et** match si attendu.
+Échecs typés : NXDOMAIN, SERVFAIL, timeout, mismatch (message inclut les answers
+reçues tronquées). Résultat : `latency_ms` (= rtt `Exchange`), `code` = RCODE
+numérique, details `{answers[≤5], qtype, resolver}`.
+Validation : qtype PTR exige une IP dans target (reverse) ; resolver custom doit
+être une IP (pas de hostname → pas de récursion bootstrap).
+
+### 6.4 Ping — `checker_ping.go`, dep `github.com/prometheus-community/pro-bing`
+
+Justification : le std n'a pas de ping ; `x/net/icmp` brut impose raw sockets
+(root) + gestion manuelle echo id/seq + code Windows spécifique. API vérifiée
+Context7 : `pinger, err := probing.NewPinger(host)`, `pinger.SetPrivileged(false)`
+(unprivileged UDP par défaut — pas de root requis), `Count/Size/Timeout/Interval`,
+`RunWithContext(ctx)`, `Statistics()` → `PacketsSent/PacketsRecv/PacketLoss/
+MinRtt/AvgRtt/MaxRtt`, callbacks `OnRecv/OnFinish` disponibles.
+Config : `count` (3, 1–10), `packet_size` (56, 0–65400), `packet_timeout` (2 s,
+≤ timeout global), `interval_between_packets` (1 s, ≥200 ms).
+Mode : `SetPrivileged(false)` d'abord ; fallback `SetPrivileged(true)` si root/
+`NET_RAW` ; si aucun mode ne fonctionne (Docker sans `NET_RAW` ni
+`ping_group_range`), échec **explicite**
+`ping unavailable: missing NET_RAW capability (see docs)` — jamais de faux down
+silencieux. Succès si ≥1 réponse (`PacketsRecv ≥ 1`).
+Résultat : `latency_ms` = AvgRtt, details `{min_ms, avg_ms, max_ms, loss_pct,
+received, sent}`. Docs : section Docker (`--cap-add=NET_RAW` ou
+`sysctl net.ipv4.ping_group_range`) + note « ICMP filtré → préférer http ».
+
+### 6.5 Dépendances (minimales, justifiées)
+
+- `github.com/miekg/dns` — §6.3.
+- `github.com/prometheus-community/pro-bing` — §6.4 (fork maintenu de go-ping).
+- HTTP/TLS/scheduler : std uniquement (`net/http`, `crypto/tls`, `crypto/x509`,
+  `net`, `time`, `context`, `sync`, `io`, `strings`, `strconv`).
+  `golang.org/x/sync` (déjà en transitif) passé en direct si `errgroup` utilisé.
+  Pas de lib cron, pas de client HTTP tiers.
+
+---
+
+## 7. API
+
+Fichier `internal/hub/monitors/api.go`, monté dans `api.go` (pattern lignes 88-140 :
+`apiAuth := se.Router.Group("/api/beszel")` + `apis.RequireAuth()` ;
+écriture + `excludeReadOnlyRole`). Accès : membre du monitor (`users` contient
+`@request.auth.id`) ou SHARE_ALL ; helper `monitorHasUser` calqué sur
+`userHasSystem` (`alerts_api.go`) et `system.HasUser`.
+
+| Route | Méthode | Notes |
+|---|---|---|
+| `/monitors` | GET | Liste (filtre `?paused=`, tri `name`), statut + uptime_24h + cert_days inclus |
+| `/monitors` | POST | Validation stricte (§4.1 + §6 + timeout<interval + ports + target par type) ; 400 typées par champ |
+| `/monitors/:id` | GET | Détail + config, **secrets redacted** (`password:"••••••"`, `token:"••••••"`) |
+| `/monitors/:id` | PATCH | Partiel, revalidation ; reschedule si interval/timeout changés ; reset `consecutive_failures` si target/config changée |
+| `/monitors/:id` | DELETE | Cascade `monitor_checks` via règle PB |
+| `/monitors/:id/checks` | GET | `?range=24h\|30d&limit=` (défaut 200, max 1000), ordre antéchronologique, pour graphs |
+| `/monitors/:id/test` | POST | Run manuel immédiat ; rate-limit 1/10 s par monitor + 10/min par user ; **n'écrit pas** l'historique, ne touche pas aux compteurs (documenté) |
+| `/monitors/summary` | GET | Compteurs up/down/warn/paused + liste des down courants (pour home) |
+
+---
+
+## 8. États, transitions, notifications, uptime
+
+- Compteur `consecutive_failures` (mémoire + persisté à chaque cycle pour reprise
+  au boot sans renotifier un DOWN déjà connu). Succès → 0. Échec → +1.
+  Passage DOWN quand `failures > max_retries` (défaut 2 : DOWN au 3e échec).
+  `upside_down` appliqué **avant** comparaison (succès brut → échec logique).
+- Transitions notifiées si `notify=true`, via `AlertManager.SendAlert`
+  (emails + webhooks shoutrrr + quiet hours via `IsNotificationSilenced`) :
+  UP→DOWN (`🔴 Monitor down: <name>` — target, dernier message d'erreur, latence,
+  lien `MakeLink("monitors", id)`), DOWN→UP (`🟢 Monitor recovered: <name>` —
+  durée du down + uptime 24h), entrée/sortie WARN TLS (`🟡 TLS cert expiring:
+  <name> (<days> days)`). `resend_after` (0 = jamais) : renotifie un DOWN persistant.
+- Historique : insert `alerts_history` avec `alert_id = "monitor:<id>"`
+  (même colonnes `user,system,alert_id,name,value,created,resolved` — `system`
+  vide pour les monitors, documenté) ; résolution à la suppression/pause
+  (pattern `resolveHistoryOnAlertDelete`).
+- Uptime % = succès/(succès+échecs) sur 24 h (checks `test` exclus), recalculé
+  toutes les 10 min en étendant le cron `create longer records` (`records.go`) —
+  **pas de nouveau cron**.
+- `paused=true` → statut `paused`, compteur reset, pas de notif, scheduler stoppé
+  pour ce monitor.
+
+---
+
+## 9. SQLite / PocketBase — durcissement (risque n°1)
+
+Rappel du volume : 50 monitors @60 s ≈ 72 000 lignes/jour dans `monitor_checks`.
+
+1. **Une seule transaction par cycle** : `RunInTransaction` (insert
+   `monitor_checks` + update `monitors` ensemble). Jamais de save par champ.
+2. **Bornes** : interval min 20 s (validation API + contrainte migration),
+   timeout < interval, concurrence globale ≤10 (`MONITORS_MAX_CONCURRENT`, max 50),
+   skip overlap, `retry_interval = interval`.
+3. **Rétention** : brut 30 j ; downsample 10 m au-delà de 12 h, 2 h au-delà de 7 j,
+   en étendant `DeleteOldRecords` + `CreateLongerRecords` (`internal/records/`,
+   même style que `deleteOldSystemStats` dans `records_deletion.go:60-100`) ;
+   cap de sécurité : si >500 k lignes, purge les plus anciennes + log warn.
+4. **Index** : `(monitor, created)` + `created` seul, créés dans la migration via
+   `AddIndex` (pattern Context7).
+5. **Realtime sobre** : subscribe PB sur `monitors` (statuts) uniquement ; jamais
+   sur chaque `monitor_checks` ; historique chargé à la demande, paginé.
+6. **Boot** : stagger + jitter (§5) ; `consecutive_failures` relu depuis DB.
+7. **Preuve exigée** : test de charge — 50 monitors @60 s sur 24 h simulées
+   (ou 200 @20 s en accéléré) : taille DB, zéro `database is locked`, p99
+   scheduler < 1 s. Chiffres repris dans la description de PR. Ne pas toucher à
+   la config SQLite de PocketBase (WAL etc.) sauf preuve mesurée.
+
+---
+
+## 10. Sécurité
+
+### 10.1 SSRF (critique sur instance multi-utilisateurs) — `ssrf.go`
+
+- `allow_private_network=false` par défaut ; override admin-only via env
+  `MONITORS_ALLOW_PRIVATE_NETWORK=true` (labo uniquement, log warn au boot).
+- Bloqués par défaut : loopback (127/8, ::1), 10/8, 172.16/12, 192.168/16,
+  169.254/16 (metadata cloud), link-local et unique-local IPv6, `0.0.0.0`.
+- HTTP : résolution du host **avant** dial + `DialContext` custom qui vérifie
+  **chaque** IP ; re-vérification à chaque redirect (même si l'initial est public) ;
+  on épingle la première résolution par tentative (anti DNS-rebinding, TTL courte
+  ignorée).
+- DNS/ping/TLS : même vérification d'IP avant connexion quand `allow_private=false`.
+- Schémas `http(s)` uniquement pour le type `http` ; `file:`, `gopher:`, `ftp:`,
+  etc. rejetés à la validation.
+- Tests : matrice SSRF (loopback, 10/8, redirect public→privé, DNS-rebinding
+  simulé, IPv6 link-local).
+
+### 10.2 Timeouts et limites
+
+Timeout global < interval (validation) ; Dial 5 s ; TLS handshake 5 s ;
+header timeout = timeout ; corps réponse 2 Mo max ; body config 1 Mo max ;
+`max_redirects` 1–20 ; headers ≤20 entrées ; test manuel rate-limité (§7).
+
+### 10.3 Secrets
+
+`password`/`token` (basic/bearer) et valeurs de headers sensibles : stockage
+chiffré au repos (mécanisme existant des tokens — à défaut, champ PB à masquage
++ redaction systématique, **jamais en clair lisible**) ; redacted `•••` en lecture
+API ; jamais loggés (revue de chaque log ajouté + helper de masquage façon
+`sanitizeHeartbeatURL` dans `heartbeat.go:297`) ; PATCH sans secret = conserve
+l'existant ; grep de contrôle `password|token|secret` sur le package avant PR.
+
+---
+
+## 11. Frontend — intégré Beszel, pas Kuma repeint
+
+Fichiers (patterns : routes dans `components/routes/*.tsx` montées en lazy dans
+`main.tsx:30-33`, formulaires valibot comme `settings/notifications.tsx`,
+stores nanostores `lib/stores.ts`, subscribe `pb.collection()`, types
+`types.d.ts`, i18n Lingui + `i18n.yml`) :
+
+- `components/routes/monitors.tsx` : liste (badge statut, uptime 24 h, latence,
+  cert_days si pertinent, menu pause/test/supprimer), états vide/erreur/loading
+  au style existant (skeleton, pas de spinner custom).
+- `components/routes/monitor.tsx` (détail `:id`) : graphs recharts latence + uptime
+  30 j (via hook façon `use-system-data.ts`), table historique paginée, panneau
+  certificat pour tls/https, lien vers `alerts_history` filtrée.
+- `components/monitors/monitor-dialog.tsx` : formulaire par type (select type →
+  champs dynamiques), validation miroir de l'API (valibot), aide inline
+  (note NET_RAW pour ping, note 2 Mo pour keyword, warning `ignore_tls_errors`).
+- `lib/monitors.ts` (+ entrées `alerts.ts`-like si toggle notify réutilisé depuis
+  `alerts-sheet.tsx`), types `Monitor`/`MonitorCheck` dans `types.d.ts`.
+- Nav existante + carte résumé sur `home.tsx` (compteurs via `/monitors/summary`).
+- i18n : nouvelles clés Lingui, FR + EN à minima.
+
+---
+
+## 12. Config déclarative
+
+Étendre `internal/hub/config/config.go` (pattern `systemConfig` + `SyncSystems`) :
+`Monitors []monitorConfig yaml:"monitors"` (mêmes champs §4.1/§6, `users` par email
+convertis en IDs comme lignes 72-86), sync au boot (créé/MAJ par `(name,target)`,
+**ne supprime jamais** ce que l'UI a créé sauf flag explicite — même prudence que
+les systems). Miroir UI `config-yaml.tsx` + exemples dans le guide.
+
+---
+
+## 13. Tests (exigés, pas optionnels)
+
+- Unitaires : parser `accepted_status_codes` (table-driven), machine d'état
+  (transitions, retries, upside_down, warn TLS, resend_after), validation par type
+  (timeout<interval, ports, target, qtype PTR…), matrice SSRF, redaction secrets,
+  calcul uptime.
+- Intégration (pattern `hub_test_helpers.go` / `systems_test_helpers.go`) :
+  serveurs `httptest` (status/redirect/keyword/timeout/troncation), serveur DNS
+  fake (`miekg/dns` côté serveur en test), TLS avec CA de test, ping 127.0.0.1
+  (skip si pas de capa, unprivileged d'abord).
+- Charge SQLite : `testing.Short`-gated (skip en CI courte), chiffres repris en PR.
+- Frontend : `vite build` OK (bun ou npm selon l'env) ; pas d'e2e exigé en PR1
+  (follow-up documenté).
+- Commandes : `gofmt -l .`, `go vet ./...`,
+  `go test ./internal/hub/monitors/... ./internal/records/... ./internal/alerts/...`.
+
+---
+
+## 14. Docs et PR upstream
+
+- `readme.md` (section Monitors), `supplemental/CHANGELOG.md` (entrée),
+  `supplemental/guides/monitors.md` (champs par type, Docker ping, SSRF, exemples
+  YAML, FAQ ICMP filtré).
+- Titre : `feat(hub): add external uptime monitors (http, tls, dns, ping)`.
+  Corps : motivation (remplace Kuma), screenshots, spec champs par type, choix Go
+  (stdlib + 2 deps justifiées), perfs (RSS + p99 @50/200 monitors vs Kuma), sécu
+  (SSRF, secrets), tests, migration PB, breaking = aucun (nouvelles collections
+  uniquement). Zéro code Kuma (inspiration seulement).
+- Workflow : petits commits conventionnels (1 checker/commit), rebase sur
+  `upstream/main` avant push, `gh pr create --repo henrygd/beszel`.
+
+---
+
+## 15. Critères de sortie PR1 (avant PR2 — tous requis)
+
+1. `gofmt`, `go vet`, tests unitaires + intégration verts.
+2. Zéro régression polling systèmes/alertes existants (`go test ./internal/...`).
+3. Charge SQLite : 50 monitors @60 s, 24 h simulées, zéro lock, DB bornée, chiffres
+   publiés.
+4. Matrice SSRF verte + secrets jamais en clair (grep + revue).
+5. UI au style Beszel + FR/EN + screenshots dans la PR.
+6. PR upstream ouverte, retours adressés.
+7. Alors seulement : design PR2 (agents) sur la base du champ `agent` réservé.
+
+---
+
+## 16. Risques résiduels assumés
+
+Ping filtré par certains réseaux (documenté, fallback http conseillé) ; débat
+`warn` vs `down` TLS (seuils configurables, défauts 21/7) ; volume
+`monitor_checks` (contraint §9, validé par test de charge) ; canaux par monitor
+reportés (notifs globales en PR1) ; pas d'e2e frontend en PR1.

--- a/docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-todo.md
+++ b/docs/superpowers/specs/2026-09-04-uptime-monitors-pr1-todo.md
@@ -1,0 +1,105 @@
+# TODO — Monitors externes Beszel, PR1 hub-only
+
+> **Règle d'or (anti-Keynit)** : aucune case cochée sans preuve — log de test,
+> screenshot, mesure ou sortie de commande citée dans le commit ou la PR.
+> Les standards applicables sont rappelés par phase ; en cas de conflit,
+> `spec.md` fait foi.
+> **Spec** : `2026-09-04-uptime-monitors-pr1-spec.md` (même dossier).
+
+## Phase 0 — Setup et cadrage
+
+- [x] Fork `henrygd/beszel` → `delta-whiplash/beszel` (`origin` = fork, `upstream` = upstream), branche `feat/uptime-monitors` créée depuis `main` à jour.
+- [ ] `go version` ≥ 1.27 OK, `gofmt -l` propre sur l'arbre existant, `go vet ./internal/hub/...` sans erreur nouvelle. Preuve : sortie de commandes.
+- [ ] Requêtes Context7 effectuées et APIs figées : PB (`NewBaseCollection`, `m.Register` + revert, `NewRecord` + `Save`, `AddIndex`), `miekg/dns` (`Client` + `Exchange`), `prometheus-community/pro-bing` (`NewPinger`, `SetPrivileged`, `RunWithContext`, `Statistics`).
+- [ ] Fichiers charnières relus : `internal/hub/hub.go` (câblage), `internal/hub/api.go:88-140` (routes), `internal/hub/collections.go` (règles), `internal/hub/systems/system_manager.go` + `systems/system.go:69-122` (ticker/jitter/stagger), `internal/alerts/alerts.go` (`SendAlert`), `internal/records/records_deletion.go:60-100` (rétention), `internal/hub/config/config.go` (sync YAML), `internal/site/src/main.tsx:30-33` (routes lazy).
+- [ ] `go get github.com/miekg/dns github.com/prometheus-community/pro-bing` passe (sinon : demander, ne pas bricoler). `go.mod`/`go.sum` à jour, `go build ./...` OK.
+
+## Phase 1 — Checker HTTP + keyword (`checker_http.go`, std uniquement)
+
+- [ ] Transport custom : Dial 5 s, TLSHandshake 5 s, header timeout = timeout, `MaxIdleConns: 0`, `CheckRedirect` max `max_redirects` (1–20). Fichier : `internal/hub/monitors/checker_http.go`.
+- [ ] Parser `accepted_status_codes` syntaxe Kuma (`200-299,401`, listes, espaces) + tests table-driven. Standard : erreurs typées par champ.
+- [ ] Headers custom (≤20, `Host`/`Content-Length` interdits, UA `Beszel-Monitor` défaut), body ≤1 Mo, auth none/basic/bearer (secrets jamais loggés).
+- [ ] Variante keyword : `keyword`/`invert_keyword`, corps limité 2 Mo (`LimitReader` + `truncated:true`), match substring case-sensitive documenté.
+- [ ] `check_cert_expiry` sur https via checker TLS (§Phase 2) ; `ignore_tls_errors` → `tls_insecure:true` + warning.
+- [ ] Tests `httptest` : status OK/KO, redirect (dont public→privé, cf. Phase 5), keyword found/not-found/invert, timeout, corps >2 Mo, `final_url` stockée. DONE = `go test ./internal/hub/monitors/ -run TestHTTP -v` vert.
+
+## Phase 2 — Checker TLS (`checker_tls.go`, std `crypto/tls`/`x509`)
+
+- [ ] `tls.DialWithDialer` + SNI = host (override `server_name`), port défaut 443 (1–65535), `VerifyHostname` sauf `ignore_tls_errors` (warning).
+- [ ] Seuils `warn_days` 21 / `crit_days` 7 (`crit < warn` validé) ; statuts UP/warn/down (§8 spec) ; `cert_days` 2 décimales ; details `{not_after RFC3339, issuer, dns_names[≤5], error?}`.
+- [ ] Tests avec CA de test : valide, expiring (warn), expiré (down), hostname mismatch, chaîne invalide. DONE = tests verts.
+
+## Phase 3 — Checker DNS (`checker_dns.go`, `miekg/dns`)
+
+- [ ] Client `dns.Client{Net: udp|tcp, Timeout/DialTimeout/ReadTimeout/WriteTimeout}`, `SetQuestion`, `Exchange(m, "IP:port")`, resolver vide = système, port 53 défaut.
+- [ ] 10 qtypes (A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, CAA, PTR) ; `expected_answer` + `contains|exact` (case-insensible, point final normalisé) ; answers ≤5 ; RCODE numérique en `code`.
+- [ ] Validation : PTR exige IP cible ; resolver custom = IP (pas de hostname).
+- [ ] Tests avec serveur DNS fake (`miekg/dns` côté serveur) : NOERROR+match, mismatch, NXDOMAIN, SERVFAIL, timeout, tcp. DONE = tests verts.
+
+## Phase 4 — Checker ping (`checker_ping.go`, `prometheus-community/pro-bing`)
+
+- [ ] `NewPinger` + `SetPrivileged(false)` d'abord, fallback `true` si capa ; `Count`/`Size`/`Timeout`/`Interval` depuis config (count 1–10, size 0–65400, packet_timeout ≤ timeout global, inter-paquets ≥200 ms) ; `RunWithContext`.
+- [ ] Succès si `PacketsRecv ≥ 1` ; `latency_ms` = AvgRtt ; details `{min,avg,max,loss,received,sent}` ; échec explicite `missing NET_RAW capability` si aucun mode (jamais de faux down silencieux).
+- [ ] Tests : 127.0.0.1 unprivileged (skip si pas de capa), host injoignable (loss 100 % typé). DONE = tests verts ou skip justifié en log.
+
+## Phase 5 — SSRF + secrets (`ssrf.go`, validation)
+
+- [ ] `allow_private_network=false` défaut, override env admin-only + log warn au boot ; blocage loopback/RFC1918/169.254/IPv6 local/`0.0.0.0` ; schémas http(s) seuls.
+- [ ] `DialContext` custom vérifiant chaque IP + re-vérif par redirect + pin de la première résolution (anti DNS-rebinding) ; même garde pour DNS/ping/TLS.
+- [ ] Matrice de tests SSRF : loopback, 10/8, redirect public→privé, rebinding simulé, IPv6 link-local. DONE = matrice verte.
+- [ ] Secrets : stockage chiffré, redacted `•••` en lecture API, PATCH sans secret = conserve, grep `password|token|secret` propre sur le package + revue de chaque log ajouté.
+
+## Phase 6 — Scheduler + manager (`manager.go`, `scheduler.go`, `models.go`)
+
+- [ ] Types + validation centralisée (`timeout < interval`, interval 20–86400, ports, target par type, qtype PTR, `crit < warn`).
+- [ ] 1 goroutine/monitor (ticker + jitter 0–5 s + stagger `min(interval/n,2000ms)`), check immédiat au démarrage, skip overlap (atomique + compteur debug), `context.WithTimeout`, `recover` panics, `retry_interval = interval` documenté.
+- [ ] Sémaphore global ≤10 (`MONITORS_MAX_CONCURRENT`, max 50) ; `OnTerminate` propre ; hooks PB create/update/delete → reschedule sans restart ; `consecutive_failures` persisté et relu au boot.
+- [ ] Machine d'état testée : retries, DOWN au (max+1)e échec, reset au succès, `upside_down`, entrée/sortie warn, `resend_after`. DONE = tests verts.
+
+## Phase 7 — Persistance (migration + règles + rétention)
+
+- [ ] Migration `internal/migrations/<ts>_monitors.go` (`m.Register` + revert) : collections §4 spec, index `(monitor,created)` + `created` via `AddIndex`, `CascadeDelete` monitor→checks, `monitor_checks` sans droits d'écriture publique.
+- [ ] Règles dans `setCollectionAuthSettings` : `monitors` calquées sur `systems` (membre ou SHARE_ALL, écriture bloque readonly) ; `monitor_checks` list/view membre-via-parent, écriture null.
+- [ ] Cycle d'écriture en **1 transaction** (`RunInTransaction` : insert check + update monitor) ; `uptime_24h` recalculé via cron `records` existant (pas de nouveau cron).
+- [ ] Rétention : étendre `DeleteOldRecords`/`CreateLongerRecords` (brut 30 j, 10 m >12 h, 2 h >7 j, cap 500 k + warn). DONE = migration up/down OK sur base vierge + testée.
+
+## Phase 8 — API (`api.go`)
+
+- [ ] 7 routes §7 spec (liste, POST validée 400/champ, détail redacted, PATCH revalidé + reschedule, DELETE cascade, historique paginé défaut 200/max 1000, test rate-limité 1/10 s + 10/min/user **sans écriture**, summary).
+- [ ] Accès membre ou SHARE_ALL (`monitorHasUser` calqué sur `userHasSystem`), écriture bloque readonly. DONE = tests API (création, 400, redaction, accès refusé, rate-limit).
+
+## Phase 9 — Alerting (transitions + historique)
+
+- [ ] UP→DOWN, DOWN→UP (durée + uptime), entrée/sortie WARN via `SendAlert` + `MakeLink("monitors", id)` + quiet hours ; `resend_after` ; `notify=false` = silencieux historisé.
+- [ ] `alerts_history` (`alert_id = "monitor:<id>"`, `system` vide documenté), résolution à pause/suppression. DONE = scénario UP→DOWN→UP vérifié en test avec notifs capturées.
+
+## Phase 10 — UI (style Beszel, pas Kuma)
+
+- [ ] `components/routes/monitors.tsx` (liste + badges + menu pause/test/supprimer + skeleton/empty/error), `components/routes/monitor.tsx` (recharts latence + uptime 30 j, table paginée, panneau cert, lien alerts_history).
+- [ ] `components/monitors/monitor-dialog.tsx` (champs dynamiques par type, valibot miroir API, aides inline NET_RAW/2 Mo/TLS), `lib/monitors.ts`, types `Monitor`/`MonitorCheck`, toggle notify réutilisant `alerts-sheet.tsx`, subscribe `monitors` uniquement.
+- [ ] Nav + carte `home.tsx` via `/monitors/summary` ; i18n Lingui FR+EN. DONE = `vite build` OK + screenshots liste/détail/dialog.
+
+## Phase 11 — Config YAML
+
+- [ ] `monitors:` dans `config.go` (users par email, match `name+target`, ne supprime jamais l'UI), miroir `config-yaml.tsx`, exemples guide. DONE = sync testée sur base de dev.
+
+## Phase 12 — Charge + benchmark (preuves pour la PR)
+
+- [ ] Charge SQLite : 50 monitors @60 s / 24 h simulées (ou 200 @20 s accéléré), `testing.Short`-gated : taille DB, zéro `database is locked`, p99 scheduler < 1 s.
+- [ ] Benchmark vs Kuma : RSS hub + p99 @50/200 monitors. DONE = chiffres dans la PR.
+
+## Phase 13 — Docs + PR upstream
+
+- [ ] `readme.md` (section Monitors), `CHANGELOG.md` (entrée), `supplemental/guides/monitors.md` (champs, Docker ping, SSRF, YAML, FAQ ICMP).
+- [ ] `gofmt -l` propre, `go vet ./...` OK, `go test ./internal/...` vert (zéro régression polling/alertes), grep secrets propre.
+- [ ] Commits petits (1 checker/commit), rebase `upstream/main`, push fork, `gh pr create --repo henrygd/beszel` avec corps §14 spec (motivation, screenshots, spec champs, choix Go, perfs, sécu, tests, migration, breaking = aucun, zéro code Kuma).
+
+## Critères de sortie PR1 (tous requis avant PR2)
+
+1. [ ] Tests unitaires + intégration verts.
+2. [ ] Zéro régression (`go test ./internal/...`).
+3. [ ] Charge SQLite OK, chiffres publiés.
+4. [ ] SSRF verte + secrets propres (grep + revue).
+5. [ ] UI Beszel FR/EN + screenshots.
+6. [ ] PR upstream ouverte, retours adressés.
+7. [ ] Alors seulement : design PR2 (champ `agent` déjà réservé).

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,11 @@ require (
 	github.com/gliderlabs/ssh v0.3.8
 	github.com/google/uuid v1.6.0
 	github.com/lxzan/gws v1.10.1
+	github.com/miekg/dns v1.1.73
 	github.com/nicholas-fedor/shoutrrr v0.19.0
 	github.com/pocketbase/dbx v1.12.0
 	github.com/pocketbase/pocketbase v0.40.2
+	github.com/prometheus-community/pro-bing v0.9.1
 	github.com/shirou/gopsutil/v4 v4.26.8
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
@@ -47,11 +49,9 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20260802145828-341c2f0c90b5 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
-	github.com/miekg/dns v1.1.73 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pocketbase/ozzo-validation/v4 v4.3.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6 // indirect
-	github.com/prometheus-community/pro-bing v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -47,9 +47,11 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20260802145828-341c2f0c90b5 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.24 // indirect
+	github.com/miekg/dns v1.1.73 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/pocketbase/ozzo-validation/v4 v4.3.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6 // indirect
+	github.com/prometheus-community/pro-bing v0.9.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/tklauser/go-sysconf v0.4.0 // indirect
 	github.com/tklauser/numcpus v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/mattn/go-colorable v0.1.15 h1:+u9SLTRGnXv73cEsnsmoZBom+dMU88B2M0aDcWy
 github.com/mattn/go-colorable v0.1.15/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI3HqDio6A=
+github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=
+github.com/miekg/dns v1.1.73/go.mod h1:RW2Obtfd5NZHvOFe3zYG0W8koWOQtAzyHaLo8vASBuQ=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/nicholas-fedor/shoutrrr v0.19.0 h1:Rl6bpK3DXuR2Trtx2JV8t+wjUwkHdRHrc8nBKoEpHr0=
@@ -98,6 +100,8 @@ github.com/pocketbase/pocketbase v0.40.2 h1:7gTqvt3bmilkphyZZ1QNhX19g3BXHqT7ynDy
 github.com/pocketbase/pocketbase v0.40.2/go.mod h1:jc3YuyToy+ZXM4CeO7uSCN/htgR8yv+tjSE3eJZ8eh8=
 github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6 h1:jL3a8soXdzuTCcRnKhOmtcsVOObdDTFf4O2B403HPRU=
 github.com/power-devops/perfstat v0.0.0-20260805114148-88456608a4f6/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/prometheus-community/pro-bing v0.9.1 h1:kpuAr6AU2oRtzGihJSUcetHtjc7ku7h6PxeuW9RVrQw=
+github.com/prometheus-community/pro-bing v0.9.1/go.mod h1:z79wYTxAOf6FpTng0QdIhZ3j/Nd5l3+gnFSCIT+SiSQ=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=

--- a/internal/hub/api.go
+++ b/internal/hub/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/henrygd/beszel/internal/alerts"
 	"github.com/henrygd/beszel/internal/ghupdate"
 	"github.com/henrygd/beszel/internal/hub/config"
+	"github.com/henrygd/beszel/internal/hub/monitors"
 	"github.com/henrygd/beszel/internal/hub/systems"
 	"github.com/henrygd/beszel/internal/hub/utils"
 	"github.com/pocketbase/dbx"
@@ -123,6 +124,8 @@ func (h *Hub) registerApiRoutes(se *core.ServeEvent) error {
 	// update / delete user alerts
 	apiAuth.POST("/user-alerts", alerts.UpsertUserAlerts)
 	apiAuth.DELETE("/user-alerts", alerts.DeleteUserAlerts)
+	// uptime monitors (routes mounted by the monitors package via OnServe)
+	monitors.RegisterRoutes(se.App)
 	// refresh SMART devices for a system
 	apiAuth.POST("/smart/refresh", h.refreshSmartData).BindFunc(excludeReadOnlyRole)
 	// refresh ZFS pool details for a system

--- a/internal/hub/api.go
+++ b/internal/hub/api.go
@@ -124,8 +124,9 @@ func (h *Hub) registerApiRoutes(se *core.ServeEvent) error {
 	// update / delete user alerts
 	apiAuth.POST("/user-alerts", alerts.UpsertUserAlerts)
 	apiAuth.DELETE("/user-alerts", alerts.DeleteUserAlerts)
-	// uptime monitors (routes mounted by the monitors package via OnServe)
-	monitors.RegisterRoutes(se.App)
+	// uptime monitors (mounted synchronously: nested OnServe hooks would
+	// never fire because PocketBase snapshots handlers at trigger time)
+	monitors.RegisterRoutes(se)
 	// refresh SMART devices for a system
 	apiAuth.POST("/smart/refresh", h.refreshSmartData).BindFunc(excludeReadOnlyRole)
 	// refresh ZFS pool details for a system

--- a/internal/hub/collections.go
+++ b/internal/hub/collections.go
@@ -115,6 +115,35 @@ func setCollectionAuthSettings(app core.App) error {
 		return err
 	}
 
+	// Uptime monitors: members of the monitor (or any authenticated user when
+	// SHARE_ALL_SYSTEMS is set) can read; writes block readonly users.
+	// monitor_checks rows are server-written, never via the public API.
+	monitorsMemberRule := authenticatedRule + " && users.id ?= @request.auth.id"
+	monitorsReadRule := monitorsMemberRule
+	checksReadRule := authenticatedRule + " && monitor.users.id ?= @request.auth.id"
+	if shareAllSystems == "true" {
+		monitorsReadRule = authenticatedRule
+		checksReadRule = authenticatedRule
+	}
+	monitorsWriteRule := monitorsReadRule + " && @request.auth.role != \"readonly\""
+
+	if err := applyCollectionRules(app, []string{"monitors"}, collectionRules{
+		list:   &monitorsReadRule,
+		view:   &monitorsReadRule,
+		create: &monitorsWriteRule,
+		update: &monitorsWriteRule,
+		delete: &monitorsWriteRule,
+	}); err != nil {
+		return err
+	}
+
+	if err := applyCollectionRules(app, []string{"monitor_checks"}, collectionRules{
+		list: &checksReadRule,
+		view: &checksReadRule,
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/internal/hub/config/config.go
+++ b/internal/hub/config/config.go
@@ -175,7 +175,8 @@ func generateYAML(h core.App) (string, error) {
 		Systems: make([]systemConfig, 0, len(systems)),
 	}
 
-	// Fetch all users at once
+	// Fetch all users at once (systems + monitors, so monitor-only users
+	// are included in the export).
 	allUserIDs := make([]string, 0)
 	for _, system := range systems {
 		allUserIDs = append(allUserIDs, system.GetStringSlice("users")...)
@@ -224,7 +225,17 @@ func generateYAML(h core.App) (string, error) {
 	}
 
 	// Populate the Config struct with monitor data (without secrets).
+	// Monitors absent from a later config.yml are never deleted (unlike
+	// systems); the header below documents this.
 	monitors, err := h.FindRecordsByFilter("monitors", "id != ''", "name", -1, 0)
+	if err != nil {
+		return "", err
+	}
+	for _, mon := range monitors {
+		allUserIDs = append(allUserIDs, mon.GetStringSlice("users")...)
+	}
+	// Rebuild the map now that monitor users are included.
+	userEmailMap, err = getUserEmailMap(h, allUserIDs)
 	if err != nil {
 		return "", err
 	}
@@ -240,12 +251,21 @@ func generateYAML(h core.App) (string, error) {
 		cfg := map[string]any{}
 		_ = mon.UnmarshalJSONField("config", &cfg)
 		for k := range cfg {
-			if yamlSecretKeys[strings.ToLower(k)] {
+			lk := strings.ToLower(k)
+			if yamlSecretKeys[lk] || lk == "headers" {
 				delete(cfg, k)
 			}
 		}
+		interval := int(mon.GetFloat("interval"))
+		timeout := int(mon.GetFloat("timeout"))
+		maxRetries := int(mon.GetFloat("max_retries"))
+		resendAfter := int(mon.GetFloat("resend_after"))
+		notify := mon.GetBool("notify")
 		config.Monitors = append(config.Monitors, monitorConfig{
 			Name: mon.GetString("name"), Type: mon.GetString("type"), Target: mon.GetString("target"),
+			Interval: &interval, Timeout: &timeout, MaxRetries: &maxRetries,
+			UpsideDown: mon.GetBool("upside_down"), Paused: mon.GetBool("paused"),
+			Notify: &notify, ResendAfter: &resendAfter,
 			Users: userEmails, Config: cfg,
 		})
 	}
@@ -257,7 +277,7 @@ func generateYAML(h core.App) (string, error) {
 	}
 
 	// Add a header to the YAML
-	yamlData = append([]byte("# Values for port, users, and token are optional.\n# Defaults are port 45876, the first created user, and a generated UUID token.\n\n"), yamlData...)
+	yamlData = append([]byte("# Values for port, users, and token are optional.\n# Defaults are port 45876, the first created user, and a generated UUID token.\n# Monitors sync from the 'monitors' key below. Unlike systems, monitors absent\n# from config.yml are never deleted, and secrets (password, token, headers)\n# are never exported - re-adding them requires editing the file manually.\n\n"), yamlData...)
 
 	return string(yamlData), nil
 }

--- a/internal/hub/config/config.go
+++ b/internal/hub/config/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/henrygd/beszel/internal/entities/system"
@@ -17,7 +18,8 @@ import (
 )
 
 type config struct {
-	Systems []systemConfig `yaml:"systems"`
+	Systems  []systemConfig  `yaml:"systems"`
+	Monitors []monitorConfig `yaml:"monitors,omitempty"`
 }
 
 type systemConfig struct {
@@ -219,6 +221,33 @@ func generateYAML(h core.App) (string, error) {
 			Token: systemTokenMap[system.Id],
 		}
 		config.Systems = append(config.Systems, sysConfig)
+	}
+
+	// Populate the Config struct with monitor data (without secrets).
+	monitors, err := h.FindRecordsByFilter("monitors", "id != ''", "name", -1, 0)
+	if err != nil {
+		return "", err
+	}
+	config.Monitors = make([]monitorConfig, 0, len(monitors))
+	for _, mon := range monitors {
+		userIDs := mon.GetStringSlice("users")
+		userEmails := make([]string, 0, len(userIDs))
+		for _, userID := range userIDs {
+			if email, ok := userEmailMap[userID]; ok {
+				userEmails = append(userEmails, email)
+			}
+		}
+		cfg := map[string]any{}
+		_ = mon.UnmarshalJSONField("config", &cfg)
+		for k := range cfg {
+			if yamlSecretKeys[strings.ToLower(k)] {
+				delete(cfg, k)
+			}
+		}
+		config.Monitors = append(config.Monitors, monitorConfig{
+			Name: mon.GetString("name"), Type: mon.GetString("type"), Target: mon.GetString("target"),
+			Users: userEmails, Config: cfg,
+		})
 	}
 
 	// Marshal the Config struct to YAML

--- a/internal/hub/config/monitors.go
+++ b/internal/hub/config/monitors.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/henrygd/beszel/internal/hub/monitors"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	"gopkg.in/yaml.v3"
+)
+
+type monitorsFile struct {
+	Monitors []monitorConfig `yaml:"monitors"`
+}
+
+type monitorConfig struct {
+	Name        string         `yaml:"name"`
+	Type        string         `yaml:"type"`
+	Target      string         `yaml:"target"`
+	Interval    *int           `yaml:"interval,omitempty"`
+	Timeout     *int           `yaml:"timeout,omitempty"`
+	MaxRetries  *int           `yaml:"max_retries,omitempty"`
+	UpsideDown  bool           `yaml:"upside_down,omitempty"`
+	Paused      bool           `yaml:"paused,omitempty"`
+	Notify      *bool          `yaml:"notify,omitempty"`
+	ResendAfter *int           `yaml:"resend_after,omitempty"`
+	Users       []string       `yaml:"users"`
+	Config      map[string]any `yaml:"config,omitempty"`
+}
+
+// SyncMonitors creates/updates monitors from config.yml (monitors: key).
+// Unlike SyncSystems it NEVER deletes records absent from the file: monitors
+// are UI-first and must survive a YAML sync that does not mention them.
+// Matching is done on (name, target).
+func SyncMonitors(e *core.ServeEvent) error {
+	h := e.App
+	configPath := filepath.Join(h.DataDir(), "config.yml")
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+
+	var file monitorsFile
+	if err := yaml.Unmarshal(configData, &file); err != nil {
+		return fmt.Errorf("failed to parse config.yml monitors: %v", err)
+	}
+	if len(file.Monitors) == 0 {
+		return nil
+	}
+
+	userEmailToID := make(map[string]string)
+	users, err := h.FindAllRecords("users", dbx.NewExp("id != ''"))
+	if err != nil {
+		return err
+	}
+	var firstUser *core.Record
+	if len(users) > 0 {
+		firstUser = users[0]
+		for _, user := range users {
+			userEmailToID[user.GetString("email")] = user.Id
+		}
+	}
+
+	monitorsCollection, err := h.FindCollectionByNameOrId("monitors")
+	if err != nil {
+		return fmt.Errorf("monitors collection not found (migration missing?): %v", err)
+	}
+
+	for _, mc := range file.Monitors {
+		if mc.Name == "" || mc.Type == "" || mc.Target == "" {
+			log.Printf("Skipping monitor with missing name/type/target")
+			continue
+		}
+		in := monitorInputFromConfig(mc)
+		if err := validateMonitorInput(in); err != nil {
+			log.Printf("Skipping monitor %q: %v", mc.Name, err)
+			continue
+		}
+		userIDs := resolveMonitorUsers(mc.Users, userEmailToID, firstUser)
+
+		existing, err := h.FindFirstRecordByFilter("monitors",
+			"name = {:name} && target = {:target}",
+			dbx.Params{"name": mc.Name, "target": strings.TrimSpace(mc.Target)})
+		if err == nil {
+			existing.Set("type", mc.Type)
+			existing.Set("target", strings.TrimSpace(mc.Target))
+			existing.Set("interval", in.IntervalSeconds)
+			existing.Set("timeout", in.TimeoutSeconds)
+			existing.Set("max_retries", in.MaxRetries)
+			existing.Set("upside_down", in.UpsideDown)
+			existing.Set("paused", mc.Paused)
+			existing.Set("notify", in.Notify)
+			existing.Set("resend_after", in.ResendAfter)
+			existing.Set("users", userIDs)
+			if len(mc.Config) > 0 {
+				existing.Set("config", mc.Config)
+			}
+			if err := h.Save(existing); err != nil {
+				return err
+			}
+			continue
+		}
+		rec := core.NewRecord(monitorsCollection)
+		rec.Set("name", mc.Name)
+		rec.Set("type", mc.Type)
+		rec.Set("target", strings.TrimSpace(mc.Target))
+		rec.Set("interval", in.IntervalSeconds)
+		rec.Set("timeout", in.TimeoutSeconds)
+		rec.Set("max_retries", in.MaxRetries)
+		rec.Set("upside_down", in.UpsideDown)
+		rec.Set("paused", mc.Paused)
+		rec.Set("notify", in.Notify)
+		rec.Set("resend_after", in.ResendAfter)
+		rec.Set("users", userIDs)
+		if len(mc.Config) > 0 {
+			rec.Set("config", mc.Config)
+		} else {
+			rec.Set("config", map[string]any{})
+		}
+		rec.Set("status", "pending")
+		if err := h.Save(rec); err != nil {
+			return fmt.Errorf("failed to create monitor %q: %v", mc.Name, err)
+		}
+	}
+
+	log.Println("Monitors synced with config.yml")
+	return nil
+}
+
+type validatedMonitorInput struct {
+	IntervalSeconds int
+	TimeoutSeconds  int
+	MaxRetries      int
+	UpsideDown      bool
+	Notify          bool
+	ResendAfter     int
+}
+
+// yamlSecretKeys are config keys stripped from generated YAML (mirrors the
+// API redaction; secrets are managed out of band).
+var yamlSecretKeys = map[string]bool{"password": true, "token": true}
+
+func monitorInputFromConfig(mc monitorConfig) validatedMonitorInput {
+	interval := 60
+	if mc.Interval != nil {
+		interval = *mc.Interval
+	}
+	timeout := 10
+	if mc.Timeout != nil {
+		timeout = *mc.Timeout
+	}
+	maxRetries := 2
+	if mc.MaxRetries != nil {
+		maxRetries = *mc.MaxRetries
+	}
+	notify := true
+	if mc.Notify != nil {
+		notify = *mc.Notify
+	}
+	resendAfter := 0
+	if mc.ResendAfter != nil {
+		resendAfter = *mc.ResendAfter
+	}
+	return validatedMonitorInput{
+		IntervalSeconds: interval, TimeoutSeconds: timeout,
+		MaxRetries: maxRetries, UpsideDown: mc.UpsideDown,
+		Notify: notify, ResendAfter: resendAfter,
+	}
+}
+
+func validateMonitorInput(in validatedMonitorInput) error {
+	m := monitors.Monitor{
+		Name: "x", Type: monitors.TypePing, Target: "example.com",
+		IntervalSeconds: in.IntervalSeconds, TimeoutSeconds: in.TimeoutSeconds,
+		MaxRetries: in.MaxRetries,
+	}
+	return m.Validate()
+}
+
+func resolveMonitorUsers(emails []string, emailToID map[string]string, firstUser *core.Record) []string {
+	if len(emails) == 0 {
+		if firstUser != nil {
+			return []string{firstUser.Id}
+		}
+		return []string{}
+	}
+	ids := make([]string, 0, len(emails))
+	for _, email := range emails {
+		if id, ok := emailToID[email]; ok {
+			ids = append(ids, id)
+		} else {
+			log.Printf("User %s not found", email)
+		}
+	}
+	return ids
+}

--- a/internal/hub/config/monitors.go
+++ b/internal/hub/config/monitors.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -72,59 +74,47 @@ func SyncMonitors(e *core.ServeEvent) error {
 	}
 
 	for _, mc := range file.Monitors {
-		if mc.Name == "" || mc.Type == "" || mc.Target == "" {
+		name := strings.TrimSpace(mc.Name)
+		typ := strings.ToLower(strings.TrimSpace(mc.Type))
+		if name == "" || typ == "" || strings.TrimSpace(mc.Target) == "" {
 			log.Printf("Skipping monitor with missing name/type/target")
+			continue
+		}
+		if !validMonitorType(typ) {
+			log.Printf("Skipping monitor %q: unknown type %q", name, mc.Type)
 			continue
 		}
 		in := monitorInputFromConfig(mc)
 		if err := validateMonitorInput(in); err != nil {
-			log.Printf("Skipping monitor %q: %v", mc.Name, err)
+			log.Printf("Skipping monitor %q: %v", name, err)
 			continue
 		}
 		userIDs := resolveMonitorUsers(mc.Users, userEmailToID, firstUser)
+		if len(userIDs) == 0 {
+			log.Printf("Skipping monitor %q: no known users", name)
+			continue
+		}
 
 		existing, err := h.FindFirstRecordByFilter("monitors",
 			"name = {:name} && target = {:target}",
-			dbx.Params{"name": mc.Name, "target": strings.TrimSpace(mc.Target)})
+			dbx.Params{"name": name, "target": strings.TrimSpace(mc.Target)})
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("failed to look up monitor %q: %v", name, err)
+		}
 		if err == nil {
-			existing.Set("type", mc.Type)
-			existing.Set("target", strings.TrimSpace(mc.Target))
-			existing.Set("interval", in.IntervalSeconds)
-			existing.Set("timeout", in.TimeoutSeconds)
-			existing.Set("max_retries", in.MaxRetries)
-			existing.Set("upside_down", in.UpsideDown)
-			existing.Set("paused", mc.Paused)
-			existing.Set("notify", in.Notify)
-			existing.Set("resend_after", in.ResendAfter)
-			existing.Set("users", userIDs)
-			if len(mc.Config) > 0 {
-				existing.Set("config", mc.Config)
-			}
+			applyMonitorConfig(existing, name, typ, strings.TrimSpace(mc.Target), in, mc, userIDs, true)
 			if err := h.Save(existing); err != nil {
-				return err
+				log.Printf("Skipping monitor %q: %v", name, err)
+				continue
 			}
 			continue
 		}
 		rec := core.NewRecord(monitorsCollection)
-		rec.Set("name", mc.Name)
-		rec.Set("type", mc.Type)
-		rec.Set("target", strings.TrimSpace(mc.Target))
-		rec.Set("interval", in.IntervalSeconds)
-		rec.Set("timeout", in.TimeoutSeconds)
-		rec.Set("max_retries", in.MaxRetries)
-		rec.Set("upside_down", in.UpsideDown)
-		rec.Set("paused", mc.Paused)
-		rec.Set("notify", in.Notify)
-		rec.Set("resend_after", in.ResendAfter)
-		rec.Set("users", userIDs)
-		if len(mc.Config) > 0 {
-			rec.Set("config", mc.Config)
-		} else {
-			rec.Set("config", map[string]any{})
-		}
+		applyMonitorConfig(rec, name, typ, strings.TrimSpace(mc.Target), in, mc, userIDs, false)
 		rec.Set("status", "pending")
 		if err := h.Save(rec); err != nil {
-			return fmt.Errorf("failed to create monitor %q: %v", mc.Name, err)
+			log.Printf("Skipping monitor %q: %v", name, err)
+			continue
 		}
 	}
 
@@ -179,7 +169,69 @@ func validateMonitorInput(in validatedMonitorInput) error {
 		IntervalSeconds: in.IntervalSeconds, TimeoutSeconds: in.TimeoutSeconds,
 		MaxRetries: in.MaxRetries,
 	}
-	return m.Validate()
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	if in.ResendAfter < 0 || in.ResendAfter > 1440 {
+		return fmt.Errorf("resend_after must be 0..1440 minutes")
+	}
+	return nil
+}
+
+func validMonitorType(t string) bool {
+	switch monitors.MonitorType(t) {
+	case monitors.TypeHTTP, monitors.TypeKeyword, monitors.TypePing, monitors.TypeDNS, monitors.TypeTLS:
+		return true
+	}
+	return false
+}
+
+// applyMonitorConfig writes validated YAML values onto a record. On update,
+// stored secrets absent from the YAML are preserved; headers are never
+// written from YAML exports (see generateYAML).
+func applyMonitorConfig(rec *core.Record, name, typ, target string, in validatedMonitorInput, mc monitorConfig, userIDs []string, isUpdate bool) {
+	rec.Set("name", name)
+	rec.Set("type", typ)
+	rec.Set("target", target)
+	rec.Set("interval", in.IntervalSeconds)
+	rec.Set("timeout", in.TimeoutSeconds)
+	rec.Set("max_retries", in.MaxRetries)
+	rec.Set("upside_down", in.UpsideDown)
+	rec.Set("paused", mc.Paused)
+	rec.Set("notify", in.Notify)
+	rec.Set("resend_after", in.ResendAfter)
+	rec.Set("users", userIDs)
+	if len(mc.Config) == 0 {
+		if !isUpdate {
+			rec.Set("config", map[string]any{})
+		}
+		return
+	}
+	merged := make(map[string]any, len(mc.Config))
+	stored := map[string]any{}
+	if isUpdate {
+		_ = rec.UnmarshalJSONField("config", &stored)
+		for k, v := range stored {
+			merged[k] = v
+		}
+	}
+	for k, v := range mc.Config {
+		merged[k] = v
+	}
+	// Never wipe stored secrets via YAML: a secret absent from the YAML
+	// keeps its stored value (the merge above already preserves it; the
+	// explicit pass documents the guarantee).
+	if isUpdate {
+		for k := range yamlSecretKeys {
+			if _, ok := mc.Config[k]; !ok {
+				delete(merged, k)
+				if sv, ok := stored[k]; ok {
+					merged[k] = sv
+				}
+			}
+		}
+	}
+	rec.Set("config", merged)
 }
 
 func resolveMonitorUsers(emails []string, emailToID map[string]string, firstUser *core.Record) []string {

--- a/internal/hub/config/monitors_test.go
+++ b/internal/hub/config/monitors_test.go
@@ -1,0 +1,126 @@
+//go:build testing
+
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/henrygd/beszel/internal/hub/config"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/henrygd/beszel/internal/migrations"
+)
+
+func writeConfigYAML(t *testing.T, dir, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "config.yml"), []byte(content), 0644))
+}
+
+func newConfigTestApp(t *testing.T) (*pbtests.TestApp, string) {
+	t.Helper()
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+	dir := app.DataDir()
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "yaml@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+	return app, dir
+}
+
+func serveEventFor(app *pbtests.TestApp) *core.ServeEvent {
+	return &core.ServeEvent{App: app}
+}
+
+func TestSyncMonitors_CreatesFromYAML(t *testing.T) {
+	app, dir := newConfigTestApp(t)
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: web
+    type: http
+    target: https://example.com
+    users: [yaml@example.com]
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	total, err := app.CountRecords("monitors")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total)
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Equal(t, "web", recs[0].GetString("name"))
+	require.Equal(t, "pending", recs[0].GetString("status"))
+}
+
+func TestSyncMonitors_NeverDeletesUIData(t *testing.T) {
+	app, dir := newConfigTestApp(t)
+
+	// UI-created monitor absent from YAML must survive the sync.
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	u, err := app.FindAuthRecordByEmail("users", "yaml@example.com")
+	require.NoError(t, err)
+	_ = users
+	ui := core.NewRecord(col)
+	ui.Set("name", "ui-only")
+	ui.Set("type", "ping")
+	ui.Set("target", "example.com")
+	ui.Set("interval", 60)
+	ui.Set("timeout", 10)
+	ui.Set("status", "up")
+	ui.Set("users", []string{u.Id})
+	require.NoError(t, app.Save(ui))
+
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: yaml-one
+    type: dns
+    target: example.com
+    users: [yaml@example.com]
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	total, err := app.CountRecords("monitors")
+	require.NoError(t, err)
+	require.EqualValues(t, 2, total, "UI-created monitors must never be deleted by YAML sync")
+}
+
+func TestSyncMonitors_UpdatesExisting(t *testing.T) {
+	app, dir := newConfigTestApp(t)
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: web
+    type: http
+    target: https://example.com
+    interval: 60
+    users: [yaml@example.com]
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: web
+    type: http
+    target: https://example.com
+    interval: 120
+    users: [yaml@example.com]
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.EqualValues(t, 120, recs[0].GetFloat("interval"))
+}

--- a/internal/hub/config/monitors_test.go
+++ b/internal/hub/config/monitors_test.go
@@ -124,3 +124,78 @@ monitors:
 	require.Len(t, recs, 1)
 	require.EqualValues(t, 120, recs[0].GetFloat("interval"))
 }
+
+func TestSyncMonitors_SkipsInvalidEntries(t *testing.T) {
+	app, dir := newConfigTestApp(t)
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: bad-type
+    type: gopher
+    target: example.com
+    users: [yaml@example.com]
+  - name: bad-interval
+    type: ping
+    target: example.com
+    interval: 5
+    users: [yaml@example.com]
+  - name: unknown-user
+    type: ping
+    target: example.com
+    users: [ghost@example.com]
+  - name: good
+    type: ping
+    target: example.com
+    users: [yaml@example.com]
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	total, err := app.CountRecords("monitors")
+	require.NoError(t, err)
+	require.EqualValues(t, 1, total, "only the valid entry must sync, boot must not fail")
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Equal(t, "good", recs[0].GetString("name"))
+}
+
+func TestSyncMonitors_PausedAndSecrets(t *testing.T) {
+	app, dir := newConfigTestApp(t)
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: quiet
+    type: http
+    target: https://example.com
+    paused: true
+    users: [yaml@example.com]
+    config:
+      auth_type: bearer
+      token: live-secret
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	require.True(t, recs[0].GetBool("paused"))
+	cfg := map[string]any{}
+	require.NoError(t, recs[0].UnmarshalJSONField("config", &cfg))
+	require.Equal(t, "live-secret", cfg["token"], "YAML-provided secrets must persist")
+
+	// Re-sync without the secret: stored secret must survive.
+	writeConfigYAML(t, dir, `
+monitors:
+  - name: quiet
+    type: http
+    target: https://example.com
+    paused: true
+    users: [yaml@example.com]
+    config:
+      auth_type: bearer
+`)
+	require.NoError(t, config.SyncMonitors(serveEventFor(app)))
+	recs, err = app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	cfg = map[string]any{}
+	require.NoError(t, recs[0].UnmarshalJSONField("config", &cfg))
+	require.Equal(t, "live-secret", cfg["token"], "stored secret must survive YAML without it")
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -14,6 +14,7 @@ import (
 	"github.com/henrygd/beszel/internal/alerts"
 	"github.com/henrygd/beszel/internal/hub/config"
 	"github.com/henrygd/beszel/internal/hub/heartbeat"
+	"github.com/henrygd/beszel/internal/hub/monitors"
 	"github.com/henrygd/beszel/internal/hub/systems"
 	"github.com/henrygd/beszel/internal/hub/utils"
 	"github.com/henrygd/beszel/internal/records"
@@ -33,6 +34,7 @@ type Hub struct {
 	sm     *systems.SystemManager
 	hb     *heartbeat.Heartbeat
 	hbStop chan struct{}
+	me     *monitors.Engine
 	pubKey string
 	signer ssh.Signer
 	appURL string
@@ -49,8 +51,17 @@ func NewHub(app core.App) *Hub {
 	if hub.hb != nil {
 		hub.hbStop = make(chan struct{})
 	}
+	hub.me = monitors.NewEngine(app, hub.sendMonitorAlert)
 	_ = onAfterBootstrapAndMigrations(app, hub.initialize)
 	return hub
+}
+
+// sendMonitorAlert adapts Engine notifications to the alerts pipeline
+// (emails + shoutrrr webhooks + quiet hours via SendAlert).
+func (h *Hub) sendMonitorAlert(userID, title, message, link string) {
+	_ = h.SendAlert(alerts.AlertMessageData{
+		UserID: userID, Title: title, Message: message, Link: link, LinkText: "View monitor",
+	})
 }
 
 // onAfterBootstrapAndMigrations ensures the provided function runs after the database is set up and migrations are applied.
@@ -95,6 +106,10 @@ func (h *Hub) StartHub() error {
 		}
 		// start system updates
 		if err := h.sm.Initialize(); err != nil {
+			return err
+		}
+		// start uptime monitors (hub-only checks, PR1)
+		if err := h.me.Start(); err != nil {
 			return err
 		}
 		// start heartbeat if configured

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -91,6 +91,10 @@ func (h *Hub) StartHub() error {
 		if err := config.SyncSystems(e); err != nil {
 			return err
 		}
+		// sync uptime monitors with config (never deletes UI-created monitors)
+		if err := config.SyncMonitors(e); err != nil {
+			return err
+		}
 		// register middlewares
 		h.registerMiddlewares(e)
 		// register api routes

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -52,6 +52,7 @@ func NewHub(app core.App) *Hub {
 		hub.hbStop = make(chan struct{})
 	}
 	hub.me = monitors.NewEngine(app, hub.sendMonitorAlert)
+	hub.me.SetLink(func(id string) string { return hub.MakeLink("monitors", id) })
 	_ = onAfterBootstrapAndMigrations(app, hub.initialize)
 	return hub
 }

--- a/internal/hub/monitors/api.go
+++ b/internal/hub/monitors/api.go
@@ -6,11 +6,13 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -135,7 +137,9 @@ func validateInput(in *monitorInput) error {
 			}
 		}
 	case TypeTLS:
-		host, port, err := ParsePortOrDefault(m.Target, 443)
+		// Same parser as the checker: URL (https://host[:port]/...) or
+		// host[:port], default 443. Sharing it guarantees API/checker parity.
+		host, port, err := parseTLSTarget(m.Target)
 		if err != nil {
 			return fmt.Errorf("invalid tls target: %v", err)
 		}
@@ -234,7 +238,9 @@ func shareAllSystems(_ core.App) bool {
 // which FindAllRecords with raw dbx expressions cannot express. Monitor
 // counts per hub stay small (Task 13 load test), so this is safe.
 func filterMonitorRecords(recs []*core.Record, userID, paused string) []*core.Record {
-	out := recs[:0]
+	// Fresh slice (never recs[:0]): aliasing the input would corrupt
+	// callers that reuse the slice across calls.
+	out := make([]*core.Record, 0, len(recs))
 	for _, rec := range recs {
 		member := shareAllSystems(nil)
 		if !member {
@@ -259,6 +265,11 @@ func filterMonitorRecords(recs []*core.Record, userID, paused string) []*core.Re
 	return out
 }
 
+// sortMonitorsByName orders monitors for the list endpoint (spec §7).
+func sortMonitorsByName(recs []*core.Record) {
+	sort.Slice(recs, func(i, j int) bool { return recs[i].GetString("name") < recs[j].GetString("name") })
+}
+
 func (a *MonitorAPI) findMonitor(e *core.RequestEvent, id string) (*core.Record, error) {
 	rec, err := a.app.FindRecordById("monitors", id)
 	if err != nil {
@@ -276,6 +287,7 @@ func (a *MonitorAPI) list(e *core.RequestEvent) error {
 		return e.InternalServerError("", err)
 	}
 	recs = filterMonitorRecords(recs, e.Auth.Id, e.Request.URL.Query().Get("paused"))
+	sortMonitorsByName(recs)
 	out := make([]map[string]any, 0, len(recs))
 	for _, rec := range recs {
 		out = append(out, monitorToResponse(rec))
@@ -402,7 +414,10 @@ func (a *MonitorAPI) update(e *core.RequestEvent) error {
 		rec.Set("users", in.Users)
 	}
 	if in.Config != nil {
-		// PATCH without secrets keeps existing secrets.
+		// Shallow top-level merge: nested objects (e.g. headers) are
+		// replaced wholesale and keys cannot be deleted individually —
+		// send the full config to rewrite it. Secrets sent back redacted
+		// keep their stored values.
 		existing := map[string]any{}
 		_ = rec.UnmarshalJSONField("config", &existing)
 		configChanged := false
@@ -459,9 +474,8 @@ func (a *MonitorAPI) checks(e *core.RequestEvent) error {
 		}
 	}
 	// Order + limit are pushed to SQL (newest first); the range cutoff is
-	// applied in Go below. rec.Id is a server-generated [a-z0-9] id, safe to
-	// interpolate (FindRecordsByFilter takes no bound params).
-	rows, err := a.app.FindRecordsByFilter("monitor_checks", "monitor = '"+rec.Id+"'", "-created", limit, 0)
+	// applied in Go below.
+	rows, err := a.app.FindRecordsByFilter("monitor_checks", "monitor = {:mon}", "-created", limit, 0, dbx.Params{"mon": rec.Id})
 	if err != nil {
 		return e.InternalServerError("failed to load check history", err)
 	}

--- a/internal/hub/monitors/api.go
+++ b/internal/hub/monitors/api.go
@@ -3,15 +3,14 @@ package monitors
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -25,28 +24,46 @@ var secretConfigKeys = map[string]bool{"password": true, "token": true}
 // MonitorAPI exposes monitor CRUD, history, testing and summary endpoints.
 // The scheduler is wired in Task 10; check runs inline here for test/manual runs.
 type MonitorAPI struct {
-	app      core.App
-	mu       sync.Mutex
-	testHits map[string][]time.Time
+	app core.App
 }
 
-// RegisterRoutes mounts the monitors API under /api/beszel/monitors via an
-// OnServe hook, so it works both in production and in ApiScenario tests.
-func RegisterRoutes(app core.App) {
-	api := &MonitorAPI{app: app, testHits: make(map[string][]time.Time)}
-	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
-		g := e.Router.Group("/api/beszel/monitors")
-		g.Bind(apis.RequireAuth())
-		g.GET("", api.list)
-		g.POST("", api.create)
-		g.GET("/summary", api.summary)
-		g.GET("/{id}", api.get)
-		g.PATCH("/{id}", api.update)
-		g.DELETE("/{id}", api.delete)
-		g.GET("/{id}/checks", api.checks)
-		g.POST("/{id}/test", api.test)
-		return e.Next()
-	})
+// testLimiter holds sliding-window timestamps for the manual-test endpoint.
+// It is shared per app (not per MonitorAPI instance): production mounts one
+// instance, but tests mount one per scenario on the same app, and the
+// rate limit must apply across them.
+type testLimiter struct {
+	mu   sync.Mutex
+	hits map[string][]time.Time
+}
+
+var testLimiters sync.Map // core.App -> *testLimiter
+
+func limiterFor(app core.App) *testLimiter {
+	if v, ok := testLimiters.Load(app); ok {
+		return v.(*testLimiter)
+	}
+	l := &testLimiter{hits: make(map[string][]time.Time)}
+	actual, _ := testLimiters.LoadOrStore(app, l)
+	return actual.(*testLimiter)
+}
+
+// RegisterRoutes mounts the monitors API under /api/beszel/monitors on the
+// given serve event's router. It must be called synchronously from the
+// parent OnServe handler (registerApiRoutes): PocketBase snapshots OnServe
+// handlers when the event triggers, so binding a nested OnServe hook here
+// would never fire in production.
+func RegisterRoutes(se *core.ServeEvent) {
+	api := &MonitorAPI{app: se.App}
+	g := se.Router.Group("/api/beszel/monitors")
+	g.Bind(apis.RequireAuth())
+	g.GET("", api.list)
+	g.POST("", api.create)
+	g.GET("/summary", api.summary)
+	g.GET("/{id}", api.get)
+	g.PATCH("/{id}", api.update)
+	g.DELETE("/{id}", api.delete)
+	g.GET("/{id}/checks", api.checks)
+	g.POST("/{id}/test", api.test)
 }
 
 type monitorInput struct {
@@ -56,8 +73,8 @@ type monitorInput struct {
 	Interval    *int           `json:"interval"`
 	Timeout     *int           `json:"timeout"`
 	MaxRetries  *int           `json:"max_retries"`
-	UpsideDown  bool           `json:"upside_down"`
-	Paused      bool           `json:"paused"`
+	UpsideDown  *bool          `json:"upside_down"`
+	Paused      *bool          `json:"paused"`
 	Notify      *bool          `json:"notify"`
 	ResendAfter *int           `json:"resend_after"`
 	Users       []string       `json:"users"`
@@ -78,17 +95,85 @@ func boolOr(v *bool, def bool) bool {
 	return *v
 }
 
-// validateInput applies defaults and returns field-typed errors.
+// validateInput applies defaults and returns field-typed errors. It
+// validates the API-level surface (types, schemes, ports, enums, bounds);
+// fine-grained config semantics stay with the checkers, which report typed
+// Down results at check time.
 func validateInput(in *monitorInput) error {
 	m := Monitor{
 		Name: in.Name, Type: MonitorType(in.Type), Target: strings.TrimSpace(in.Target),
 		IntervalSeconds: intOr(in.Interval, 60), TimeoutSeconds: intOr(in.Timeout, 10),
-		MaxRetries: intOr(in.MaxRetries, 2), UpsideDown: in.UpsideDown,
+		MaxRetries: intOr(in.MaxRetries, 2), UpsideDown: boolOr(in.UpsideDown, false),
 	}
 	if in.Name == "" {
 		return fmt.Errorf("name is required")
 	}
-	return m.Validate()
+	if err := m.Validate(); err != nil {
+		return err
+	}
+	if ra := intOr(in.ResendAfter, 0); ra < 0 || ra > 1440 {
+		return fmt.Errorf("resend_after must be 0..1440 minutes")
+	}
+	switch m.Type {
+	case TypeHTTP, TypeKeyword:
+		u, err := parseMonitorURL(m.Target)
+		if err != nil {
+			return fmt.Errorf("invalid http target: %v", err)
+		}
+		if u.Scheme != "http" && u.Scheme != "https" {
+			return fmt.Errorf("http target must use http(s) scheme")
+		}
+		if u.Hostname() == "" {
+			return fmt.Errorf("http target must have a host")
+		}
+		if in.Config != nil {
+			if method, ok := in.Config["method"]; ok {
+				s, _ := method.(string)
+				if !allowedHTTPMethods[strings.ToUpper(s)] {
+					return fmt.Errorf("invalid method %q", s)
+				}
+			}
+		}
+	case TypeTLS:
+		host, port, err := ParsePortOrDefault(m.Target, 443)
+		if err != nil {
+			return fmt.Errorf("invalid tls target: %v", err)
+		}
+		if host == "" || port <= 0 || port > 65535 {
+			return fmt.Errorf("tls target must be host[:port]")
+		}
+	case TypeDNS:
+		if in.Config != nil {
+			if qtype, ok := in.Config["qtype"]; ok {
+				s, _ := qtype.(string)
+				if _, ok := allowedDNSQTypes[strings.ToUpper(s)]; !ok {
+					return fmt.Errorf("invalid qtype %q", s)
+				}
+			}
+			if proto, ok := in.Config["protocol"]; ok {
+				s, _ := proto.(string)
+				if s != "udp" && s != "tcp" {
+					return fmt.Errorf("invalid protocol %q: must be udp or tcp", s)
+				}
+			}
+			if resolver, ok := in.Config["resolver"]; ok {
+				if s, _ := resolver.(string); s != "" {
+					host, _, err := ParsePortOrDefault(s, 53)
+					if err != nil {
+						return fmt.Errorf("invalid resolver: %v", err)
+					}
+					if net.ParseIP(stripBrackets(host)) == nil {
+						return fmt.Errorf("resolver must be an IP address")
+					}
+				}
+			}
+		}
+	case TypePing:
+		if strings.TrimSpace(m.Target) == "" {
+			return fmt.Errorf("ping target must not be empty")
+		}
+	}
+	return nil
 }
 
 func redactConfig(cfg map[string]any) map[string]any {
@@ -234,9 +319,9 @@ func (a *MonitorAPI) create(e *core.RequestEvent) error {
 	rec.Set("config", in.Config)
 	rec.Set("status", "pending")
 	if err := a.app.Save(rec); err != nil {
-		return e.BadRequestError("", err)
+		return e.BadRequestError("failed to save monitor", err)
 	}
-	return e.JSON(http.StatusOK, monitorToResponse(rec))
+	return e.JSON(http.StatusCreated, monitorToResponse(rec))
 }
 
 func (a *MonitorAPI) get(e *core.RequestEvent) error {
@@ -270,8 +355,9 @@ func (a *MonitorAPI) update(e *core.RequestEvent) error {
 	mr := int(rec.GetFloat("max_retries"))
 	ra := int(rec.GetFloat("resend_after"))
 	nv := rec.GetBool("notify")
+	ud := rec.GetBool("upside_down")
 	merged.Interval, merged.Timeout, merged.MaxRetries = &iv, &tv, &mr
-	merged.ResendAfter, merged.Notify = &ra, &nv
+	merged.ResendAfter, merged.Notify, merged.UpsideDown = &ra, &nv, &ud
 	if in.Interval != nil {
 		merged.Interval = in.Interval
 	}
@@ -287,9 +373,8 @@ func (a *MonitorAPI) update(e *core.RequestEvent) error {
 	if in.ResendAfter != nil {
 		merged.ResendAfter = in.ResendAfter
 	}
-	merged.UpsideDown = rec.GetBool("upside_down")
-	if in.UpsideDown {
-		merged.UpsideDown = true
+	if in.UpsideDown != nil {
+		merged.UpsideDown = in.UpsideDown
 	}
 	if err := validateInput(&merged); err != nil {
 		return e.BadRequestError(err.Error(), nil)
@@ -303,9 +388,14 @@ func (a *MonitorAPI) update(e *core.RequestEvent) error {
 	rec.Set("max_retries", *merged.MaxRetries)
 	rec.Set("notify", *merged.Notify)
 	rec.Set("resend_after", *merged.ResendAfter)
-	if in.Paused != rec.GetBool("paused") {
-		rec.Set("paused", in.Paused)
-		rec.Set("status", "paused")
+	rec.Set("upside_down", *merged.UpsideDown)
+	if in.Paused != nil && *in.Paused != rec.GetBool("paused") {
+		rec.Set("paused", *in.Paused)
+		if *in.Paused {
+			rec.Set("status", "paused")
+		} else {
+			rec.Set("status", "pending")
+		}
 		rec.Set("consecutive_failures", 0)
 	}
 	if in.Users != nil {
@@ -331,7 +421,7 @@ func (a *MonitorAPI) update(e *core.RequestEvent) error {
 		rec.Set("consecutive_failures", 0)
 	}
 	if err := a.app.Save(rec); err != nil {
-		return e.BadRequestError("", err)
+		return e.BadRequestError("failed to save monitor", err)
 	}
 	return e.JSON(http.StatusOK, monitorToResponse(rec))
 }
@@ -368,25 +458,26 @@ func (a *MonitorAPI) checks(e *core.RequestEvent) error {
 			limit = min(n, 1000)
 		}
 	}
-	filter := "monitor = {:mon}"
-	params := dbx.Params{"mon": rec.Id}
+	// Order + limit are pushed to SQL (newest first); the range cutoff is
+	// applied in Go below. rec.Id is a server-generated [a-z0-9] id, safe to
+	// interpolate (FindRecordsByFilter takes no bound params).
+	rows, err := a.app.FindRecordsByFilter("monitor_checks", "monitor = '"+rec.Id+"'", "-created", limit, 0)
+	if err != nil {
+		return e.InternalServerError("failed to load check history", err)
+	}
 	if rng := e.Request.URL.Query().Get("range"); rng == "24h" || rng == "30d" {
 		hours := 24
 		if rng == "30d" {
 			hours = 30 * 24
 		}
-		filter += " && created >= {:cutoff}"
-		params["cutoff"] = time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
-	}
-	rows, err := a.app.FindAllRecords("monitor_checks", dbx.NewExp(filter, params))
-	if err != nil {
-		return e.InternalServerError("", err)
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		return rows[i].GetDateTime("created").After(rows[j].GetDateTime("created"))
-	})
-	if len(rows) > limit {
-		rows = rows[:limit]
+		cutoff := time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
+		kept := rows[:0]
+		for _, r := range rows {
+			if !r.GetDateTime("created").Time().Before(cutoff) {
+				kept = append(kept, r)
+			}
+		}
+		rows = kept
 	}
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
@@ -403,8 +494,9 @@ func (a *MonitorAPI) checks(e *core.RequestEvent) error {
 
 // allowTest enforces 1 run per 10s per monitor and 10/min per user.
 func (a *MonitorAPI) allowTest(userID, monitorID string) bool {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	l := limiterFor(a.app)
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	now := time.Now()
 	keep := func(ts []time.Time, window time.Duration) []time.Time {
 		out := ts[:0]
@@ -415,17 +507,17 @@ func (a *MonitorAPI) allowTest(userID, monitorID string) bool {
 		}
 		return out
 	}
-	user := a.testHits["u:"+userID]
-	mon := a.testHits["m:"+monitorID]
+	user := l.hits["u:"+userID]
+	mon := l.hits["m:"+monitorID]
 	user = keep(user, time.Minute)
 	mon = keep(mon, 10*time.Second)
 	if len(user) >= 10 || len(mon) >= 1 {
-		a.testHits["u:"+userID] = user
-		a.testHits["m:"+monitorID] = mon
+		l.hits["u:"+userID] = user
+		l.hits["m:"+monitorID] = mon
 		return false
 	}
-	a.testHits["u:"+userID] = append(user, now)
-	a.testHits["m:"+monitorID] = append(mon, now)
+	l.hits["u:"+userID] = append(user, now)
+	l.hits["m:"+monitorID] = append(mon, now)
 	return true
 }
 
@@ -461,12 +553,9 @@ func (a *MonitorAPI) test(e *core.RequestEvent) error {
 func (a *MonitorAPI) summary(e *core.RequestEvent) error {
 	recs, err := a.app.FindAllRecords("monitors")
 	if err != nil {
-		return e.InternalServerError("", err)
+		return e.InternalServerError("failed to load monitors", err)
 	}
 	recs = filterMonitorRecords(recs, e.Auth.Id, "")
-	if err != nil {
-		return e.InternalServerError("", err)
-	}
 	counts := map[string]int{"up": 0, "down": 0, "warn": 0, "paused": 0, "pending": 0}
 	var down []map[string]any
 	for _, rec := range recs {

--- a/internal/hub/monitors/api.go
+++ b/internal/hub/monitors/api.go
@@ -1,0 +1,486 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// redactedSecret masks secret values in API responses.
+const redactedSecret = "••••••"
+
+// secretConfigKeys are config keys never returned in clear text.
+var secretConfigKeys = map[string]bool{"password": true, "token": true}
+
+// MonitorAPI exposes monitor CRUD, history, testing and summary endpoints.
+// The scheduler is wired in Task 10; check runs inline here for test/manual runs.
+type MonitorAPI struct {
+	app      core.App
+	mu       sync.Mutex
+	testHits map[string][]time.Time
+}
+
+// RegisterRoutes mounts the monitors API under /api/beszel/monitors via an
+// OnServe hook, so it works both in production and in ApiScenario tests.
+func RegisterRoutes(app core.App) {
+	api := &MonitorAPI{app: app, testHits: make(map[string][]time.Time)}
+	app.OnServe().BindFunc(func(e *core.ServeEvent) error {
+		g := e.Router.Group("/api/beszel/monitors")
+		g.Bind(apis.RequireAuth())
+		g.GET("", api.list)
+		g.POST("", api.create)
+		g.GET("/summary", api.summary)
+		g.GET("/{id}", api.get)
+		g.PATCH("/{id}", api.update)
+		g.DELETE("/{id}", api.delete)
+		g.GET("/{id}/checks", api.checks)
+		g.POST("/{id}/test", api.test)
+		return e.Next()
+	})
+}
+
+type monitorInput struct {
+	Name        string         `json:"name"`
+	Type        string         `json:"type"`
+	Target      string         `json:"target"`
+	Interval    *int           `json:"interval"`
+	Timeout     *int           `json:"timeout"`
+	MaxRetries  *int           `json:"max_retries"`
+	UpsideDown  bool           `json:"upside_down"`
+	Paused      bool           `json:"paused"`
+	Notify      *bool          `json:"notify"`
+	ResendAfter *int           `json:"resend_after"`
+	Users       []string       `json:"users"`
+	Config      map[string]any `json:"config"`
+}
+
+func intOr(v *int, def int) int {
+	if v == nil {
+		return def
+	}
+	return *v
+}
+
+func boolOr(v *bool, def bool) bool {
+	if v == nil {
+		return def
+	}
+	return *v
+}
+
+// validateInput applies defaults and returns field-typed errors.
+func validateInput(in *monitorInput) error {
+	m := Monitor{
+		Name: in.Name, Type: MonitorType(in.Type), Target: strings.TrimSpace(in.Target),
+		IntervalSeconds: intOr(in.Interval, 60), TimeoutSeconds: intOr(in.Timeout, 10),
+		MaxRetries: intOr(in.MaxRetries, 2), UpsideDown: in.UpsideDown,
+	}
+	if in.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	return m.Validate()
+}
+
+func redactConfig(cfg map[string]any) map[string]any {
+	if cfg == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(cfg))
+	for k, v := range cfg {
+		if secretConfigKeys[strings.ToLower(k)] {
+			out[k] = redactedSecret
+			continue
+		}
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = redactConfig(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+func monitorToResponse(rec *core.Record) map[string]any {
+	cfg := map[string]any{}
+	_ = rec.UnmarshalJSONField("config", &cfg)
+	return map[string]any{
+		"id": rec.Id, "name": rec.GetString("name"), "type": rec.GetString("type"),
+		"target": rec.GetString("target"), "interval": rec.GetFloat("interval"),
+		"timeout": rec.GetFloat("timeout"), "max_retries": rec.GetFloat("max_retries"),
+		"upside_down": rec.GetBool("upside_down"), "paused": rec.GetBool("paused"),
+		"notify": rec.GetBool("notify"), "resend_after": rec.GetFloat("resend_after"),
+		"users": rec.GetStringSlice("users"), "config": redactConfig(cfg),
+		"status": rec.GetString("status"), "last_check": rec.GetDateTime("last_check"),
+		"last_latency_ms": rec.GetFloat("last_latency_ms"), "uptime_24h": rec.GetFloat("uptime_24h"),
+		"cert_days": rec.GetFloat("cert_days"),
+		"created":   rec.GetDateTime("created"), "updated": rec.GetDateTime("updated"),
+	}
+}
+
+// monitorHasUser mirrors alerts.userHasSystem plus SHARE_ALL_SYSTEMS.
+func monitorHasUser(app core.App, userID string, rec *core.Record) bool {
+	if shareAllSystems(app) {
+		return true
+	}
+	for _, u := range rec.GetStringSlice("users") {
+		if u == userID {
+			return true
+		}
+	}
+	return false
+}
+
+func shareAllSystems(_ core.App) bool {
+	return os.Getenv("SHARE_ALL_SYSTEMS") == "true"
+}
+
+// filterMonitorRecords applies membership and paused filters in Go instead
+// of SQL: relation membership needs PocketBase filter parsing with joins,
+// which FindAllRecords with raw dbx expressions cannot express. Monitor
+// counts per hub stay small (Task 13 load test), so this is safe.
+func filterMonitorRecords(recs []*core.Record, userID, paused string) []*core.Record {
+	out := recs[:0]
+	for _, rec := range recs {
+		member := shareAllSystems(nil)
+		if !member {
+			for _, u := range rec.GetStringSlice("users") {
+				if u == userID {
+					member = true
+					break
+				}
+			}
+		}
+		if !member {
+			continue
+		}
+		if paused != "" {
+			want := paused == "true" || paused == "1"
+			if rec.GetBool("paused") != want {
+				continue
+			}
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func (a *MonitorAPI) findMonitor(e *core.RequestEvent, id string) (*core.Record, error) {
+	rec, err := a.app.FindRecordById("monitors", id)
+	if err != nil {
+		return nil, e.NotFoundError("monitor not found", err)
+	}
+	if !monitorHasUser(a.app, e.Auth.Id, rec) {
+		return nil, e.NotFoundError("monitor not found", nil)
+	}
+	return rec, nil
+}
+
+func (a *MonitorAPI) list(e *core.RequestEvent) error {
+	recs, err := a.app.FindAllRecords("monitors")
+	if err != nil {
+		return e.InternalServerError("", err)
+	}
+	recs = filterMonitorRecords(recs, e.Auth.Id, e.Request.URL.Query().Get("paused"))
+	out := make([]map[string]any, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, monitorToResponse(rec))
+	}
+	return e.JSON(http.StatusOK, out)
+}
+
+func (a *MonitorAPI) create(e *core.RequestEvent) error {
+	if e.Auth.GetString("role") == "readonly" {
+		return e.ForbiddenError("readonly users cannot create monitors", nil)
+	}
+	var in monitorInput
+	if err := e.BindBody(&in); err != nil {
+		return e.BadRequestError("invalid body", err)
+	}
+	if len(in.Users) == 0 {
+		in.Users = []string{e.Auth.Id}
+	}
+	if err := validateInput(&in); err != nil {
+		return e.BadRequestError(err.Error(), nil)
+	}
+	col, err := a.app.FindCachedCollectionByNameOrId("monitors")
+	if err != nil {
+		return e.InternalServerError("", err)
+	}
+	rec := core.NewRecord(col)
+	rec.Set("name", in.Name)
+	rec.Set("type", in.Type)
+	rec.Set("target", strings.TrimSpace(in.Target))
+	rec.Set("interval", intOr(in.Interval, 60))
+	rec.Set("timeout", intOr(in.Timeout, 10))
+	rec.Set("max_retries", intOr(in.MaxRetries, 2))
+	rec.Set("upside_down", in.UpsideDown)
+	rec.Set("paused", in.Paused)
+	rec.Set("notify", boolOr(in.Notify, true))
+	rec.Set("resend_after", intOr(in.ResendAfter, 0))
+	rec.Set("users", in.Users)
+	if in.Config == nil {
+		in.Config = map[string]any{}
+	}
+	rec.Set("config", in.Config)
+	rec.Set("status", "pending")
+	if err := a.app.Save(rec); err != nil {
+		return e.BadRequestError("", err)
+	}
+	return e.JSON(http.StatusOK, monitorToResponse(rec))
+}
+
+func (a *MonitorAPI) get(e *core.RequestEvent) error {
+	rec, err := a.findMonitor(e, e.Request.PathValue("id"))
+	if err != nil {
+		return err
+	}
+	return e.JSON(http.StatusOK, monitorToResponse(rec))
+}
+
+func (a *MonitorAPI) update(e *core.RequestEvent) error {
+	if e.Auth.GetString("role") == "readonly" {
+		return e.ForbiddenError("readonly users cannot update monitors", nil)
+	}
+	rec, err := a.findMonitor(e, e.Request.PathValue("id"))
+	if err != nil {
+		return err
+	}
+	var in monitorInput
+	if err := e.BindBody(&in); err != nil {
+		return e.BadRequestError("invalid body", err)
+	}
+	// Merge with existing values, then validate the whole.
+	merged := monitorInput{
+		Name:   firstNonEmpty(in.Name, rec.GetString("name")),
+		Type:   firstNonEmpty(in.Type, rec.GetString("type")),
+		Target: firstNonEmpty(strings.TrimSpace(in.Target), rec.GetString("target")),
+	}
+	iv := int(rec.GetFloat("interval"))
+	tv := int(rec.GetFloat("timeout"))
+	mr := int(rec.GetFloat("max_retries"))
+	ra := int(rec.GetFloat("resend_after"))
+	nv := rec.GetBool("notify")
+	merged.Interval, merged.Timeout, merged.MaxRetries = &iv, &tv, &mr
+	merged.ResendAfter, merged.Notify = &ra, &nv
+	if in.Interval != nil {
+		merged.Interval = in.Interval
+	}
+	if in.Timeout != nil {
+		merged.Timeout = in.Timeout
+	}
+	if in.MaxRetries != nil {
+		merged.MaxRetries = in.MaxRetries
+	}
+	if in.Notify != nil {
+		merged.Notify = in.Notify
+	}
+	if in.ResendAfter != nil {
+		merged.ResendAfter = in.ResendAfter
+	}
+	merged.UpsideDown = rec.GetBool("upside_down")
+	if in.UpsideDown {
+		merged.UpsideDown = true
+	}
+	if err := validateInput(&merged); err != nil {
+		return e.BadRequestError(err.Error(), nil)
+	}
+	prevTarget, prevType := rec.GetString("target"), rec.GetString("type")
+	rec.Set("name", merged.Name)
+	rec.Set("type", merged.Type)
+	rec.Set("target", merged.Target)
+	rec.Set("interval", *merged.Interval)
+	rec.Set("timeout", *merged.Timeout)
+	rec.Set("max_retries", *merged.MaxRetries)
+	rec.Set("notify", *merged.Notify)
+	rec.Set("resend_after", *merged.ResendAfter)
+	if in.Paused != rec.GetBool("paused") {
+		rec.Set("paused", in.Paused)
+		rec.Set("status", "paused")
+		rec.Set("consecutive_failures", 0)
+	}
+	if in.Users != nil {
+		rec.Set("users", in.Users)
+	}
+	if in.Config != nil {
+		// PATCH without secrets keeps existing secrets.
+		existing := map[string]any{}
+		_ = rec.UnmarshalJSONField("config", &existing)
+		configChanged := false
+		for k, v := range in.Config {
+			if s, ok := v.(string); ok && s == redactedSecret && secretConfigKeys[strings.ToLower(k)] {
+				continue
+			}
+			existing[k] = v
+			configChanged = true
+		}
+		rec.Set("config", existing)
+		if configChanged || merged.Target != prevTarget || merged.Type != prevType {
+			rec.Set("consecutive_failures", 0)
+		}
+	} else if merged.Target != prevTarget || merged.Type != prevType {
+		rec.Set("consecutive_failures", 0)
+	}
+	if err := a.app.Save(rec); err != nil {
+		return e.BadRequestError("", err)
+	}
+	return e.JSON(http.StatusOK, monitorToResponse(rec))
+}
+
+func firstNonEmpty(v, fallback string) string {
+	if v != "" {
+		return v
+	}
+	return fallback
+}
+
+func (a *MonitorAPI) delete(e *core.RequestEvent) error {
+	if e.Auth.GetString("role") == "readonly" {
+		return e.ForbiddenError("readonly users cannot delete monitors", nil)
+	}
+	rec, err := a.findMonitor(e, e.Request.PathValue("id"))
+	if err != nil {
+		return err
+	}
+	if err := a.app.Delete(rec); err != nil {
+		return e.InternalServerError("", err)
+	}
+	return e.NoContent(http.StatusNoContent)
+}
+
+func (a *MonitorAPI) checks(e *core.RequestEvent) error {
+	rec, err := a.findMonitor(e, e.Request.PathValue("id"))
+	if err != nil {
+		return err
+	}
+	limit := 200
+	if v := e.Request.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = min(n, 1000)
+		}
+	}
+	filter := "monitor = {:mon}"
+	params := dbx.Params{"mon": rec.Id}
+	if rng := e.Request.URL.Query().Get("range"); rng == "24h" || rng == "30d" {
+		hours := 24
+		if rng == "30d" {
+			hours = 30 * 24
+		}
+		filter += " && created >= {:cutoff}"
+		params["cutoff"] = time.Now().UTC().Add(-time.Duration(hours) * time.Hour)
+	}
+	rows, err := a.app.FindAllRecords("monitor_checks", dbx.NewExp(filter, params))
+	if err != nil {
+		return e.InternalServerError("", err)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].GetDateTime("created").After(rows[j].GetDateTime("created"))
+	})
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		details := map[string]any{}
+		_ = r.UnmarshalJSONField("details", &details)
+		out = append(out, map[string]any{
+			"id": r.Id, "status": r.GetString("status"), "latency_ms": r.GetFloat("latency_ms"),
+			"code": r.GetRaw("code"), "message": r.GetString("message"), "details": details,
+			"cert_days": r.GetRaw("cert_days"), "created": r.GetDateTime("created"),
+		})
+	}
+	return e.JSON(http.StatusOK, out)
+}
+
+// allowTest enforces 1 run per 10s per monitor and 10/min per user.
+func (a *MonitorAPI) allowTest(userID, monitorID string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	now := time.Now()
+	keep := func(ts []time.Time, window time.Duration) []time.Time {
+		out := ts[:0]
+		for _, t := range ts {
+			if now.Sub(t) < window {
+				out = append(out, t)
+			}
+		}
+		return out
+	}
+	user := a.testHits["u:"+userID]
+	mon := a.testHits["m:"+monitorID]
+	user = keep(user, time.Minute)
+	mon = keep(mon, 10*time.Second)
+	if len(user) >= 10 || len(mon) >= 1 {
+		a.testHits["u:"+userID] = user
+		a.testHits["m:"+monitorID] = mon
+		return false
+	}
+	a.testHits["u:"+userID] = append(user, now)
+	a.testHits["m:"+monitorID] = append(mon, now)
+	return true
+}
+
+func (a *MonitorAPI) test(e *core.RequestEvent) error {
+	if e.Auth.GetString("role") == "readonly" {
+		return e.ForbiddenError("readonly users cannot test monitors", nil)
+	}
+	rec, err := a.findMonitor(e, e.Request.PathValue("id"))
+	if err != nil {
+		return err
+	}
+	if !a.allowTest(e.Auth.Id, rec.Id) {
+		return e.JSON(429, map[string]any{"error": "rate limited, try again later"})
+	}
+	mr := recordToMonitor(rec)
+	timeout := time.Duration(mr.TimeoutSeconds) * time.Second
+	ctx, cancel := context.WithTimeout(e.Request.Context(), timeout)
+	defer cancel()
+	res := RunCheck(ctx, mr.ToMonitor())
+	out := map[string]any{
+		"status": res.Status, "latency_ms": res.LatencyMs, "message": res.Message,
+		"details": res.Details,
+	}
+	if res.Code != nil {
+		out["code"] = *res.Code
+	}
+	if res.CertDays != nil {
+		out["cert_days"] = *res.CertDays
+	}
+	return e.JSON(http.StatusOK, out)
+}
+
+func (a *MonitorAPI) summary(e *core.RequestEvent) error {
+	recs, err := a.app.FindAllRecords("monitors")
+	if err != nil {
+		return e.InternalServerError("", err)
+	}
+	recs = filterMonitorRecords(recs, e.Auth.Id, "")
+	if err != nil {
+		return e.InternalServerError("", err)
+	}
+	counts := map[string]int{"up": 0, "down": 0, "warn": 0, "paused": 0, "pending": 0}
+	var down []map[string]any
+	for _, rec := range recs {
+		st := rec.GetString("status")
+		if rec.GetBool("paused") {
+			st = "paused"
+		}
+		counts[st]++
+		if st == "down" {
+			down = append(down, map[string]any{"id": rec.Id, "name": rec.GetString("name")})
+		}
+	}
+	if down == nil {
+		down = []map[string]any{}
+	}
+	return e.JSON(http.StatusOK, map[string]any{"counts": counts, "down": down})
+}

--- a/internal/hub/monitors/api_internal_test.go
+++ b/internal/hub/monitors/api_internal_test.go
@@ -1,0 +1,110 @@
+//go:build testing
+
+package monitors
+
+import (
+	"testing"
+
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/require"
+)
+
+func testSortApp(t *testing.T) (*pbtests.TestApp, *core.Record) {
+	t.Helper()
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "sort@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mk := func(name string, paused bool) *core.Record {
+		r := core.NewRecord(col)
+		r.Set("name", name)
+		r.Set("type", "ping")
+		r.Set("target", "example.com")
+		r.Set("interval", 60)
+		r.Set("timeout", 10)
+		r.Set("status", "up")
+		r.Set("users", []string{user.Id})
+		r.Set("paused", paused)
+		require.NoError(t, app.Save(r))
+		return r
+	}
+	_ = mk
+	return app, user
+}
+
+func TestSortMonitorsByName(t *testing.T) {
+	app, user := testSortApp(t)
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	names := []string{"zeta", "alpha", "mid"}
+	for _, n := range names {
+		r := core.NewRecord(col)
+		r.Set("name", n)
+		r.Set("type", "ping")
+		r.Set("target", "example.com")
+		r.Set("interval", 60)
+		r.Set("timeout", 10)
+		r.Set("users", []string{user.Id})
+		require.NoError(t, app.Save(r))
+	}
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	sortMonitorsByName(recs)
+	want := []string{"alpha", "mid", "zeta"}
+	for i, w := range want {
+		if recs[i].GetString("name") != w {
+			t.Fatalf("position %d: got %q, want %q", i, recs[i].GetString("name"), w)
+		}
+	}
+}
+
+func TestFilterMonitorRecords(t *testing.T) {
+	app, user := testSortApp(t)
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mk := func(name string, users []string, paused bool) {
+		r := core.NewRecord(col)
+		r.Set("name", name)
+		r.Set("type", "ping")
+		r.Set("target", "example.com")
+		r.Set("interval", 60)
+		r.Set("timeout", 10)
+		r.Set("users", users)
+		r.Set("paused", paused)
+		require.NoError(t, app.Save(r))
+	}
+	mk("mine", []string{user.Id}, false)
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	other := core.NewRecord(users)
+	other.Set("email", "other@example.com")
+	other.Set("password", "password12345")
+	require.NoError(t, app.Save(other))
+	mk("theirs", []string{other.Id}, false)
+	mk("paused-mine", []string{user.Id}, true)
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	if got := filterMonitorRecords(recs, user.Id, ""); len(got) != 2 {
+		t.Fatalf("expected 2 records for member, got %d", len(got))
+	}
+	got := filterMonitorRecords(recs, user.Id, "true")
+	if len(got) != 1 || got[0].GetString("name") != "paused-mine" {
+		t.Fatalf("paused filter broken: %d records", len(got))
+	}
+	if got := filterMonitorRecords(recs, "nobody", ""); len(got) != 0 {
+		t.Fatalf("expected 0 for stranger, got %d", len(got))
+	}
+}

--- a/internal/hub/monitors/api_test.go
+++ b/internal/hub/monitors/api_test.go
@@ -595,3 +595,46 @@ func TestMonitorAPI_HistoryLimitAndOrder(t *testing.T) {
 	_ = limited
 	limited.Test(t)
 }
+
+func TestMonitorAPI_ListSortedAndBounds(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+	hook := withMonitorRoutes()
+
+	for _, name := range []string{"zeta", "alpha", "mid"} {
+		sc := pbtests.ApiScenario{
+			Name: "create " + name, Method: http.MethodPost, URL: "/api/beszel/monitors",
+			Body:    strings.NewReader(`{"name":"` + name + `","type":"ping","target":"example.com"}`),
+			Headers: auth, ExpectedStatus: 201, ExpectedContent: []string{`"name":"` + name + `"`},
+			TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+		}
+		sc.Test(t)
+	}
+
+	// Task-1 bounds enforced at API level.
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"empty target", `{"name":"e","type":"ping","target":""}`, "Target is required"},
+		{"interval too small", `{"name":"e","type":"ping","target":"example.com","interval":5}`, "Interval must be"},
+		{"interval too big", `{"name":"e","type":"ping","target":"example.com","interval":99999}`, "Interval must be"},
+		{"bad retries", `{"name":"e","type":"ping","target":"example.com","max_retries":11}`, "Max_retries must be"},
+		{"tls url accepted", `{"name":"t","type":"tls","target":"https://example.com:8443/x"}`, `"name":"t"`},
+	} {
+		sc := pbtests.ApiScenario{
+			Name: tc.name, Method: http.MethodPost, URL: "/api/beszel/monitors",
+			Body:    strings.NewReader(tc.body),
+			Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{tc.want},
+			TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+		}
+		if tc.name == "tls url accepted" {
+			sc.ExpectedStatus = 201
+		} else {
+			sc.ExpectedStatus = 400
+		}
+		sc.Test(t)
+	}
+}

--- a/internal/hub/monitors/api_test.go
+++ b/internal/hub/monitors/api_test.go
@@ -1,0 +1,393 @@
+//go:build testing
+
+package monitors_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/henrygd/beszel/internal/hub/monitors"
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/require"
+)
+
+// sharedAPIApp builds one TestApp with a user + token + monitor routes,
+// reused across scenarios via TestAppFactory (repo pattern).
+func sharedAPIApp(t *testing.T) (*pbtests.TestApp, string) {
+	t.Helper()
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "api@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+	token, err := user.NewAuthToken()
+	require.NoError(t, err)
+
+	monitors.RegisterRoutes(app)
+	return app, token
+}
+
+func TestMonitorAPI_CreateValidation(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+
+	scenarios := []pbtests.ApiScenario{
+		{
+			Name:   "create monitor with defaults",
+			Method: http.MethodPost,
+			URL:    "/api/beszel/monitors",
+			Body:   strings.NewReader(`{"name":"web","type":"http","target":"https://example.com"}`),
+			Headers: map[string]string{
+				"Authorization": token,
+				"Content-Type":  "application/json",
+			},
+			ExpectedStatus:        200,
+			ExpectedContent:       []string{`"name":"web"`, `"status":"pending"`, `"interval":60`, `"timeout":10`},
+			TestAppFactory:        factory,
+			DisableTestAppCleanup: true,
+		},
+		{
+			Name:   "reject timeout >= interval",
+			Method: http.MethodPost,
+			URL:    "/api/beszel/monitors",
+			Body:   strings.NewReader(`{"name":"bad","type":"http","target":"https://example.com","interval":60,"timeout":60}`),
+			Headers: map[string]string{
+				"Authorization": token,
+				"Content-Type":  "application/json",
+			},
+			ExpectedStatus:        400,
+			ExpectedContent:       []string{"Timeout"},
+			TestAppFactory:        factory,
+			DisableTestAppCleanup: true,
+		},
+		{
+			Name:   "reject unknown type",
+			Method: http.MethodPost,
+			URL:    "/api/beszel/monitors",
+			Body:   strings.NewReader(`{"name":"bad","type":"gopher","target":"example.com"}`),
+			Headers: map[string]string{
+				"Authorization": token,
+				"Content-Type":  "application/json",
+			},
+			ExpectedStatus:        400,
+			ExpectedContent:       []string{"Unknown monitor type"},
+			TestAppFactory:        factory,
+			DisableTestAppCleanup: true,
+		},
+		{
+			Name:                  "unauthenticated rejected",
+			Method:                http.MethodGet,
+			URL:                   "/api/beszel/monitors",
+			ExpectedStatus:        401,
+			ExpectedContent:       []string{"requires valid"},
+			TestAppFactory:        factory,
+			DisableTestAppCleanup: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		scenario.Test(t)
+	}
+}
+
+func TestMonitorAPI_SecretsRedactedAndKept(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+
+	create := pbtests.ApiScenario{
+		Name:   "create with bearer secret",
+		Method: http.MethodPost,
+		URL:    "/api/beszel/monitors",
+		Body: strings.NewReader(`{"name":"secret","type":"http","target":"https://example.com",` +
+			`"config":{"auth_type":"bearer","token":"s3cr3t-live"}}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`••••••`},
+		NotExpectedContent:    []string{"s3cr3t-live"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+
+	list := pbtests.ApiScenario{
+		Name:                  "list redacts secrets",
+		Method:                http.MethodGet,
+		URL:                   "/api/beszel/monitors",
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`••••••`},
+		NotExpectedContent:    []string{"s3cr3t-live"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	list.Test(t)
+}
+
+func TestMonitorAPI_TestEndpointRateLimited(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+
+	create := pbtests.ApiScenario{
+		Name:                  "create ping monitor",
+		Method:                http.MethodPost,
+		URL:                   "/api/beszel/monitors",
+		Body:                  strings.NewReader(`{"name":"p","type":"ping","target":"192.0.2.1","interval":60,"timeout":10,"config":{"count":1,"packet_timeout":"1s"}}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"name":"p"`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+
+	var id string
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	id = recs[0].Id
+
+	first := pbtests.ApiScenario{
+		Name:                  "first test runs",
+		Method:                http.MethodPost,
+		URL:                   "/api/beszel/monitors/" + id + "/test",
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"status":`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	first.Test(t)
+
+	second := pbtests.ApiScenario{
+		Name:                  "second test rate limited",
+		Method:                http.MethodPost,
+		URL:                   "/api/beszel/monitors/" + id + "/test",
+		Headers:               auth,
+		ExpectedStatus:        429,
+		ExpectedContent:       []string{"rate limited"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	second.Test(t)
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total, "manual tests must not write history")
+}
+
+func TestMonitorAPI_SummaryAndAccess(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+
+	create := pbtests.ApiScenario{
+		Name:                  "create monitor",
+		Method:                http.MethodPost,
+		URL:                   "/api/beszel/monitors",
+		Body:                  strings.NewReader(`{"name":"s","type":"dns","target":"example.com"}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"name":"s"`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+
+	summary := pbtests.ApiScenario{
+		Name:                  "summary counts",
+		Method:                http.MethodGet,
+		URL:                   "/api/beszel/monitors/summary",
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"pending":1`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	summary.Test(t)
+
+	// Second user must not see the first user's monitor.
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	other := core.NewRecord(users)
+	other.Set("email", "other@example.com")
+	other.Set("password", "password12345")
+	require.NoError(t, app.Save(other))
+	otherToken, err := other.NewAuthToken()
+	require.NoError(t, err)
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+
+	denied := pbtests.ApiScenario{
+		Name:   "non-member cannot view",
+		Method: http.MethodGet,
+		URL:    "/api/beszel/monitors/" + recs[0].Id,
+		Headers: map[string]string{
+			"Authorization": otherToken,
+		},
+		ExpectedStatus:        404,
+		ExpectedContent:       []string{"Monitor not found"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	denied.Test(t)
+
+	empty := pbtests.ApiScenario{
+		Name:   "empty history",
+		Method: http.MethodGet,
+		URL:    "/api/beszel/monitors/" + recs[0].Id + "/checks",
+		Headers: map[string]string{
+			"Authorization": token,
+		},
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`[]`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	empty.Test(t)
+}
+
+func TestMonitorAPI_UpdateAndDelete(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+
+	create := pbtests.ApiScenario{
+		Name:   "create with secret",
+		Method: http.MethodPost,
+		URL:    "/api/beszel/monitors",
+		Body: strings.NewReader(`{"name":"u","type":"http","target":"https://example.com",` +
+			`"config":{"auth_type":"basic","username":"u","password":"pw-live"}}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`••••••`},
+		NotExpectedContent:    []string{"pw-live"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	id := recs[0].Id
+
+	patch := pbtests.ApiScenario{
+		Name:                  "patch keeps secret when redacted",
+		Method:                http.MethodPatch,
+		URL:                   "/api/beszel/monitors/" + id,
+		Body:                  strings.NewReader(`{"name":"u2","config":{"auth_type":"basic","username":"u","password":"••••••"}}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"name":"u2"`, `••••••`},
+		NotExpectedContent:    []string{"pw-live"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	patch.Test(t)
+
+	stored, err := app.FindRecordById("monitors", id)
+	require.NoError(t, err)
+	cfg := map[string]any{}
+	require.NoError(t, stored.UnmarshalJSONField("config", &cfg))
+	require.Equal(t, "pw-live", cfg["password"], "redacted password must keep stored secret")
+
+	badPatch := pbtests.ApiScenario{
+		Name:                  "patch rejects timeout >= interval",
+		Method:                http.MethodPatch,
+		URL:                   "/api/beszel/monitors/" + id,
+		Body:                  strings.NewReader(`{"timeout":3600,"interval":60}`),
+		Headers:               auth,
+		ExpectedStatus:        400,
+		ExpectedContent:       []string{"Timeout"},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	badPatch.Test(t)
+
+	del := pbtests.ApiScenario{
+		Name:                  "delete monitor",
+		Method:                http.MethodDelete,
+		URL:                   "/api/beszel/monitors/" + id,
+		Headers:               auth,
+		ExpectedStatus:        204,
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	del.Test(t)
+
+	total, err := app.CountRecords("monitors")
+	require.NoError(t, err)
+	require.EqualValues(t, 0, total)
+}
+
+func TestMonitorAPI_PatchTargetResetsFailures(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+
+	create := pbtests.ApiScenario{
+		Name:                  "create monitor",
+		Method:                http.MethodPost,
+		URL:                   "/api/beszel/monitors",
+		Body:                  strings.NewReader(`{"name":"r","type":"http","target":"https://example.com"}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"name":"r"`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	id := recs[0].Id
+
+	recs[0].Set("consecutive_failures", 2)
+	require.NoError(t, app.SaveNoValidate(recs[0]))
+
+	sameTarget := pbtests.ApiScenario{
+		Name:                  "patch name only keeps failures",
+		Method:                http.MethodPatch,
+		URL:                   "/api/beszel/monitors/" + id,
+		Body:                  strings.NewReader(`{"name":"r2"}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`"name":"r2"`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	sameTarget.Test(t)
+	stored, err := app.FindRecordById("monitors", id)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, stored.GetFloat("consecutive_failures"))
+
+	newTarget := pbtests.ApiScenario{
+		Name:                  "patch target resets failures",
+		Method:                http.MethodPatch,
+		URL:                   "/api/beszel/monitors/" + id,
+		Body:                  strings.NewReader(`{"target":"https://example.org"}`),
+		Headers:               auth,
+		ExpectedStatus:        200,
+		ExpectedContent:       []string{`example.org`},
+		TestAppFactory:        factory,
+		DisableTestAppCleanup: true,
+	}
+	newTarget.Test(t)
+	stored, err = app.FindRecordById("monitors", id)
+	require.NoError(t, err)
+	require.EqualValues(t, 0, stored.GetFloat("consecutive_failures"))
+}

--- a/internal/hub/monitors/api_test.go
+++ b/internal/hub/monitors/api_test.go
@@ -17,6 +17,13 @@ import (
 
 // sharedAPIApp builds one TestApp with a user + token + monitor routes,
 // reused across scenarios via TestAppFactory (repo pattern).
+// withMonitorRoutes registers the monitors API on the scenario's serve event.
+func withMonitorRoutes() func(testing.TB, *pbtests.TestApp, *core.ServeEvent) {
+	return func(_ testing.TB, _ *pbtests.TestApp, e *core.ServeEvent) {
+		monitors.RegisterRoutes(e)
+	}
+}
+
 func sharedAPIApp(t *testing.T) (*pbtests.TestApp, string) {
 	t.Helper()
 	app, err := pbtests.NewTestApp(t.TempDir())
@@ -32,7 +39,6 @@ func sharedAPIApp(t *testing.T) (*pbtests.TestApp, string) {
 	token, err := user.NewAuthToken()
 	require.NoError(t, err)
 
-	monitors.RegisterRoutes(app)
 	return app, token
 }
 
@@ -50,10 +56,11 @@ func TestMonitorAPI_CreateValidation(t *testing.T) {
 				"Authorization": token,
 				"Content-Type":  "application/json",
 			},
-			ExpectedStatus:        200,
+			ExpectedStatus:        201,
 			ExpectedContent:       []string{`"name":"web"`, `"status":"pending"`, `"interval":60`, `"timeout":10`},
 			TestAppFactory:        factory,
 			DisableTestAppCleanup: true,
+			BeforeTestFunc:        withMonitorRoutes(),
 		},
 		{
 			Name:   "reject timeout >= interval",
@@ -68,6 +75,7 @@ func TestMonitorAPI_CreateValidation(t *testing.T) {
 			ExpectedContent:       []string{"Timeout"},
 			TestAppFactory:        factory,
 			DisableTestAppCleanup: true,
+			BeforeTestFunc:        withMonitorRoutes(),
 		},
 		{
 			Name:   "reject unknown type",
@@ -82,6 +90,7 @@ func TestMonitorAPI_CreateValidation(t *testing.T) {
 			ExpectedContent:       []string{"Unknown monitor type"},
 			TestAppFactory:        factory,
 			DisableTestAppCleanup: true,
+			BeforeTestFunc:        withMonitorRoutes(),
 		},
 		{
 			Name:                  "unauthenticated rejected",
@@ -91,6 +100,7 @@ func TestMonitorAPI_CreateValidation(t *testing.T) {
 			ExpectedContent:       []string{"requires valid"},
 			TestAppFactory:        factory,
 			DisableTestAppCleanup: true,
+			BeforeTestFunc:        withMonitorRoutes(),
 		},
 	}
 
@@ -111,11 +121,12 @@ func TestMonitorAPI_SecretsRedactedAndKept(t *testing.T) {
 		Body: strings.NewReader(`{"name":"secret","type":"http","target":"https://example.com",` +
 			`"config":{"auth_type":"bearer","token":"s3cr3t-live"}}`),
 		Headers:               auth,
-		ExpectedStatus:        200,
+		ExpectedStatus:        201,
 		ExpectedContent:       []string{`••••••`},
 		NotExpectedContent:    []string{"s3cr3t-live"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	create.Test(t)
 
@@ -129,6 +140,7 @@ func TestMonitorAPI_SecretsRedactedAndKept(t *testing.T) {
 		NotExpectedContent:    []string{"s3cr3t-live"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	list.Test(t)
 }
@@ -144,10 +156,11 @@ func TestMonitorAPI_TestEndpointRateLimited(t *testing.T) {
 		URL:                   "/api/beszel/monitors",
 		Body:                  strings.NewReader(`{"name":"p","type":"ping","target":"192.0.2.1","interval":60,"timeout":10,"config":{"count":1,"packet_timeout":"1s"}}`),
 		Headers:               auth,
-		ExpectedStatus:        200,
+		ExpectedStatus:        201,
 		ExpectedContent:       []string{`"name":"p"`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	create.Test(t)
 
@@ -166,6 +179,7 @@ func TestMonitorAPI_TestEndpointRateLimited(t *testing.T) {
 		ExpectedContent:       []string{`"status":`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	first.Test(t)
 
@@ -178,6 +192,7 @@ func TestMonitorAPI_TestEndpointRateLimited(t *testing.T) {
 		ExpectedContent:       []string{"rate limited"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	second.Test(t)
 
@@ -197,10 +212,11 @@ func TestMonitorAPI_SummaryAndAccess(t *testing.T) {
 		URL:                   "/api/beszel/monitors",
 		Body:                  strings.NewReader(`{"name":"s","type":"dns","target":"example.com"}`),
 		Headers:               auth,
-		ExpectedStatus:        200,
+		ExpectedStatus:        201,
 		ExpectedContent:       []string{`"name":"s"`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	create.Test(t)
 
@@ -213,6 +229,7 @@ func TestMonitorAPI_SummaryAndAccess(t *testing.T) {
 		ExpectedContent:       []string{`"pending":1`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	summary.Test(t)
 
@@ -241,6 +258,7 @@ func TestMonitorAPI_SummaryAndAccess(t *testing.T) {
 		ExpectedContent:       []string{"Monitor not found"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	denied.Test(t)
 
@@ -255,6 +273,7 @@ func TestMonitorAPI_SummaryAndAccess(t *testing.T) {
 		ExpectedContent:       []string{`[]`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	empty.Test(t)
 }
@@ -271,11 +290,12 @@ func TestMonitorAPI_UpdateAndDelete(t *testing.T) {
 		Body: strings.NewReader(`{"name":"u","type":"http","target":"https://example.com",` +
 			`"config":{"auth_type":"basic","username":"u","password":"pw-live"}}`),
 		Headers:               auth,
-		ExpectedStatus:        200,
+		ExpectedStatus:        201,
 		ExpectedContent:       []string{`••••••`},
 		NotExpectedContent:    []string{"pw-live"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	create.Test(t)
 
@@ -295,6 +315,7 @@ func TestMonitorAPI_UpdateAndDelete(t *testing.T) {
 		NotExpectedContent:    []string{"pw-live"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	patch.Test(t)
 
@@ -314,6 +335,7 @@ func TestMonitorAPI_UpdateAndDelete(t *testing.T) {
 		ExpectedContent:       []string{"Timeout"},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	badPatch.Test(t)
 
@@ -325,6 +347,7 @@ func TestMonitorAPI_UpdateAndDelete(t *testing.T) {
 		ExpectedStatus:        204,
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	del.Test(t)
 
@@ -344,10 +367,11 @@ func TestMonitorAPI_PatchTargetResetsFailures(t *testing.T) {
 		URL:                   "/api/beszel/monitors",
 		Body:                  strings.NewReader(`{"name":"r","type":"http","target":"https://example.com"}`),
 		Headers:               auth,
-		ExpectedStatus:        200,
+		ExpectedStatus:        201,
 		ExpectedContent:       []string{`"name":"r"`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	create.Test(t)
 
@@ -369,6 +393,7 @@ func TestMonitorAPI_PatchTargetResetsFailures(t *testing.T) {
 		ExpectedContent:       []string{`"name":"r2"`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	sameTarget.Test(t)
 	stored, err := app.FindRecordById("monitors", id)
@@ -385,9 +410,188 @@ func TestMonitorAPI_PatchTargetResetsFailures(t *testing.T) {
 		ExpectedContent:       []string{`example.org`},
 		TestAppFactory:        factory,
 		DisableTestAppCleanup: true,
+		BeforeTestFunc:        withMonitorRoutes(),
 	}
 	newTarget.Test(t)
 	stored, err = app.FindRecordById("monitors", id)
 	require.NoError(t, err)
 	require.EqualValues(t, 0, stored.GetFloat("consecutive_failures"))
+}
+
+func TestMonitorAPI_ReadonlyBlocked(t *testing.T) {
+	app, _ := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	ro := core.NewRecord(users)
+	ro.Set("email", "ro@example.com")
+	ro.Set("password", "password12345")
+	ro.Set("role", "readonly")
+	require.NoError(t, app.Save(ro))
+	roToken, err := ro.NewAuthToken()
+	require.NoError(t, err)
+	auth := map[string]string{"Authorization": roToken, "Content-Type": "application/json"}
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		url    string
+		body   string
+	}{
+		{"post", http.MethodPost, "/api/beszel/monitors", `{"name":"x","type":"ping","target":"example.com"}`},
+		{"patch", http.MethodPatch, "/api/beszel/monitors/nonexistent", `{"name":"x"}`},
+		{"delete", http.MethodDelete, "/api/beszel/monitors/nonexistent", ``},
+	} {
+		sc := pbtests.ApiScenario{
+			Name:                  "readonly " + tc.name + " forbidden",
+			Method:                tc.method,
+			URL:                   tc.url,
+			Headers:               auth,
+			ExpectedStatus:        403,
+			ExpectedContent:       []string{"Readonly"},
+			TestAppFactory:        factory,
+			BeforeTestFunc:        withMonitorRoutes(),
+			DisableTestAppCleanup: true,
+		}
+		if tc.body != "" {
+			sc.Body = strings.NewReader(tc.body)
+		}
+		sc.Test(t)
+	}
+}
+
+func TestMonitorAPI_PausedToggleAndUpsideDown(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+	hook := withMonitorRoutes()
+
+	create := pbtests.ApiScenario{
+		Name: "create", Method: http.MethodPost, URL: "/api/beszel/monitors",
+		Body:    strings.NewReader(`{"name":"t","type":"ping","target":"example.com"}`),
+		Headers: auth, ExpectedStatus: 201, ExpectedContent: []string{`"name":"t"`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	create.Test(t)
+	recs, err := app.FindAllRecords("monitors")
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+	id := recs[0].Id
+
+	pause := pbtests.ApiScenario{
+		Name: "pause", Method: http.MethodPatch, URL: "/api/beszel/monitors/" + id,
+		Body:    strings.NewReader(`{"paused":true}`),
+		Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{`"status":"paused"`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	pause.Test(t)
+
+	unpauseOmitted := pbtests.ApiScenario{
+		Name: "patch without paused keeps pause", Method: http.MethodPatch, URL: "/api/beszel/monitors/" + id,
+		Body:    strings.NewReader(`{"name":"t2"}`),
+		Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{`"status":"paused"`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	unpauseOmitted.Test(t)
+
+	unpause := pbtests.ApiScenario{
+		Name: "unpause returns to pending", Method: http.MethodPatch, URL: "/api/beszel/monitors/" + id,
+		Body:    strings.NewReader(`{"paused":false}`),
+		Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{`"status":"pending"`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	unpause.Test(t)
+
+	setUD := pbtests.ApiScenario{
+		Name: "set upside_down", Method: http.MethodPatch, URL: "/api/beszel/monitors/" + id,
+		Body:    strings.NewReader(`{"upside_down":true}`),
+		Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{`"upside_down":true`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	setUD.Test(t)
+
+	clearUD := pbtests.ApiScenario{
+		Name: "clear upside_down", Method: http.MethodPatch, URL: "/api/beszel/monitors/" + id,
+		Body:    strings.NewReader(`{"upside_down":false}`),
+		Headers: auth, ExpectedStatus: 200, ExpectedContent: []string{`"upside_down":false`},
+		TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	clearUD.Test(t)
+}
+
+func TestMonitorAPI_PerTypeValidation(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token, "Content-Type": "application/json"}
+	hook := withMonitorRoutes()
+
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"http without scheme", `{"name":"a","type":"http","target":"example.com"}`, "Invalid http target"},
+		{"http gopher scheme", `{"name":"a","type":"http","target":"gopher://example.com"}`, "Invalid http target"},
+		{"http bad method", `{"name":"a","type":"http","target":"https://example.com","config":{"method":"BREW"}}`, "Invalid method"},
+		{"tls bare port text", `{"name":"a","type":"tls","target":"example.com:notaport"}`, "Invalid tls target"},
+		{"dns bad qtype", `{"name":"a","type":"dns","target":"example.com","config":{"qtype":"SMOKE"}}`, "Invalid qtype"},
+		{"dns bad protocol", `{"name":"a","type":"dns","target":"example.com","config":{"protocol":"quic"}}`, "Invalid protocol"},
+		{"dns hostname resolver", `{"name":"a","type":"dns","target":"example.com","config":{"resolver":"dns.example.com"}}`, "must be an IP"},
+		{"resend_after too big", `{"name":"a","type":"ping","target":"example.com","resend_after":2000}`, "Resend_after"},
+	}
+	for _, tc := range cases {
+		sc := pbtests.ApiScenario{
+			Name: tc.name, Method: http.MethodPost, URL: "/api/beszel/monitors",
+			Body:    strings.NewReader(tc.body),
+			Headers: auth, ExpectedStatus: 400, ExpectedContent: []string{tc.want},
+			TestAppFactory: factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+		}
+		sc.Test(t)
+	}
+}
+
+func TestMonitorAPI_HistoryLimitAndOrder(t *testing.T) {
+	app, token := sharedAPIApp(t)
+	factory := func(testing.TB) *pbtests.TestApp { return app }
+	auth := map[string]string{"Authorization": token}
+	hook := withMonitorRoutes()
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	u, err := app.FindAuthRecordByEmail("users", "api@example.com")
+	require.NoError(t, err)
+	_ = users
+	mon := core.NewRecord(col)
+	mon.Set("name", "h")
+	mon.Set("type", "ping")
+	mon.Set("target", "example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("status", "up")
+	mon.Set("users", []string{u.Id})
+	require.NoError(t, app.Save(mon))
+
+	checksCol, err := app.FindCachedCollectionByNameOrId("monitor_checks")
+	require.NoError(t, err)
+	for i := 0; i < 5; i++ {
+		c := core.NewRecord(checksCol)
+		c.Set("monitor", mon.Id)
+		c.Set("status", "up")
+		c.Set("latency_ms", float64(i))
+		require.NoError(t, app.Save(c))
+	}
+
+	limited := pbtests.ApiScenario{
+		Name: "history limit 2", Method: http.MethodGet,
+		URL:     "/api/beszel/monitors/" + mon.Id + "/checks?limit=2",
+		Headers: auth, ExpectedStatus: 200,
+		ExpectedContent:    []string{`"latency_ms":4`, `"latency_ms":3`},
+		NotExpectedContent: []string{`"latency_ms":0`},
+		TestAppFactory:     factory, BeforeTestFunc: hook, DisableTestAppCleanup: true,
+	}
+	_ = limited
+	limited.Test(t)
 }

--- a/internal/hub/monitors/checker_dns.go
+++ b/internal/hub/monitors/checker_dns.go
@@ -1,0 +1,256 @@
+package monitors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Defaults and bounds for the DNS checker (spec §6.3).
+const (
+	defaultDNSQType        = "A"
+	defaultDNSProtocol     = "udp"
+	defaultDNSQueryTimeout = 5 // seconds
+	maxDNSAnswers          = 5
+)
+
+// dnsResolvConfPath is a test-only seam for the system-resolver lookup
+// (default /etc/resolv.conf). Tests point it at a missing file to simulate
+// an unreadable resolver config without touching the host.
+var dnsResolvConfPath = "/etc/resolv.conf"
+
+// allowedDNSQTypes is the supported qtype enum (spec §6.3). It mirrors the
+// miekg/dns type constants instead of dns.StringToType so that only the
+// spec'd qtypes are accepted.
+var allowedDNSQTypes = map[string]uint16{
+	"A":     dns.TypeA,
+	"AAAA":  dns.TypeAAAA,
+	"CNAME": dns.TypeCNAME,
+	"MX":    dns.TypeMX,
+	"TXT":   dns.TypeTXT,
+	"NS":    dns.TypeNS,
+	"SOA":   dns.TypeSOA,
+	"SRV":   dns.TypeSRV,
+	"CAA":   dns.TypeCAA,
+	"PTR":   dns.TypePTR,
+}
+
+// CheckDNS performs a DNS uptime check from the hub: it sends a single query
+// for m.Target with the configured qtype to a custom resolver (IP or
+// IP:port) or, when resolver is empty, to the first nameserver listed in the
+// system resolv.conf (via dns.ClientConfigFromFile). It never applies
+// upside_down: Task 7 applies that inversion. Only stdlib + miekg/dns are
+// used.
+func CheckDNS(ctx context.Context, m Monitor) CheckResult {
+	details := map[string]any{}
+	down := func(msg string) CheckResult {
+		return CheckResult{Status: StatusDown, Message: msg, Details: details}
+	}
+
+	target := strings.TrimSpace(m.Target)
+	if target == "" {
+		return down("dns: target is required")
+	}
+
+	qtypeName := strings.ToUpper(strings.TrimSpace(configString(m.Config["qtype"], defaultDNSQType)))
+	qtype, ok := allowedDNSQTypes[qtypeName]
+	if !ok {
+		return down(fmt.Sprintf("dns: invalid qtype %q: must be A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, CAA or PTR", configString(m.Config["qtype"], "")))
+	}
+
+	protocol := strings.ToLower(strings.TrimSpace(configString(m.Config["protocol"], defaultDNSProtocol)))
+	if protocol != "udp" && protocol != "tcp" {
+		return down(fmt.Sprintf("dns: invalid protocol %q: must be udp or tcp", configString(m.Config["protocol"], "")))
+	}
+
+	var qname string
+	if qtype == dns.TypePTR {
+		ip := net.ParseIP(target)
+		if ip == nil {
+			return down(fmt.Sprintf("dns: PTR target must be an IP address, got %q", target))
+		}
+		arpa, err := dns.ReverseAddr(ip.String())
+		if err != nil {
+			return down(fmt.Sprintf("dns: PTR target must be an IP address, got %q", target))
+		}
+		qname = arpa
+	} else {
+		qname = dns.Fqdn(target)
+	}
+
+	expected := strings.TrimSpace(configString(m.Config["expected_answer"], ""))
+	matchMode := strings.ToLower(strings.TrimSpace(configString(m.Config["match_mode"], "contains")))
+	if expected != "" && matchMode != "contains" && matchMode != "exact" {
+		return down(fmt.Sprintf("dns: invalid match_mode %q: must be contains or exact", configString(m.Config["match_mode"], "")))
+	}
+
+	timeout := time.Duration(m.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+	queryTimeout := time.Duration(configInt(m.Config["query_timeout"], defaultDNSQueryTimeout)) * time.Second
+	if queryTimeout <= 0 {
+		queryTimeout = time.Duration(defaultDNSQueryTimeout) * time.Second
+	}
+	if queryTimeout > timeout {
+		queryTimeout = timeout
+	}
+
+	resolverCfg := strings.TrimSpace(configString(m.Config["resolver"], ""))
+	server := ""
+	resolverLabel := "system"
+	if resolverCfg == "" {
+		cc, err := dns.ClientConfigFromFile(dnsResolvConfPath)
+		if err != nil {
+			return down(fmt.Sprintf("dns: cannot read system resolver config: %v", err))
+		}
+		if len(cc.Servers) == 0 {
+			return down("dns: cannot read system resolver config: no nameservers")
+		}
+		if net.ParseIP(cc.Servers[0]) == nil {
+			return down(fmt.Sprintf("dns: cannot use system resolver %q: not an IP address", cc.Servers[0]))
+		}
+		port := strings.TrimSpace(cc.Port)
+		if port == "" {
+			port = "53"
+		}
+		server = net.JoinHostPort(cc.Servers[0], port)
+	} else {
+		host, port, err := ParsePortOrDefault(resolverCfg, 53)
+		if err != nil {
+			return down(fmt.Sprintf("dns: invalid resolver %q: %v", resolverCfg, err))
+		}
+		rip := net.ParseIP(host)
+		if rip == nil {
+			return down(fmt.Sprintf("dns: invalid resolver %q: must be an IP or IP:port", resolverCfg))
+		}
+		if os.Getenv(allowPrivateNetworkEnv) != "true" && IsPrivateIP(rip) {
+			return down(fmt.Sprintf("dns: resolver is private network %s (set %s=true to allow)", rip.String(), allowPrivateNetworkEnv))
+		}
+		server = net.JoinHostPort(rip.String(), strconv.Itoa(port))
+		resolverLabel = server
+	}
+	details["qtype"] = qtypeName
+	details["resolver"] = resolverLabel
+
+	req := new(dns.Msg)
+	req.SetQuestion(qname, qtype)
+
+	client := new(dns.Client)
+	client.Net = protocol
+	client.Timeout = queryTimeout
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	resp, rtt, err := client.ExchangeContext(reqCtx, req, server)
+	latencyMs := float64(rtt) / float64(time.Millisecond)
+	if err != nil {
+		var nerr net.Error
+		if errors.As(err, &nerr) && nerr.Timeout() {
+			return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Message: "dns: query timed out", Details: details}
+		}
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Message: fmt.Sprintf("dns: query failed: %v", err), Details: details}
+	}
+	if resp == nil {
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Message: "dns: query failed: empty response", Details: details}
+	}
+
+	rcode := resp.Rcode
+	if rcode != dns.RcodeSuccess {
+		var msg string
+		switch rcode {
+		case dns.RcodeNameError:
+			msg = "dns: NXDOMAIN"
+		case dns.RcodeServerFailure:
+			msg = fmt.Sprintf("dns: SERVFAIL (rcode %d)", rcode)
+		default:
+			name := dns.RcodeToString[rcode]
+			if name == "" {
+				name = "ERROR"
+			}
+			msg = fmt.Sprintf("dns: %s (rcode %d)", name, rcode)
+		}
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(rcode), Message: msg, Details: details}
+	}
+
+	answers := dnsAnswerStrings(resp)
+	details["answers"] = answers
+	if len(answers) == 0 {
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(rcode), Message: "dns: no records", Details: details}
+	}
+	if expected != "" && !dnsMatchAnswer(matchMode, expected, answers) {
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(rcode), Message: fmt.Sprintf("dns: expected answer not found (got: [%s])", strings.Join(answers, ", ")), Details: details}
+	}
+	return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(rcode), Message: fmt.Sprintf("dns: NOERROR with %d answer(s)", len(answers)), Details: details}
+}
+
+// dnsAnswerStrings renders the answer section of a DNS response as short
+// strings (A/AAAA → IP, CNAME/NS/PTR → target, MX → "pref exchange", TXT →
+// concatenated strings, SOA → "ns mbox serial", SRV → "prio weight port
+// target", CAA → "flag tag value"), truncated to maxDNSAnswers entries.
+func dnsAnswerStrings(r *dns.Msg) []string {
+	if r == nil {
+		return nil
+	}
+	out := make([]string, 0, len(r.Answer))
+	for _, rr := range r.Answer {
+		switch v := rr.(type) {
+		case *dns.A:
+			out = append(out, v.A.String())
+		case *dns.AAAA:
+			out = append(out, v.AAAA.String())
+		case *dns.CNAME:
+			out = append(out, v.Target)
+		case *dns.NS:
+			out = append(out, v.Ns)
+		case *dns.PTR:
+			out = append(out, v.Ptr)
+		case *dns.MX:
+			out = append(out, fmt.Sprintf("%d %s", v.Preference, v.Mx))
+		case *dns.TXT:
+			out = append(out, strings.Join(v.Txt, ""))
+		case *dns.SOA:
+			out = append(out, fmt.Sprintf("%s %s %d", v.Ns, v.Mbox, v.Serial))
+		case *dns.SRV:
+			out = append(out, fmt.Sprintf("%d %d %d %s", v.Priority, v.Weight, v.Port, v.Target))
+		case *dns.CAA:
+			out = append(out, fmt.Sprintf("%d %s %s", v.Flag, v.Tag, v.Value))
+		default:
+			out = append(out, rr.String())
+		}
+		if len(out) >= maxDNSAnswers {
+			break
+		}
+	}
+	return out
+}
+
+// dnsMatchAnswer reports whether expected matches any answer. Matching is
+// case-insensitive with trailing dots ignored; "exact" requires full
+// equality after normalization, anything else behaves as "contains".
+func dnsMatchAnswer(mode, expected string, answers []string) bool {
+	normalize := func(s string) string {
+		return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(s)), ".")
+	}
+	want := normalize(expected)
+	for _, a := range answers {
+		got := normalize(a)
+		if mode == "exact" {
+			if got == want {
+				return true
+			}
+			continue
+		}
+		if strings.Contains(got, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/hub/monitors/checker_dns_test.go
+++ b/internal/hub/monitors/checker_dns_test.go
@@ -1,0 +1,403 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func dnsTestMonitor(target string) Monitor {
+	return Monitor{
+		Name:            "dns-test",
+		Type:            TypeDNS,
+		Target:          target,
+		IntervalSeconds: 60,
+		TimeoutSeconds:  5,
+		Config:          map[string]any{},
+	}
+}
+
+func dnsTestCtx() context.Context {
+	return context.Background()
+}
+
+// startDNSTestServer runs a fake DNS server on loopback (UDP or TCP) and
+// returns its address. It enables the private-network override so the
+// loopback resolver is accepted by the SSRF guard.
+func startDNSTestServer(t *testing.T, network string, handle dns.HandlerFunc) string {
+	t.Helper()
+	allowPrivateNet(t)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", handle)
+	srv := &dns.Server{Net: network, Handler: mux}
+	var addr string
+	switch network {
+	case "tcp":
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen tcp: %v", err)
+		}
+		srv.Listener = ln
+		addr = ln.Addr().String()
+	default:
+		pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen udp: %v", err)
+		}
+		srv.PacketConn = pc
+		addr = pc.LocalAddr().String()
+	}
+	go func() {
+		_ = srv.ActivateAndServe()
+	}()
+	t.Cleanup(func() {
+		_ = srv.Shutdown()
+	})
+	// Give the server a moment to start accepting.
+	time.Sleep(50 * time.Millisecond)
+	return addr
+}
+
+func dnsAResponder(ip string) dns.HandlerFunc {
+	return func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   net.ParseIP(ip),
+			},
+		}
+		_ = w.WriteMsg(m)
+	}
+}
+
+func TestDNSNoErrorMatch(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", dnsAResponder("93.184.216.34"))
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	m.Config["expected_answer"] = "93.184.216.34"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Code == nil || *res.Code != 0 {
+		t.Fatalf("expected rcode 0, got %+v", res.Code)
+	}
+	if len(res.Details["answers"].([]string)) != 1 {
+		t.Fatalf("expected 1 answer, got %v", res.Details["answers"])
+	}
+	if res.Details["qtype"] != "A" {
+		t.Fatalf("expected qtype A, got %v", res.Details["qtype"])
+	}
+	if res.Details["resolver"] != addr {
+		t.Fatalf("expected resolver %q, got %v", addr, res.Details["resolver"])
+	}
+}
+
+func TestDNSTrailingDotTarget(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", dnsAResponder("93.184.216.34"))
+	m := dnsTestMonitor("example.com.")
+	m.Config["resolver"] = addr
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestDNSMismatch(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", dnsAResponder("93.184.216.34"))
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	m.Config["expected_answer"] = "1.2.3.4"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.HasPrefix(res.Message, "dns: expected answer not found (got: ") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestDNSNXDOMAIN(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeNameError)
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("nonexistent.example.com")
+	m.Config["resolver"] = addr
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Message != "dns: NXDOMAIN" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+	if res.Code == nil || *res.Code != 3 {
+		t.Fatalf("expected rcode 3, got %+v", res.Code)
+	}
+}
+
+func TestDNSServfail(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeServerFailure)
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Message != "dns: SERVFAIL (rcode 2)" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+	if res.Code == nil || *res.Code != 2 {
+		t.Fatalf("expected rcode 2, got %+v", res.Code)
+	}
+}
+
+func TestDNSNoRecords(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r) // NOERROR, empty answer section
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Message != "dns: no records" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestDNSQueryTimeout(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		time.Sleep(3 * time.Second)
+		m := new(dns.Msg)
+		m.SetReply(r)
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	m.Config["query_timeout"] = 1
+	m.TimeoutSeconds = 10
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Message != "dns: query timed out" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestDNSTCP(t *testing.T) {
+	addr := startDNSTestServer(t, "tcp", dnsAResponder("93.184.216.34"))
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	m.Config["protocol"] = "tcp"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestDNSTXTContains(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = []dns.RR{
+			&dns.TXT{
+				Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 300},
+				Txt: []string{"v=spf1 include:_spf.example.com ~all"},
+			},
+		}
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = addr
+	m.Config["qtype"] = "TXT"
+	m.Config["expected_answer"] = "spf1"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestDNSPTRLookup(t *testing.T) {
+	addr := startDNSTestServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = []dns.RR{
+			&dns.PTR{
+				Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypePTR, Class: dns.ClassINET, Ttl: 300},
+				Ptr: "host.example.com.",
+			},
+		}
+		_ = w.WriteMsg(m)
+	})
+	m := dnsTestMonitor("8.8.8.8")
+	m.Config["resolver"] = addr
+	m.Config["qtype"] = "PTR"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestDNSValidation(t *testing.T) {
+	allowPrivateNet(t)
+	cases := []struct {
+		name   string
+		mon    func() Monitor
+		prefix string
+	}{
+		{"empty target", func() Monitor { return dnsTestMonitor("") }, "dns: target is required"},
+		{"unknown qtype", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["qtype"] = "NOPE"
+			return m
+		}, "dns: invalid qtype"},
+		{"resolver hostname", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["resolver"] = "dns.google"
+			return m
+		}, "dns: invalid resolver"},
+		{"resolver bad port", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["resolver"] = "8.8.8.8:99999"
+			return m
+		}, "dns: invalid resolver"},
+		{"PTR non-IP target", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["qtype"] = "PTR"
+			return m
+		}, "dns: PTR target must be an IP"},
+		{"bad protocol", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["protocol"] = "icmp"
+			return m
+		}, "dns: invalid protocol"},
+		{"bad match mode", func() Monitor {
+			m := dnsTestMonitor("example.com")
+			m.Config["expected_answer"] = "x"
+			m.Config["match_mode"] = "fuzzy"
+			return m
+		}, "dns: invalid match_mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := CheckDNS(dnsTestCtx(), tc.mon())
+			if res.Status != StatusDown {
+				t.Fatalf("expected down, got %q", res.Status)
+			}
+			if !strings.HasPrefix(res.Message, tc.prefix) {
+				t.Fatalf("expected message prefix %q, got %q", tc.prefix, res.Message)
+			}
+		})
+	}
+}
+
+func TestDNSPrivateResolverBlocked(t *testing.T) {
+	// No override: private resolver IPs must be rejected.
+	m := dnsTestMonitor("example.com")
+	m.Config["resolver"] = "10.0.0.1"
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.HasPrefix(res.Message, "dns: resolver is private network") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestDNSSystemResolverUnreadable(t *testing.T) {
+	old := dnsResolvConfPath
+	dnsResolvConfPath = "/nonexistent/resolv.conf"
+	t.Cleanup(func() { dnsResolvConfPath = old })
+	m := dnsTestMonitor("example.com")
+	res := CheckDNS(dnsTestCtx(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.HasPrefix(res.Message, "dns: cannot read system resolver config") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestDnsAnswerStrings(t *testing.T) {
+	qname := "example.com."
+	hdr := func(t uint16) dns.RR_Header {
+		return dns.RR_Header{Name: qname, Rrtype: t, Class: dns.ClassINET, Ttl: 300}
+	}
+	cases := []struct {
+		name string
+		rr   dns.RR
+		want []string
+	}{
+		{"A", &dns.A{Hdr: hdr(dns.TypeA), A: net.ParseIP("93.184.216.34")}, []string{"93.184.216.34"}},
+		{"AAAA", &dns.AAAA{Hdr: hdr(dns.TypeAAAA), AAAA: net.ParseIP("2606:2800:220:1:248:1893:25c8:1946")}, []string{"2606:2800:220:1:248:1893:25c8:1946"}},
+		{"CNAME", &dns.CNAME{Hdr: hdr(dns.TypeCNAME), Target: "alias.example.com."}, []string{"alias.example.com."}},
+		{"MX", &dns.MX{Hdr: hdr(dns.TypeMX), Preference: 10, Mx: "mail.example.com."}, []string{"10 mail.example.com."}},
+		{"TXT", &dns.TXT{Hdr: hdr(dns.TypeTXT), Txt: []string{"hello ", "world"}}, []string{"hello world"}},
+		{"NS", &dns.NS{Hdr: hdr(dns.TypeNS), Ns: "ns1.example.com."}, []string{"ns1.example.com."}},
+		{"SOA", &dns.SOA{
+			Hdr: hdr(dns.TypeSOA), Ns: "ns1.example.com.",
+			Mbox: "hostmaster.example.com.", Serial: 2024010101,
+		}, []string{"ns1.example.com. hostmaster.example.com. 2024010101"}},
+		{"SRV", &dns.SRV{Hdr: hdr(dns.TypeSRV), Priority: 10, Weight: 20, Port: 80, Target: "web.example.com."}, []string{"10 20 80 web.example.com."}},
+		{"CAA", &dns.CAA{Hdr: hdr(dns.TypeCAA), Flag: 0, Tag: "issue", Value: "letsencrypt.org"}, []string{"0 issue letsencrypt.org"}},
+		{"PTR", &dns.PTR{Hdr: hdr(dns.TypePTR), Ptr: "host.example.com."}, []string{"host.example.com."}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := new(dns.Msg)
+			msg.Answer = []dns.RR{tc.rr}
+			got := dnsAnswerStrings(msg)
+			if len(got) != len(tc.want) || got[0] != tc.want[0] {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Truncation to 5.
+	many := new(dns.Msg)
+	for i := 1; i <= 6; i++ {
+		many.Answer = append(many.Answer, &dns.A{
+			Hdr: hdr(dns.TypeA),
+			A:   net.ParseIP(fmt.Sprintf("10.0.0.%d", i)),
+		})
+	}
+	if got := dnsAnswerStrings(many); len(got) != 5 {
+		t.Fatalf("expected 5 answers, got %d", len(got))
+	}
+}
+
+func TestDnsMatchAnswer(t *testing.T) {
+	answers := []string{"93.184.216.34", "Mail.Example.COM."}
+	if !dnsMatchAnswer("contains", "93.184.216", answers) {
+		t.Error("contains should match substring")
+	}
+	if !dnsMatchAnswer("contains", "mail.example.com", answers) {
+		t.Error("contains should be case-insensitive and ignore trailing dot")
+	}
+	if dnsMatchAnswer("contains", "1.2.3.4", answers) {
+		t.Error("contains should not match absent value")
+	}
+	if !dnsMatchAnswer("exact", "mail.example.com.", answers) {
+		t.Error("exact should match after normalization")
+	}
+	if dnsMatchAnswer("exact", "mail.example", answers) {
+		t.Error("exact should not match partial value")
+	}
+}

--- a/internal/hub/monitors/checker_http.go
+++ b/internal/hub/monitors/checker_http.go
@@ -1,0 +1,462 @@
+package monitors
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Defaults and bounds for the HTTP/keyword checker (spec §6.1).
+const (
+	defaultAcceptedStatusCodes = "200-299"
+	defaultMaxRedirects        = 10
+	minMaxRedirects            = 1
+	maxMaxRedirects            = 20
+	maxHeaderEntries           = 20
+	maxRequestBodyBytes        = 1 << 20
+	maxResponseBodyBytes       = 2 << 20
+	defaultUserAgent           = "Beszel-Monitor"
+	certSkippedNote            = "tls checker pending (task 4)"
+	defaultCheckTimeout        = 10 * time.Second
+	tlsHandshakeTimeout        = 5 * time.Second
+)
+
+// allowedHTTPMethods is the enum of supported request methods.
+var allowedHTTPMethods = map[string]bool{
+	http.MethodGet:     true,
+	http.MethodPost:    true,
+	http.MethodPut:     true,
+	http.MethodPatch:   true,
+	http.MethodDelete:  true,
+	http.MethodHead:    true,
+	http.MethodOptions: true,
+}
+
+// CheckHTTP performs an HTTP (or keyword) uptime check from the hub.
+// It never applies upside_down: Task 7 applies that inversion. Secrets from
+// the config are never included in messages or details.
+func CheckHTTP(ctx context.Context, m Monitor) CheckResult {
+	details := map[string]any{}
+	down := func(msg string) CheckResult {
+		return CheckResult{Status: StatusDown, Message: msg, Details: details}
+	}
+
+	timeout := time.Duration(m.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+
+	target, err := parseMonitorURL(m.Target)
+	if err != nil {
+		return down(err.Error())
+	}
+
+	method, err := parseHTTPMethod(m.Config["method"])
+	if err != nil {
+		return down(err.Error())
+	}
+
+	accept, err := parseAcceptedStatusCodes(configString(m.Config["accepted_status_codes"], defaultAcceptedStatusCodes))
+	if err != nil {
+		return down(err.Error())
+	}
+
+	followRedirects := configBool(m.Config["follow_redirects"], true)
+	maxRedirects := configInt(m.Config["max_redirects"], defaultMaxRedirects)
+	if maxRedirects < minMaxRedirects {
+		maxRedirects = minMaxRedirects
+	}
+	if maxRedirects > maxMaxRedirects {
+		maxRedirects = maxMaxRedirects
+	}
+
+	headers, hasUserAgent, err := parseHTTPHeaders(m.Config["headers"])
+	if err != nil {
+		return down(err.Error())
+	}
+
+	body := configString(m.Config["body"], "")
+	if len(body) > maxRequestBodyBytes {
+		return down(fmt.Sprintf("request body exceeds 1 MB limit (%d bytes)", len(body)))
+	}
+	contentType := configString(m.Config["content_type"], "")
+
+	auth, err := parseHTTPAuth(m.Config)
+	if err != nil {
+		return down(err.Error())
+	}
+
+	ignoreTLS := configBool(m.Config["ignore_tls_errors"], false)
+	if ignoreTLS {
+		details["tls_insecure"] = true
+	}
+	if configBool(m.Config["check_cert_expiry"], false) {
+		// check_cert_expiry is wired by Task 4 (CheckTLS). Note it without
+		// failing the check.
+		details["cert_skipped"] = certSkippedNote
+	}
+
+	keyword := configString(m.Config["keyword"], "")
+	invertKeyword := configBool(m.Config["invert_keyword"], false)
+	if m.Type == TypeKeyword && keyword == "" {
+		return down("keyword is required for keyword monitors")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(reqCtx, method, target.String(), bodyReader)
+	if err != nil {
+		return down(fmt.Sprintf("cannot build request: %v", err))
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	if !hasUserAgent {
+		req.Header.Set("User-Agent", defaultUserAgent)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	switch auth.scheme {
+	case "basic":
+		req.SetBasicAuth(auth.username, auth.password)
+	case "bearer":
+		req.Header.Set("Authorization", "Bearer "+auth.token)
+	}
+
+	transport := &http.Transport{
+		DialContext:           GuardDialContext,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ResponseHeaderTimeout: timeout,
+		MaxIdleConns:          0,
+	}
+	if ignoreTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if !followRedirects {
+				return http.ErrUseLastResponse
+			}
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects: redirect limit exceeded", maxRedirects)
+			}
+			if err := redirectHostAllowed(req.Context(), req.URL.Hostname()); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		msg := err.Error()
+		var urlErr *url.Error
+		if errors.As(err, &urlErr) && urlErr.Timeout() {
+			msg = fmt.Sprintf("request timed out after %s", timeout)
+		}
+		res := CheckResult{Status: StatusDown, LatencyMs: elapsedMs(start), Message: msg, Details: details}
+		if resp != nil {
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+			res.Code = intPtr(resp.StatusCode)
+			if res.Details["final_url"] == nil && resp.Request != nil && resp.Request.URL != nil {
+				res.Details["final_url"] = resp.Request.URL.String()
+			}
+		}
+		return res
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes+1))
+	if err != nil {
+		return CheckResult{Status: StatusDown, LatencyMs: elapsedMs(start), Code: intPtr(resp.StatusCode), Message: fmt.Sprintf("error reading response body: %v", err), Details: details}
+	}
+	if len(data) > maxResponseBodyBytes {
+		data = data[:maxResponseBodyBytes]
+		details["truncated"] = true
+	}
+	latencyMs := elapsedMs(start)
+	details["final_url"] = resp.Request.URL.String()
+
+	if !accept(resp.StatusCode) {
+		return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: fmt.Sprintf("status %d not accepted", resp.StatusCode), Details: details}
+	}
+
+	if keyword != "" {
+		found := strings.Contains(string(data), keyword)
+		details["keyword_found"] = found
+		switch {
+		case found && invertKeyword:
+			return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword found (inverted)", Details: details}
+		case !found && invertKeyword:
+			return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword not found (inverted)", Details: details}
+		case found:
+			return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword found", Details: details}
+		default:
+			return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword not found", Details: details}
+		}
+	}
+
+	return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: fmt.Sprintf("status %d accepted", resp.StatusCode), Details: details}
+}
+
+// parseMonitorURL validates that target is an http(s) URL with a host.
+func parseMonitorURL(target string) (*url.URL, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("invalid URL %q: target is required", target)
+	}
+	u, err := url.Parse(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %v", target, err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("invalid URL %q: scheme must be http or https", target)
+	}
+	if u.Host == "" || u.Hostname() == "" {
+		return nil, fmt.Errorf("invalid URL %q: missing host", target)
+	}
+	return u, nil
+}
+
+// parseHTTPMethod validates the configured method (default GET).
+func parseHTTPMethod(v any) (string, error) {
+	s := strings.ToUpper(strings.TrimSpace(configString(v, http.MethodGet)))
+	if !allowedHTTPMethods[s] {
+		return "", fmt.Errorf("invalid method %q: must be GET, POST, PUT, PATCH, DELETE, HEAD or OPTIONS", configString(v, ""))
+	}
+	return s, nil
+}
+
+// parseAcceptedStatusCodes parses a Kuma-style spec: comma-separated codes
+// and ranges (e.g. "200,201,204" or "200-299"), tolerating spaces.
+func parseAcceptedStatusCodes(spec string) (func(int) bool, error) {
+	type codeRange struct{ lo, hi int }
+	var ranges []codeRange
+	for _, part := range strings.Split(spec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return nil, fmt.Errorf("invalid accepted_status_codes %q: empty entry", spec)
+		}
+		if loStr, hiStr, ok := strings.Cut(part, "-"); ok {
+			lo, errLo := parseStatusCode(strings.TrimSpace(loStr))
+			hi, errHi := parseStatusCode(strings.TrimSpace(hiStr))
+			if errLo != nil || errHi != nil || lo > hi {
+				return nil, fmt.Errorf("invalid accepted_status_codes %q: bad range %q", spec, part)
+			}
+			ranges = append(ranges, codeRange{lo, hi})
+			continue
+		}
+		n, err := parseStatusCode(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid accepted_status_codes %q: bad code %q", spec, part)
+		}
+		ranges = append(ranges, codeRange{n, n})
+	}
+	if len(ranges) == 0 {
+		return nil, fmt.Errorf("invalid accepted_status_codes %q: empty spec", spec)
+	}
+	return func(code int) bool {
+		for _, r := range ranges {
+			if code >= r.lo && code <= r.hi {
+				return true
+			}
+		}
+		return false
+	}, nil
+}
+
+func parseStatusCode(s string) (int, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil || n < 100 || n > 599 {
+		return 0, fmt.Errorf("invalid status code %q", s)
+	}
+	return n, nil
+}
+
+// httpAuth carries validated credentials. Secrets must never be logged.
+type httpAuth struct {
+	scheme   string
+	username string
+	password string
+	token    string
+}
+
+// parseHTTPAuth validates auth_type/username/password/token.
+func parseHTTPAuth(cfg map[string]any) (httpAuth, error) {
+	t := strings.ToLower(strings.TrimSpace(configString(cfg["auth_type"], "none")))
+	switch t {
+	case "", "none":
+		return httpAuth{}, nil
+	case "basic":
+		u := configString(cfg["username"], "")
+		p := configString(cfg["password"], "")
+		if u == "" || p == "" {
+			return httpAuth{}, fmt.Errorf("basic auth requires username and password")
+		}
+		return httpAuth{scheme: "basic", username: u, password: p}, nil
+	case "bearer":
+		tok := configString(cfg["token"], "")
+		if tok == "" {
+			return httpAuth{}, fmt.Errorf("bearer auth requires token")
+		}
+		return httpAuth{scheme: "bearer", token: tok}, nil
+	default:
+		return httpAuth{}, fmt.Errorf("unsupported auth_type %q: must be none, basic or bearer", t)
+	}
+}
+
+// parseHTTPHeaders validates the custom headers map (<=20 entries, Host and
+// Content-Length forbidden). It also reports whether User-Agent is overridden.
+func parseHTTPHeaders(v any) (map[string]string, bool, error) {
+	headers := map[string]string{}
+	if v == nil {
+		return headers, false, nil
+	}
+	var entries map[string]any
+	switch t := v.(type) {
+	case map[string]any:
+		entries = t
+	case map[string]string:
+		entries = make(map[string]any, len(t))
+		for k, val := range t {
+			entries[k] = val
+		}
+	default:
+		return nil, false, fmt.Errorf("invalid headers: must be an object")
+	}
+	if len(entries) > maxHeaderEntries {
+		return nil, false, fmt.Errorf("too many headers: max %d entries", maxHeaderEntries)
+	}
+	hasUserAgent := false
+	for k, val := range entries {
+		if strings.EqualFold(k, "host") || strings.EqualFold(k, "content-length") {
+			return nil, false, fmt.Errorf("forbidden header %q: must not be set manually", k)
+		}
+		if strings.TrimSpace(k) == "" {
+			return nil, false, fmt.Errorf("invalid headers: empty header name")
+		}
+		s, ok := val.(string)
+		if !ok {
+			s = fmt.Sprint(val)
+		}
+		headers[k] = s
+		if strings.EqualFold(k, "user-agent") {
+			hasUserAgent = true
+		}
+	}
+	return headers, hasUserAgent, nil
+}
+
+// redirectHostAllowed re-validates each redirect hop against the SSRF
+// blocklist. The admin-only env override relaxes the private-IP check but
+// unresolvable hosts are still rejected.
+func redirectHostAllowed(ctx context.Context, host string) error {
+	h := stripBrackets(strings.TrimSpace(host))
+	if h == "" {
+		return fmt.Errorf("redirect to empty host blocked")
+	}
+	allowPrivate := os.Getenv(allowPrivateNetworkEnv) == "true"
+	if ip := net.ParseIP(h); ip != nil {
+		if !allowPrivate && IsPrivateIP(ip) {
+			return fmt.Errorf("redirect to private address %q blocked", host)
+		}
+		return nil
+	}
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", h)
+	if err != nil || len(ips) == 0 {
+		return fmt.Errorf("cannot resolve redirect host %q", host)
+	}
+	if allowPrivate {
+		return nil
+	}
+	for _, ip := range ips {
+		if !IsPrivateIP(ip) {
+			return nil
+		}
+	}
+	return fmt.Errorf("redirect to private address %q blocked", host)
+}
+
+func configString(v any, def string) string {
+	switch t := v.(type) {
+	case nil:
+		return def
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		return fmt.Sprint(t)
+	}
+}
+
+func configBool(v any, def bool) bool {
+	switch t := v.(type) {
+	case nil:
+		return def
+	case bool:
+		return t
+	case string:
+		if b, err := strconv.ParseBool(strings.TrimSpace(t)); err == nil {
+			return b
+		}
+		return def
+	case int:
+		return t != 0
+	case int64:
+		return t != 0
+	case float64:
+		return t != 0
+	default:
+		return def
+	}
+}
+
+func configInt(v any, def int) int {
+	switch t := v.(type) {
+	case nil:
+		return def
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case float64:
+		return int(t)
+	case string:
+		if n, err := strconv.Atoi(strings.TrimSpace(t)); err == nil {
+			return n
+		}
+		return def
+	default:
+		return def
+	}
+}
+
+func elapsedMs(start time.Time) float64 {
+	return float64(time.Since(start)) / float64(time.Millisecond)
+}
+
+func intPtr(n int) *int {
+	return &n
+}

--- a/internal/hub/monitors/checker_http.go
+++ b/internal/hub/monitors/checker_http.go
@@ -22,6 +22,7 @@ const (
 	minMaxRedirects            = 1
 	maxMaxRedirects            = 20
 	maxHeaderEntries           = 20
+	maxHeaderKeyLen            = 100
 	maxRequestBodyBytes        = 1 << 20
 	maxResponseBodyBytes       = 2 << 20
 	defaultUserAgent           = "Beszel-Monitor"
@@ -144,6 +145,7 @@ func CheckHTTP(ctx context.Context, m Monitor) CheckResult {
 		ResponseHeaderTimeout: timeout,
 		MaxIdleConns:          0,
 	}
+	defer transport.CloseIdleConnections()
 	if ignoreTLS {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
@@ -154,6 +156,8 @@ func CheckHTTP(ctx context.Context, m Monitor) CheckResult {
 			if !followRedirects {
 				return http.ErrUseLastResponse
 			}
+			// via holds previous requests: len(via)==maxRedirects means
+			// maxRedirects follows already happened, so stop here.
 			if len(via) >= maxRedirects {
 				return fmt.Errorf("stopped after %d redirects: redirect limit exceeded", maxRedirects)
 			}
@@ -355,6 +359,9 @@ func parseHTTPHeaders(v any) (map[string]string, bool, error) {
 		}
 		if strings.TrimSpace(k) == "" {
 			return nil, false, fmt.Errorf("invalid headers: empty header name")
+		}
+		if len(k) > maxHeaderKeyLen {
+			return nil, false, fmt.Errorf("header name too long: max %d characters", maxHeaderKeyLen)
 		}
 		s, ok := val.(string)
 		if !ok {

--- a/internal/hub/monitors/checker_http.go
+++ b/internal/hub/monitors/checker_http.go
@@ -26,7 +26,6 @@ const (
 	maxRequestBodyBytes        = 1 << 20
 	maxResponseBodyBytes       = 2 << 20
 	defaultUserAgent           = "Beszel-Monitor"
-	certSkippedNote            = "tls checker pending (task 4)"
 	defaultCheckTimeout        = 10 * time.Second
 	tlsHandshakeTimeout        = 5 * time.Second
 )
@@ -100,11 +99,9 @@ func CheckHTTP(ctx context.Context, m Monitor) CheckResult {
 	if ignoreTLS {
 		details["tls_insecure"] = true
 	}
-	if configBool(m.Config["check_cert_expiry"], false) {
-		// check_cert_expiry is wired by Task 4 (CheckTLS). Note it without
-		// failing the check.
-		details["cert_skipped"] = certSkippedNote
-	}
+	// Certificate expiry follows spec §6.1: checked by default for https
+	// targets, using the same TLS evaluation as the tls checker.
+	checkCert := configBool(m.Config["check_cert_expiry"], target.Scheme == "https")
 
 	keyword := configString(m.Config["keyword"], "")
 	invertKeyword := configBool(m.Config["invert_keyword"], false)
@@ -210,17 +207,44 @@ func CheckHTTP(ctx context.Context, m Monitor) CheckResult {
 		details["keyword_found"] = found
 		switch {
 		case found && invertKeyword:
-			return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword found (inverted)", Details: details}
+			return httpResult(ctx, m, target, checkCert, details, StatusDown, latencyMs, resp.StatusCode, "keyword found (inverted)")
 		case !found && invertKeyword:
-			return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword not found (inverted)", Details: details}
+			return httpResult(ctx, m, target, checkCert, details, StatusUp, latencyMs, resp.StatusCode, "keyword not found (inverted)")
 		case found:
-			return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword found", Details: details}
+			return httpResult(ctx, m, target, checkCert, details, StatusUp, latencyMs, resp.StatusCode, "keyword found")
 		default:
-			return CheckResult{Status: StatusDown, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: "keyword not found", Details: details}
+			return httpResult(ctx, m, target, checkCert, details, StatusDown, latencyMs, resp.StatusCode, "keyword not found")
 		}
 	}
 
-	return CheckResult{Status: StatusUp, LatencyMs: latencyMs, Code: intPtr(resp.StatusCode), Message: fmt.Sprintf("status %d accepted", resp.StatusCode), Details: details}
+	return httpResult(ctx, m, target, checkCert, details, StatusUp, latencyMs, resp.StatusCode, fmt.Sprintf("status %d accepted", resp.StatusCode))
+}
+
+// httpResult merges TLS expiry into an HTTP outcome. A critical or expired
+// cert fails the check even when HTTP succeeded; a warning is recorded in
+// details without failing it (the tls monitor type owns warn states).
+func httpResult(ctx context.Context, m Monitor, target *url.URL, checkCert bool, details map[string]any, status string, latencyMs float64, code int, msg string) CheckResult {
+	res := CheckResult{Status: status, LatencyMs: latencyMs, Code: intPtr(code), Message: msg, Details: details}
+	if checkCert && target.Scheme == "https" {
+		host := target.Hostname()
+		port := target.Port()
+		if port == "" {
+			port = "443"
+		}
+		tlsRes := CheckTLS(ctx, Monitor{
+			Name: m.Name, Type: TypeTLS, Target: net.JoinHostPort(stripBrackets(host), port),
+			TimeoutSeconds: m.TimeoutSeconds, Config: m.Config,
+		})
+		if tlsRes.CertDays != nil {
+			details["cert_days"] = *tlsRes.CertDays
+			res.CertDays = tlsRes.CertDays
+		}
+		if tlsRes.Status == StatusDown {
+			res.Status = StatusDown
+			res.Message = fmt.Sprintf("certificate: %s", tlsRes.Message)
+		}
+	}
+	return res
 }
 
 // parseMonitorURL validates that target is an http(s) URL with a host.

--- a/internal/hub/monitors/checker_http_test.go
+++ b/internal/hub/monitors/checker_http_test.go
@@ -495,7 +495,8 @@ func TestHTTPHeaderKeyTooLong(t *testing.T) {
 	}
 }
 
-func TestHTTPBodyTooLarge(t *testing.T) {	allowPrivateNet(t)
+func TestHTTPBodyTooLarge(t *testing.T) {
+	allowPrivateNet(t)
 	m := httpTestMonitor("http://example.com")
 	m.Config["body"] = strings.Repeat("x", (1<<20)+1)
 	if res := CheckHTTP(context.Background(), m); res.Status != StatusDown {

--- a/internal/hub/monitors/checker_http_test.go
+++ b/internal/hub/monitors/checker_http_test.go
@@ -1,0 +1,638 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func httpTestMonitor(target string) Monitor {
+	return Monitor{
+		Name:            "http-test",
+		Type:            TypeHTTP,
+		Target:          target,
+		IntervalSeconds: 60,
+		TimeoutSeconds:  5,
+		Config:          map[string]any{},
+	}
+}
+
+func allowPrivateNet(t *testing.T) {
+	t.Helper()
+	t.Setenv(allowPrivateNetworkEnv, "true")
+}
+
+func TestHTTPParseAcceptedStatusCodes(t *testing.T) {
+	allowPrivateNet(t)
+	cases := []struct {
+		name    string
+		spec    string
+		accept  []int
+		reject  []int
+		wantErr bool
+	}{
+		{"default range", "200-299", []int{200, 201, 250, 299}, []int{199, 300, 404, 500}, false},
+		{"list", "200,201,204", []int{200, 201, 204}, []int{202, 203, 404}, false},
+		{"mixed with spaces", " 200 , 201-203 , 299 ", []int{200, 202, 203, 299}, []int{204, 404}, false},
+		{"single", "200", []int{200}, []int{201, 404}, false},
+		{"full range", "100-599", []int{100, 404, 599}, []int{99, 600}, false},
+		{"invalid token", "abc", nil, nil, true},
+		{"invalid range order", "299-200", nil, nil, true},
+		{"empty", "", nil, nil, true},
+		{"blank", "   ", nil, nil, true},
+		{"code too small", "99", nil, nil, true},
+		{"code too large", "600", nil, nil, true},
+		{"range with bad end", "200-abc", nil, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			matcher, err := parseAcceptedStatusCodes(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for spec %q, got nil", tc.spec)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for spec %q: %v", tc.spec, err)
+			}
+			for _, code := range tc.accept {
+				if !matcher(code) {
+					t.Errorf("spec %q should accept %d", tc.spec, code)
+				}
+			}
+			for _, code := range tc.reject {
+				if matcher(code) {
+					t.Errorf("spec %q should reject %d", tc.spec, code)
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPOK(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	res := CheckHTTP(context.Background(), httpTestMonitor(srv.URL))
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Code == nil || *res.Code != 200 {
+		t.Fatalf("expected code 200, got %+v", res.Code)
+	}
+	if res.LatencyMs <= 0 {
+		t.Fatalf("expected positive latency, got %v", res.LatencyMs)
+	}
+	if res.Details["final_url"] != srv.URL {
+		t.Fatalf("expected final_url %q, got %v", srv.URL, res.Details["final_url"])
+	}
+}
+
+func TestHTTPStatusNotAccepted(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	res := CheckHTTP(context.Background(), httpTestMonitor(srv.URL))
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Code == nil || *res.Code != 500 {
+		t.Fatalf("expected code 500, got %+v", res.Code)
+	}
+	if !strings.Contains(res.Message, "status 500 not accepted") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPCustomAcceptedCodes(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/created" {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	accepted := httpTestMonitor(srv.URL + "/created")
+	accepted.Config["accepted_status_codes"] = "200,201,204"
+	if res := CheckHTTP(context.Background(), accepted); res.Status != StatusUp {
+		t.Fatalf("expected up for custom accepted code, got %q (%s)", res.Status, res.Message)
+	}
+
+	rejected := httpTestMonitor(srv.URL + "/missing")
+	rejected.Config["accepted_status_codes"] = "200, 201-203"
+	res := CheckHTTP(context.Background(), rejected)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for non-accepted code, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "status 404 not accepted") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+
+	bad := httpTestMonitor(srv.URL)
+	bad.Config["accepted_status_codes"] = "bogus"
+	if res := CheckHTTP(context.Background(), bad); res.Status != StatusDown {
+		t.Fatalf("expected down for invalid spec, got %q", res.Status)
+	}
+}
+
+func TestHTTPRedirectFollowed(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/final" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("done"))
+			return
+		}
+		http.Redirect(w, r, "/final", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	res := CheckHTTP(context.Background(), httpTestMonitor(srv.URL))
+	if res.Status != StatusUp {
+		t.Fatalf("expected up after redirect, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Details["final_url"] != srv.URL+"/final" {
+		t.Fatalf("expected final_url %q, got %v", srv.URL+"/final", res.Details["final_url"])
+	}
+}
+
+func TestHTTPRedirectNotFollowed(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/final", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["follow_redirects"] = false
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for unfollowed redirect, got %q", res.Status)
+	}
+	if res.Code == nil || *res.Code != 302 {
+		t.Fatalf("expected code 302, got %+v", res.Code)
+	}
+	if res.Details["final_url"] != srv.URL {
+		t.Fatalf("expected final_url %q, got %v", srv.URL, res.Details["final_url"])
+	}
+}
+
+func TestHTTPRedirectCap(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/loop", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL + "/loop")
+	m.Config["max_redirects"] = 1
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down when redirect cap hit, got %q", res.Status)
+	}
+	if res.Code == nil || *res.Code != 302 {
+		t.Fatalf("expected code 302, got %+v", res.Code)
+	}
+	if !strings.Contains(res.Message, "redirect") {
+		t.Fatalf("expected redirect message, got %q", res.Message)
+	}
+}
+
+func TestHTTPRedirectPrivateHopBlocked(t *testing.T) {
+	t.Setenv(allowPrivateNetworkEnv, "")
+	if err := redirectHostAllowed(context.Background(), "127.0.0.1"); err == nil {
+		t.Fatal("expected private redirect hop to be blocked")
+	}
+	if err := redirectHostAllowed(context.Background(), "localhost"); err == nil {
+		t.Fatal("expected loopback redirect hop to be blocked")
+	}
+	t.Setenv(allowPrivateNetworkEnv, "true")
+	if err := redirectHostAllowed(context.Background(), "127.0.0.1"); err != nil {
+		t.Fatalf("expected override to allow private hop, got %v", err)
+	}
+	if err := redirectHostAllowed(context.Background(), "no-such-host.invalid."); err == nil {
+		t.Fatal("expected unresolvable redirect hop to be blocked")
+	}
+}
+
+func TestHTTPKeywordFound(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello beszel world"))
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Type = TypeKeyword
+	m.Config["keyword"] = "beszel"
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+	if found, _ := res.Details["keyword_found"].(bool); !found {
+		t.Fatalf("expected keyword_found=true, got %v", res.Details)
+	}
+	if res.Message != "keyword found" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPKeywordNotFound(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("nothing to see here"))
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["keyword"] = "beszel"
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if res.Message != "keyword not found" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPKeywordInverted(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("beszel is here"))
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["keyword"] = "beszel"
+	m.Config["invert_keyword"] = true
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for inverted match, got %q", res.Status)
+	}
+	if res.Message != "keyword found (inverted)" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+
+	m.Config["keyword"] = "absent-word"
+	res = CheckHTTP(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up for inverted absence, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestHTTPKeywordRequired(t *testing.T) {
+	allowPrivateNet(t)
+	m := httpTestMonitor("http://example.com")
+	m.Type = TypeKeyword
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down without keyword, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "keyword is required") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPTimeout(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(3 * time.Second)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.TimeoutSeconds = 1
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down on timeout, got %q", res.Status)
+	}
+	if res.Code != nil {
+		t.Fatalf("expected nil code on timeout, got %d", *res.Code)
+	}
+	if !strings.Contains(res.Message, "timed out") {
+		t.Fatalf("expected timeout message, got %q", res.Message)
+	}
+}
+
+func TestHTTPTruncatedBody(t *testing.T) {
+	allowPrivateNet(t)
+	big := "KEY:" + strings.Repeat("a", (2<<20)+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["keyword"] = "KEY"
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Details["truncated"] != true {
+		t.Fatalf("expected truncated=true, got %v", res.Details)
+	}
+}
+
+func TestHTTPTruncatedKeywordBeyondCutoff(t *testing.T) {
+	allowPrivateNet(t)
+	big := strings.Repeat("a", 2<<20) + "TAILKEY"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(big))
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["keyword"] = "TAILKEY"
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for keyword past cutoff, got %q", res.Status)
+	}
+	if res.Message != "keyword not found" {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+	if res.Details["truncated"] != true {
+		t.Fatalf("expected truncated=true, got %v", res.Details)
+	}
+}
+
+func TestHTTPBasicAuth(t *testing.T) {
+	allowPrivateNet(t)
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if u, p, ok := r.BasicAuth(); !ok || u != "u" || p != "p" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["auth_type"] = "basic"
+	m.Config["username"] = "u"
+	m.Config["password"] = "p"
+	if res := CheckHTTP(context.Background(), m); res.Status != StatusUp {
+		t.Fatalf("expected up with valid basic auth, got %q (%s)", res.Status, res.Message)
+	}
+
+	missing := httpTestMonitor(srv.URL)
+	missing.Config["auth_type"] = "basic"
+	missing.Config["username"] = "u"
+	before := hits
+	res := CheckHTTP(context.Background(), missing)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down with missing password, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "username and password") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+	if res.Code != nil {
+		t.Fatalf("expected nil code when validation fails before request, got %d", *res.Code)
+	}
+	if hits != before {
+		t.Fatal("no request should be sent when auth config is invalid")
+	}
+}
+
+func TestHTTPBearerAuth(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer s3cr3t-bearer-xyz" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["auth_type"] = "bearer"
+	m.Config["token"] = "s3cr3t-bearer-xyz"
+	if res := CheckHTTP(context.Background(), m); res.Status != StatusUp {
+		t.Fatalf("expected up with valid bearer token, got %q (%s)", res.Status, res.Message)
+	}
+
+	missing := httpTestMonitor(srv.URL)
+	missing.Config["auth_type"] = "bearer"
+	res := CheckHTTP(context.Background(), missing)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down with missing token, got %q", res.Status)
+	}
+	if strings.Contains(res.Message, "s3cr3t-bearer-xyz") {
+		t.Fatalf("message must never contain secrets: %q", res.Message)
+	}
+
+	unknown := httpTestMonitor(srv.URL)
+	unknown.Config["auth_type"] = "digest"
+	if res := CheckHTTP(context.Background(), unknown); res.Status != StatusDown {
+		t.Fatalf("expected down for unknown auth_type, got %q", res.Status)
+	}
+}
+
+func TestHTTPForbiddenHeader(t *testing.T) {
+	allowPrivateNet(t)
+	for _, h := range []string{"Host", "host", "Content-Length"} {
+		m := httpTestMonitor("http://example.com")
+		m.Config["headers"] = map[string]any{h: "evil"}
+		res := CheckHTTP(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Fatalf("expected down for header %q, got %q", h, res.Status)
+		}
+		if !strings.Contains(res.Message, "forbidden header") {
+			t.Fatalf("unexpected message %q", res.Message)
+		}
+	}
+}
+
+func TestHTTPTooManyHeaders(t *testing.T) {
+	allowPrivateNet(t)
+	headers := map[string]any{}
+	for i := 0; i < 21; i++ {
+		headers[fmt.Sprintf("X-Test-%d", i)] = "v"
+	}
+	m := httpTestMonitor("http://example.com")
+	m.Config["headers"] = headers
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for too many headers, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "too many headers") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPBodyTooLarge(t *testing.T) {
+	allowPrivateNet(t)
+	m := httpTestMonitor("http://example.com")
+	m.Config["body"] = strings.Repeat("x", (1<<20)+1)
+	if res := CheckHTTP(context.Background(), m); res.Status != StatusDown {
+		t.Fatalf("expected down for oversized body, got %q", res.Status)
+	}
+}
+
+func TestHTTPPostBody(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Header.Get("Content-Type") != "text/plain" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		buf := make([]byte, 16)
+		n, _ := r.Body.Read(buf)
+		if string(buf[:n]) != "hello" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["method"] = "POST"
+	m.Config["body"] = "hello"
+	m.Config["content_type"] = "text/plain"
+	if res := CheckHTTP(context.Background(), m); res.Status != StatusUp {
+		t.Fatalf("expected up for POST with body, got %q (%s)", res.Status, res.Message)
+	}
+
+	lower := httpTestMonitor(srv.URL)
+	lower.Config["method"] = "post"
+	lower.Config["body"] = "hello"
+	lower.Config["content_type"] = "text/plain"
+	if res := CheckHTTP(context.Background(), lower); res.Status != StatusUp {
+		t.Fatalf("expected lowercase method to be accepted, got %q (%s)", res.Status, res.Message)
+	}
+
+	bad := httpTestMonitor(srv.URL)
+	bad.Config["method"] = "FETCH"
+	res := CheckHTTP(context.Background(), bad)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for invalid method, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "invalid method") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPUserAgent(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ua:" + r.UserAgent()))
+	}))
+	defer srv.Close()
+
+	def := httpTestMonitor(srv.URL)
+	def.Config["keyword"] = "ua:Beszel-Monitor"
+	if res := CheckHTTP(context.Background(), def); res.Status != StatusUp {
+		t.Fatalf("expected default User-Agent, got %q (%s)", res.Status, res.Message)
+	}
+
+	custom := httpTestMonitor(srv.URL)
+	custom.Config["keyword"] = "ua:Custom/1.0"
+	custom.Config["headers"] = map[string]any{"User-Agent": "Custom/1.0"}
+	if res := CheckHTTP(context.Background(), custom); res.Status != StatusUp {
+		t.Fatalf("expected custom User-Agent override, got %q (%s)", res.Status, res.Message)
+	}
+}
+
+func TestHTTPIgnoreTLSErrors(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	strict := httpTestMonitor(srv.URL)
+	if res := CheckHTTP(context.Background(), strict); res.Status != StatusDown {
+		t.Fatalf("expected down for untrusted cert, got %q", res.Status)
+	}
+
+	relaxed := httpTestMonitor(srv.URL)
+	relaxed.Config["ignore_tls_errors"] = true
+	res := CheckHTTP(context.Background(), relaxed)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up with ignore_tls_errors, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Details["tls_insecure"] != true {
+		t.Fatalf("expected tls_insecure=true, got %v", res.Details)
+	}
+}
+
+func TestHTTPCertExpirySkipped(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.Config["check_cert_expiry"] = true
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	}
+	if res.Details["cert_skipped"] != "tls checker pending (task 4)" {
+		t.Fatalf("expected cert_skipped note, got %v", res.Details)
+	}
+}
+
+func TestHTTPUpsideDownIgnored(t *testing.T) {
+	allowPrivateNet(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := httpTestMonitor(srv.URL)
+	m.UpsideDown = true
+	if res := CheckHTTP(context.Background(), m); res.Status != StatusUp {
+		t.Fatalf("expected raw up status (upside_down applied by task 7), got %q", res.Status)
+	}
+}
+
+func TestHTTPInvalidScheme(t *testing.T) {
+	allowPrivateNet(t)
+	for _, target := range []string{
+		"file:///etc/passwd",
+		"ftp://example.com/file",
+		"gopher://example.com/",
+		"http://",
+		"://bad",
+		"",
+		"notaurl",
+	} {
+		res := CheckHTTP(context.Background(), httpTestMonitor(target))
+		if res.Status != StatusDown {
+			t.Errorf("expected down for target %q, got %q", target, res.Status)
+		}
+		if res.Code != nil {
+			t.Errorf("expected nil code for target %q, got %d", target, *res.Code)
+		}
+	}
+}

--- a/internal/hub/monitors/checker_http_test.go
+++ b/internal/hub/monitors/checker_http_test.go
@@ -597,21 +597,43 @@ func TestHTTPIgnoreTLSErrors(t *testing.T) {
 	}
 }
 
-func TestHTTPCertExpirySkipped(t *testing.T) {
+func TestHTTPCertExpiryEvaluated(t *testing.T) {
 	allowPrivateNet(t)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
+	// Self-signed test cert with default (strict) verification fails at the
+	// HTTP layer first; with ignore + expiry check, the TLS evaluation runs
+	// and reports (expiry of the test cert is what it is — we assert the
+	// plumbing, not a fixed verdict).
 	m := httpTestMonitor(srv.URL)
 	m.Config["check_cert_expiry"] = true
+	m.Config["ignore_tls_errors"] = true
 	res := CheckHTTP(context.Background(), m)
-	if res.Status != StatusUp {
-		t.Fatalf("expected up, got %q (%s)", res.Status, res.Message)
+	if res.Status != StatusUp && res.Status != StatusDown {
+		t.Fatalf("unexpected status %q (%s)", res.Status, res.Message)
 	}
-	if res.Details["cert_skipped"] != "tls checker pending (task 4)" {
-		t.Fatalf("expected cert_skipped note, got %v", res.Details)
+	if _, ok := res.Details["cert_days"]; !ok {
+		t.Fatalf("expected cert_days in details, got %v", res.Details)
+	}
+	if res.CertDays == nil {
+		t.Fatal("expected CertDays pointer on https result")
+	}
+
+	// Plain http: no cert evaluation at all.
+	plain := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer plain.Close()
+	m2 := httpTestMonitor(plain.URL)
+	res2 := CheckHTTP(context.Background(), m2)
+	if res2.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%s)", res2.Status, res2.Message)
+	}
+	if _, ok := res2.Details["cert_days"]; ok {
+		t.Fatalf("plain http must not evaluate certs, got %v", res2.Details)
 	}
 }
 

--- a/internal/hub/monitors/checker_http_test.go
+++ b/internal/hub/monitors/checker_http_test.go
@@ -482,8 +482,20 @@ func TestHTTPTooManyHeaders(t *testing.T) {
 	}
 }
 
-func TestHTTPBodyTooLarge(t *testing.T) {
+func TestHTTPHeaderKeyTooLong(t *testing.T) {
 	allowPrivateNet(t)
+	m := httpTestMonitor("http://example.com")
+	m.Config["headers"] = map[string]any{strings.Repeat("X", 101): "v"}
+	res := CheckHTTP(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for oversized header name, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "too long") {
+		t.Fatalf("unexpected message %q", res.Message)
+	}
+}
+
+func TestHTTPBodyTooLarge(t *testing.T) {	allowPrivateNet(t)
 	m := httpTestMonitor("http://example.com")
 	m.Config["body"] = strings.Repeat("x", (1<<20)+1)
 	if res := CheckHTTP(context.Background(), m); res.Status != StatusDown {

--- a/internal/hub/monitors/checker_ping.go
+++ b/internal/hub/monitors/checker_ping.go
@@ -1,0 +1,220 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus-community/pro-bing"
+)
+
+// Defaults and bounds for the ping checker (spec §6.4).
+const (
+	defaultPingCount         = 3
+	minPingCount             = 1
+	maxPingCount             = 10
+	defaultPingPacketSize    = 56
+	maxPingPacketSize        = 65400
+	defaultPingPacketTimeout = 2 * time.Second
+	defaultPingInterval      = time.Second
+	minPingInterval          = 200 * time.Millisecond
+	pingTimeoutMargin        = 2 * time.Second
+)
+
+// pingUnavailableMsg is returned when neither unprivileged nor privileged
+// ping can run in this environment (e.g. Docker without NET_RAW nor
+// ping_group_range). It is an explicit capability signal, never a silent
+// false down.
+const pingUnavailableMsg = "ping unavailable: missing NET_RAW capability (see docs)"
+
+// pingPermissionSubstrings classifies socket/capability failures (spec §6.4,
+// case-insensitive): unprivileged ping fails this way when the process lacks
+// NET_RAW / ping_group_range membership, and privileged ping fails this way
+// without root or CAP_NET_RAW.
+var pingPermissionSubstrings = []string{
+	"permission",
+	"operation not permitted",
+	"socket",
+	"capability",
+	"privileged",
+}
+
+// CheckPing performs an ICMP echo uptime check from the hub using
+// pro-bing in UDP (unprivileged) mode first, with a single fallback to
+// privileged (raw socket) mode on permission errors. It never applies
+// upside_down: Task 7 applies that inversion. Only pro-bing + stdlib.
+func CheckPing(ctx context.Context, m Monitor) CheckResult {
+	details := map[string]any{}
+	down := func(msg string) CheckResult {
+		return CheckResult{Status: StatusDown, Message: msg, Details: details}
+	}
+
+	target := strings.TrimSpace(m.Target)
+	if target == "" {
+		return down("ping: target is required")
+	}
+
+	// SSRF guard: only literal IPs are checked. Hostnames are passed as-is
+	// to the pinger (which resolves them) and intentionally NOT blocked:
+	// their resolution may legitimately be local in tests (localhost), CI,
+	// or intranet monitoring, and ping stays informative there.
+	if ip := net.ParseIP(stripBrackets(target)); ip != nil {
+		if os.Getenv(allowPrivateNetworkEnv) != "true" && IsPrivateIP(ip) {
+			return down(fmt.Sprintf("ping: target is private network %s (set %s=true to allow)", ip.String(), allowPrivateNetworkEnv))
+		}
+	}
+
+	count := configInt(m.Config["count"], defaultPingCount)
+	if count < minPingCount || count > maxPingCount {
+		return down(fmt.Sprintf("invalid count %v: must be %d..%d", m.Config["count"], minPingCount, maxPingCount))
+	}
+
+	size := configInt(m.Config["packet_size"], defaultPingPacketSize)
+	if size < 0 || size > maxPingPacketSize {
+		return down(fmt.Sprintf("invalid packet_size %v: must be 0..%d", m.Config["packet_size"], maxPingPacketSize))
+	}
+
+	timeout := time.Duration(m.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+
+	packetTimeout := parsePingDuration(m.Config["packet_timeout"], defaultPingPacketTimeout)
+	if packetTimeout <= 0 || packetTimeout > timeout {
+		return down(fmt.Sprintf("invalid packet_timeout %v: must be > 0 and <= check timeout (%s)", m.Config["packet_timeout"], timeout))
+	}
+
+	interval := parsePingDuration(m.Config["interval_between_packets"], defaultPingInterval)
+	if interval < minPingInterval {
+		return down(fmt.Sprintf("invalid interval_between_packets %v: must be >= %s", m.Config["interval_between_packets"], minPingInterval))
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Bound the pinger's internal timeout: per-packet budget over all
+	// packets plus margin, capped by the global check timeout.
+	// RunWithContext(reqCtx) propagates cancellation on top.
+	want := packetTimeout*time.Duration(count) + pingTimeoutMargin
+	if want > timeout {
+		want = timeout
+	}
+
+	newPinger := func(privileged bool) (*probing.Pinger, error) {
+		p, err := probing.NewPinger(target)
+		if err != nil {
+			return nil, err
+		}
+		p.SetPrivileged(privileged)
+		p.Count = count
+		p.Size = size
+		p.Interval = interval
+		p.Timeout = want
+		p.ResolveTimeout = timeout
+		return p, nil
+	}
+
+	p, err := newPinger(false)
+	if err != nil {
+		return down(fmt.Sprintf("cannot resolve host: %v", err))
+	}
+	if err := p.RunWithContext(reqCtx); err != nil {
+		if !isPingPermissionError(err) {
+			return down(fmt.Sprintf("ping failed: %v", err))
+		}
+		// Unprivileged mode lacks socket capability: retry exactly once
+		// in privileged mode with a fresh pinger.
+		fp, ferr := newPinger(true)
+		if ferr != nil {
+			return down(fmt.Sprintf("cannot resolve host: %v", ferr))
+		}
+		if err := fp.RunWithContext(reqCtx); err != nil {
+			if isPingPermissionError(err) {
+				return down(pingUnavailableMsg)
+			}
+			return down(fmt.Sprintf("ping failed: %v", err))
+		}
+		return pingResult(fp.Statistics())
+	}
+	return pingResult(p.Statistics())
+}
+
+// pingResult maps pro-bing statistics to a CheckResult: up with
+// "<recv>/<sent> packets received" when at least one reply arrived, else a
+// typed 100%-loss down. LatencyMs is the average RTT in fractional
+// milliseconds (0 when nothing replied). Code stays nil.
+func pingResult(stats *probing.Statistics) CheckResult {
+	details := map[string]any{}
+	if stats == nil {
+		return CheckResult{Status: StatusDown, Message: "ping: no statistics", Details: details}
+	}
+	ms := func(d time.Duration) float64 { return float64(d) / float64(time.Millisecond) }
+	details["min_ms"] = ms(stats.MinRtt)
+	details["avg_ms"] = ms(stats.AvgRtt)
+	details["max_ms"] = ms(stats.MaxRtt)
+	details["loss_pct"] = stats.PacketLoss
+	details["received"] = stats.PacketsRecv
+	details["sent"] = stats.PacketsSent
+	if stats.PacketsRecv >= 1 {
+		return CheckResult{
+			Status:    StatusUp,
+			LatencyMs: ms(stats.AvgRtt),
+			Message:   fmt.Sprintf("%d/%d packets received", stats.PacketsRecv, stats.PacketsSent),
+			Details:   details,
+		}
+	}
+	return CheckResult{
+		Status:    StatusDown,
+		LatencyMs: ms(stats.AvgRtt),
+		Message:   "ping: no reply, packet loss 100%",
+		Details:   details,
+	}
+}
+
+// isPingPermissionError reports whether err looks like a missing socket
+// capability (spec §6.4 substring list, case-insensitive).
+func isPingPermissionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	for _, sub := range pingPermissionSubstrings {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// parsePingDuration parses packet_timeout / interval_between_packets values:
+// nil → default, time.Duration as-is, numerics → seconds, strings →
+// time.ParseDuration then integer seconds, anything else → default.
+func parsePingDuration(v any, def time.Duration) time.Duration {
+	switch t := v.(type) {
+	case nil:
+		return def
+	case time.Duration:
+		return t
+	case int:
+		return time.Duration(t) * time.Second
+	case int64:
+		return time.Duration(t) * time.Second
+	case float64:
+		return time.Duration(t * float64(time.Second))
+	case string:
+		s := strings.TrimSpace(t)
+		if d, err := time.ParseDuration(s); err == nil {
+			return d
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			return time.Duration(n) * time.Second
+		}
+		return def
+	default:
+		return def
+	}
+}

--- a/internal/hub/monitors/checker_ping_test.go
+++ b/internal/hub/monitors/checker_ping_test.go
@@ -1,0 +1,238 @@
+package monitors
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func pingTestMonitor(target string) Monitor {
+	return Monitor{
+		Name:            "ping-test",
+		Type:            TypePing,
+		Target:          target,
+		IntervalSeconds: 60,
+		TimeoutSeconds:  5,
+		Config:          map[string]any{},
+	}
+}
+
+// skipIfPingUnavailable skips explicitly when the sandbox lacks the NET_RAW
+// capability (and ping_group_range): neither unprivileged nor privileged ping
+// can run here, so live-ping assertions cannot execute.
+func skipIfPingUnavailable(t *testing.T, res CheckResult) {
+	t.Helper()
+	if res.Status == StatusDown && strings.Contains(res.Message, "missing NET_RAW capability") {
+		t.Skipf("skipping live ping assertions: %s", res.Message)
+	}
+}
+
+func TestPingEmptyTarget(t *testing.T) {
+	for _, target := range []string{"", "   "} {
+		m := pingTestMonitor(target)
+		res := CheckPing(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Errorf("target %q: expected down, got %q", target, res.Status)
+		}
+		if res.Message == "" {
+			t.Errorf("target %q: expected non-empty down message", target)
+		}
+	}
+}
+
+func TestPingInvalidCount(t *testing.T) {
+	for _, count := range []any{0, -1, 11} {
+		m := pingTestMonitor("192.0.2.1")
+		m.Config["count"] = count
+		res := CheckPing(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Errorf("count %v: expected down, got %q", count, res.Status)
+		}
+		if !strings.Contains(res.Message, "invalid count") {
+			t.Errorf("count %v: expected 'invalid count' message, got %q", count, res.Message)
+		}
+	}
+}
+
+func TestPingInvalidPacketSize(t *testing.T) {
+	for _, size := range []any{-1, 65401} {
+		m := pingTestMonitor("192.0.2.1")
+		m.Config["packet_size"] = size
+		res := CheckPing(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Errorf("packet_size %v: expected down, got %q", size, res.Status)
+		}
+		if !strings.Contains(res.Message, "invalid packet_size") {
+			t.Errorf("packet_size %v: expected 'invalid packet_size' message, got %q", size, res.Message)
+		}
+	}
+}
+
+func TestPingInvalidPacketTimeout(t *testing.T) {
+	// TimeoutSeconds is 5: zero, negative, unparseable-equivalent and values
+	// above the global timeout are all rejected before any socket is opened.
+	for _, pt := range []any{0, -1, "0", 30} {
+		m := pingTestMonitor("192.0.2.1")
+		m.Config["packet_timeout"] = pt
+		res := CheckPing(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Errorf("packet_timeout %v: expected down, got %q", pt, res.Status)
+		}
+		if !strings.Contains(res.Message, "invalid packet_timeout") {
+			t.Errorf("packet_timeout %v: expected 'invalid packet_timeout' message, got %q", pt, res.Message)
+		}
+	}
+}
+
+func TestPingInvalidInterval(t *testing.T) {
+	// Minimum is 200ms: zero, sub-200ms numerics and duration strings below
+	// the floor are rejected.
+	for _, iv := range []any{0, 0.1, "10ms", -1} {
+		m := pingTestMonitor("192.0.2.1")
+		m.Config["interval_between_packets"] = iv
+		res := CheckPing(context.Background(), m)
+		if res.Status != StatusDown {
+			t.Errorf("interval %v: expected down, got %q", iv, res.Status)
+		}
+		if !strings.Contains(res.Message, "invalid interval_between_packets") {
+			t.Errorf("interval %v: expected 'invalid interval_between_packets' message, got %q", iv, res.Message)
+		}
+	}
+}
+
+func TestPingUnresolvableHost(t *testing.T) {
+	m := pingTestMonitor("does-not-exist.invalid")
+	res := CheckPing(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.HasPrefix(res.Message, "cannot resolve host") {
+		t.Fatalf("expected 'cannot resolve host ...' message, got %q", res.Message)
+	}
+}
+
+func TestPingPrivateTargetBlocked(t *testing.T) {
+	t.Setenv(allowPrivateNetworkEnv, "")
+	m := pingTestMonitor("10.0.0.1")
+	res := CheckPing(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "private network") {
+		t.Fatalf("expected private-network guard message, got %q", res.Message)
+	}
+}
+
+func TestPingPrivateTargetAllowedWithOverride(t *testing.T) {
+	allowPrivateNet(t)
+	m := pingTestMonitor("10.0.0.1")
+	m.Config["count"] = 1
+	m.Config["packet_timeout"] = 1
+	res := CheckPing(context.Background(), m)
+	// The override must let the check proceed past the SSRF guard: any
+	// outcome is fine except the private-network block.
+	if strings.Contains(res.Message, "private network") {
+		t.Fatalf("override set but guard still blocked: %q", res.Message)
+	}
+}
+
+func TestPingLoopback(t *testing.T) {
+	allowPrivateNet(t)
+	m := pingTestMonitor("127.0.0.1")
+	m.Config["count"] = 1
+	res := CheckPing(context.Background(), m)
+	skipIfPingUnavailable(t, res)
+	if res.Status != StatusUp {
+		t.Fatalf("expected up, got %q (%q)", res.Status, res.Message)
+	}
+	if res.Message != "1/1 packets received" {
+		t.Errorf("expected '1/1 packets received', got %q", res.Message)
+	}
+	if res.Code != nil {
+		t.Errorf("expected nil code, got %d", *res.Code)
+	}
+	if res.LatencyMs < 0 {
+		t.Errorf("expected non-negative latency, got %v", res.LatencyMs)
+	}
+	if res.Details["sent"] != 1 || res.Details["received"] != 1 {
+		t.Errorf("expected sent=1 received=1, got details %v", res.Details)
+	}
+	for _, k := range []string{"min_ms", "avg_ms", "max_ms", "loss_pct"} {
+		if _, ok := res.Details[k].(float64); !ok {
+			t.Errorf("expected float64 detail %q, got %v", k, res.Details)
+		}
+	}
+}
+
+func TestPingUnreachableLoss(t *testing.T) {
+	// TEST-NET-1 is reserved and unroutable: no external network needed.
+	// count=1 + packet_timeout=1 keeps this test to ~1-2s.
+	m := pingTestMonitor("192.0.2.1")
+	m.Config["count"] = 1
+	m.Config["packet_timeout"] = 1
+	start := time.Now()
+	res := CheckPing(context.Background(), m)
+	elapsed := time.Since(start)
+	t.Logf("unreachable ping took %s: status=%s msg=%q", elapsed, res.Status, res.Message)
+	if elapsed > 10*time.Second {
+		t.Errorf("unreachable check took too long: %s", elapsed)
+	}
+	if strings.Contains(res.Message, "missing NET_RAW capability") {
+		t.Skipf("skipping loss assertions: %s", res.Message)
+	}
+	if res.Status != StatusDown {
+		t.Fatalf("expected down, got %q", res.Status)
+	}
+	if !strings.Contains(res.Message, "packet loss 100%") {
+		t.Fatalf("expected typed 100%% loss message, got %q", res.Message)
+	}
+}
+
+func TestPingUpsideDownIgnored(t *testing.T) {
+	allowPrivateNet(t)
+	m := pingTestMonitor("127.0.0.1")
+	m.Config["count"] = 1
+	m.UpsideDown = true
+	res := CheckPing(context.Background(), m)
+	skipIfPingUnavailable(t, res)
+	// upside_down inversion is Task 7's job: a reachable host stays up here.
+	if res.Status != StatusUp {
+		t.Fatalf("expected up (upside_down ignored), got %q (%q)", res.Status, res.Message)
+	}
+}
+
+func TestPingPermissionErrorClassifier(t *testing.T) {
+	yes := []string{
+		"socket: permission denied",
+		"listen ip4:icmp 0.0.0.0: socket: operation not permitted",
+		"Operation Not Permitted",
+		"missing CAP_NET_RAW capability",
+		"privileged ping requires root",
+		"could not create socket",
+	}
+	for _, msg := range yes {
+		if !isPingPermissionError(errors.New(msg)) {
+			t.Errorf("expected permission error for %q", msg)
+		}
+	}
+	no := []error{
+		nil,
+		errors.New("no route to host"),
+		errors.New("i/o timeout"),
+		errors.New("cannot resolve host: no such host"),
+		errors.New("no reply, packet loss 100%"),
+	}
+	for _, err := range no {
+		if isPingPermissionError(err) {
+			t.Errorf("expected non-permission error for %v", err)
+		}
+	}
+}
+
+func TestPingUnavailableMessage(t *testing.T) {
+	if !strings.Contains(pingUnavailableMsg, "missing NET_RAW capability") {
+		t.Fatalf("unavailable message must contain 'missing NET_RAW capability', got %q", pingUnavailableMsg)
+	}
+}

--- a/internal/hub/monitors/checker_tls.go
+++ b/internal/hub/monitors/checker_tls.go
@@ -1,0 +1,230 @@
+package monitors
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Defaults and bounds for the TLS certificate checker (spec §6.2).
+const (
+	defaultTLSPort  = 443
+	defaultWarnDays = 21
+	defaultCritDays = 7
+	maxDNSNames     = 5
+	// emptyChainDays is returned by CertDaysLeft for an empty chain: a very
+	// negative value so callers bucket it as down.
+	emptyChainDays = -1e9
+)
+
+// tlsTestRoots is a test-only seam: when non-nil it replaces the system root
+// pool for CheckTLS so tests can trust a throwaway CA without network access.
+// Production code leaves it nil (system roots are used).
+var tlsTestRoots *x509.CertPool
+
+// CertDaysLeft returns the remaining lifetime of the leaf certificate
+// (chain[0].NotAfter - now) in fractional days. It is pure and needs no
+// network. An empty chain yields a very negative value which the caller
+// treats as down.
+func CertDaysLeft(chain []*x509.Certificate, now time.Time) float64 {
+	if len(chain) == 0 || chain[0] == nil {
+		return emptyChainDays
+	}
+	return chain[0].NotAfter.Sub(now).Hours() / 24
+}
+
+// CheckTLS performs a TLS certificate check from the hub: it opens a guarded
+// TCP connection (SSRF blocklist enforced), completes a TLS handshake with
+// full hostname verification, and evaluates certificate expiry against the
+// warn_days / crit_days thresholds. It never applies upside_down: Task 7
+// applies that inversion.
+func CheckTLS(ctx context.Context, m Monitor) CheckResult {
+	details := map[string]any{}
+	down := func(msg string) CheckResult {
+		return CheckResult{Status: StatusDown, Message: msg, Details: details}
+	}
+
+	timeout := time.Duration(m.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+
+	host, port, err := parseTLSTarget(m.Target)
+	if err != nil {
+		return down(err.Error())
+	}
+
+	warnDays := configInt(m.Config["warn_days"], defaultWarnDays)
+	critDays := configInt(m.Config["crit_days"], defaultCritDays)
+	if critDays >= warnDays {
+		return down(fmt.Sprintf("invalid thresholds: crit_days (%d) must be less than warn_days (%d)", critDays, warnDays))
+	}
+
+	serverName := strings.TrimSpace(configString(m.Config["server_name"], ""))
+	verifyHost := host
+	if serverName != "" {
+		verifyHost = serverName
+	}
+
+	ignoreTLS := configBool(m.Config["ignore_tls_errors"], false)
+	if ignoreTLS {
+		details["tls_insecure"] = true
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// TCP must go through the SSRF guard: every resolved IP is vetted and
+	// the admin-only env override is honored. GuardDialContext dials with a
+	// 5 s timeout internally; the check context adds the global timeout.
+	start := time.Now()
+	rawConn, err := GuardDialContext(reqCtx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		// The private-network block surfaces here; the guard message names
+		// it explicitly ("... are private network ...").
+		msg := fmt.Sprintf("connection failed: %v", err)
+		details["error"] = msg
+		return CheckResult{Status: StatusDown, LatencyMs: elapsedMs(start), Message: msg, Details: details}
+	}
+	defer rawConn.Close()
+
+	// tls.Client on the guarded connection + HandshakeContext honors both
+	// the guard and the check timeout. (tls.DialWithDialer pins
+	// context.Background internally, which would ignore m.TimeoutSeconds.)
+	tlsConfig := &tls.Config{
+		ServerName:         verifyHost,
+		InsecureSkipVerify: ignoreTLS,
+	}
+	if tlsTestRoots != nil {
+		tlsConfig.RootCAs = tlsTestRoots
+	}
+	tlsConn := tls.Client(rawConn, tlsConfig)
+	if err := tlsConn.HandshakeContext(reqCtx); err != nil {
+		msg := classifyTLSHandshakeError(err)
+		details["error"] = err.Error()
+		return CheckResult{Status: StatusDown, LatencyMs: elapsedMs(start), Message: msg, Details: details}
+	}
+	defer tlsConn.Close()
+
+	chain := tlsConn.ConnectionState().PeerCertificates
+	latency := elapsedMs(start)
+	if len(chain) == 0 || chain[0] == nil {
+		msg := "invalid certificate chain"
+		details["error"] = "server presented no certificates"
+		return CheckResult{Status: StatusDown, LatencyMs: latency, Message: msg, Details: details}
+	}
+	leaf := chain[0]
+	now := time.Now()
+	days := CertDaysLeft(chain, now)
+	rounded := math.Round(days*100) / 100
+
+	details["not_after"] = leaf.NotAfter.UTC().Format(time.RFC3339)
+	issuer := leaf.Issuer.CommonName
+	if issuer == "" {
+		issuer = leaf.Issuer.String()
+	}
+	details["issuer"] = issuer
+	names := leaf.DNSNames
+	if len(names) > maxDNSNames {
+		names = names[:maxDNSNames]
+	}
+	dnsNames := make([]string, len(names))
+	copy(dnsNames, names)
+	details["dns_names"] = dnsNames
+
+	res := CheckResult{LatencyMs: latency, Details: details, CertDays: &rounded}
+	switch {
+	case !now.Before(leaf.NotAfter):
+		res.Status = StatusDown
+		res.Message = "certificate expired"
+	case now.Before(leaf.NotBefore):
+		res.Status = StatusDown
+		res.Message = "invalid certificate chain"
+		details["error"] = fmt.Sprintf("certificate is not valid before %s", leaf.NotBefore.UTC().Format(time.RFC3339))
+	case days <= float64(critDays):
+		res.Status = StatusDown
+		res.Message = fmt.Sprintf("certificate expires in %.2f days", rounded)
+	case days <= float64(warnDays):
+		res.Status = StatusWarn
+		res.Message = fmt.Sprintf("certificate expires in %.2f days (warning)", rounded)
+	default:
+		res.Status = StatusUp
+		res.Message = fmt.Sprintf("certificate expires in %.2f days", rounded)
+	}
+	return res
+}
+
+// parseTLSTarget accepts a URL (https://host[:port]/...), host[:port], or a
+// bare host. The port defaults to 443 and must be 1-65535. An empty host is a
+// validation failure, never a panic.
+func parseTLSTarget(target string) (string, int, error) {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" {
+		return "", 0, fmt.Errorf("invalid target %q: target is required", target)
+	}
+	if strings.Contains(trimmed, "://") {
+		u, err := url.Parse(trimmed)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid target %q: %v", target, err)
+		}
+		host := u.Hostname()
+		if host == "" {
+			return "", 0, fmt.Errorf("invalid target %q: missing host", target)
+		}
+		port := defaultTLSPort
+		if u.Port() != "" {
+			p, err := strconv.Atoi(u.Port())
+			if err != nil || p <= 0 || p > 65535 {
+				return "", 0, fmt.Errorf("invalid target %q: invalid port", target)
+			}
+			port = p
+		}
+		return stripBrackets(host), port, nil
+	}
+	host, port, err := ParsePortOrDefault(trimmed, defaultTLSPort)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid target %q: %v", target, err)
+	}
+	if host == "" {
+		return "", 0, fmt.Errorf("invalid target %q: missing host", target)
+	}
+	return host, port, nil
+}
+
+// classifyTLSHandshakeError maps handshake failures to stable messages.
+// Messages stay fixed for tests and dashboards; the raw error lands in
+// Details["error"] for debugging.
+func classifyTLSHandshakeError(err error) string {
+	var verErr *tls.CertificateVerificationError
+	if errors.As(err, &verErr) {
+		return classifyTLSVerifyError(verErr.Err)
+	}
+	return classifyTLSVerifyError(err)
+}
+
+func classifyTLSVerifyError(err error) string {
+	var hostErr x509.HostnameError
+	if errors.As(err, &hostErr) {
+		return "hostname mismatch"
+	}
+	var invalid x509.CertificateInvalidError
+	if errors.As(err, &invalid) {
+		if invalid.Reason == x509.Expired {
+			return "certificate expired"
+		}
+		return "invalid certificate chain"
+	}
+	var unknown x509.UnknownAuthorityError
+	if errors.As(err, &unknown) {
+		return "invalid certificate chain"
+	}
+	return fmt.Sprintf("TLS handshake failed: %v", err)
+}

--- a/internal/hub/monitors/checker_tls_test.go
+++ b/internal/hub/monitors/checker_tls_test.go
@@ -1,0 +1,350 @@
+package monitors
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// tlsTestPKI is a throwaway CA used to issue server certificates for tests.
+// No external network is involved: servers listen on 127.0.0.1.
+type tlsTestPKI struct {
+	ca   *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pool *x509.CertPool
+}
+
+func newTLSTestPKI(t *testing.T) *tlsTestPKI {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tls-test-ca"},
+		NotBefore:             time.Now().Add(-2 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA cert: %v", err)
+	}
+	ca, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	return &tlsTestPKI{ca: ca, key: key, pool: pool}
+}
+
+// serverCert issues a leaf certificate signed by the test CA.
+func (p *tlsTestPKI) serverCert(t *testing.T, dns []string, ips []net.IP, notAfter time.Time) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: "tls-test-leaf"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     dns,
+		IPAddresses:  ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, p.ca, &key.PublicKey, p.key)
+	if err != nil {
+		t.Fatalf("create leaf cert: %v", err)
+	}
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+	}
+}
+
+// startTLSTestServer serves TLS handshakes on 127.0.0.1 and returns
+// the host:port address. Callers must allow the private network.
+func startTLSTestServer(t *testing.T, cert tls.Certificate) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	tlsLn := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{cert}})
+	t.Cleanup(func() { _ = tlsLn.Close() })
+	go func() {
+		for {
+			c, err := tlsLn.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				if tc, ok := c.(*tls.Conn); ok {
+					_ = tc.Handshake()
+				}
+			}()
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func tlsTestMonitor(target string) Monitor {
+	return Monitor{
+		Name:            "tls-test",
+		Type:            TypeTLS,
+		Target:          target,
+		IntervalSeconds: 60,
+		TimeoutSeconds:  5,
+		Config:          map[string]any{},
+	}
+}
+
+// withTLSTestRoots trusts the test CA for the duration of the test.
+func withTLSTestRoots(t *testing.T, pki *tlsTestPKI) {
+	t.Helper()
+	old := tlsTestRoots
+	tlsTestRoots = pki.pool
+	t.Cleanup(func() { tlsTestRoots = old })
+}
+
+func TestCertDaysLeft(t *testing.T) {
+	now := time.Now()
+	future := &x509.Certificate{NotAfter: now.Add(30 * 24 * time.Hour)}
+	if got := CertDaysLeft([]*x509.Certificate{future}, now); got < 29.9 || got > 30.1 {
+		t.Fatalf("future cert: got %v days, want ~30", got)
+	}
+	past := &x509.Certificate{NotAfter: now.Add(-24 * time.Hour)}
+	if got := CertDaysLeft([]*x509.Certificate{past}, now); got > -0.9 || got < -1.1 {
+		t.Fatalf("expired cert: got %v days, want ~-1", got)
+	}
+	if got := CertDaysLeft(nil, now); got > -1e6 {
+		t.Fatalf("empty chain: got %v, want a very negative value", got)
+	}
+	if got := CertDaysLeft([]*x509.Certificate{}, now); got > -1e6 {
+		t.Fatalf("empty chain: got %v, want a very negative value", got)
+	}
+}
+
+func TestTLSValidLongLived(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	leafNotAfter := time.Now().Add(90 * 24 * time.Hour).Truncate(time.Second)
+	dns := []string{"a.example", "b.example", "c.example", "d.example", "e.example", "f.example", "g.example"}
+	cert := pki.serverCert(t, dns, []net.IP{net.ParseIP("127.0.0.1")}, leafNotAfter)
+	addr := startTLSTestServer(t, cert)
+
+	for _, target := range []string{"https://" + addr + "/some/path", addr} {
+		res := CheckTLS(context.Background(), tlsTestMonitor(target))
+		if res.Status != StatusUp {
+			t.Fatalf("target %q: got status %q (%s), want up", target, res.Status, res.Message)
+		}
+		if !strings.Contains(res.Message, "certificate expires in") {
+			t.Fatalf("target %q: unexpected message %q", target, res.Message)
+		}
+		if res.Code != nil {
+			t.Fatalf("target %q: Code must be nil for TLS, got %d", target, *res.Code)
+		}
+		if res.CertDays == nil || *res.CertDays < 80 {
+			t.Fatalf("target %q: CertDays = %v, want ~90", target, res.CertDays)
+		}
+		notAfter, ok := res.Details["not_after"].(string)
+		if !ok {
+			t.Fatalf("target %q: Details[not_after] missing", target)
+		}
+		if ts, err := time.Parse(time.RFC3339, notAfter); err != nil || ts.Unix() != leafNotAfter.Unix() {
+			t.Fatalf("target %q: not_after = %q (err %v), want RFC3339 of leaf expiry", target, notAfter, err)
+		}
+		if res.Details["issuer"] != "tls-test-ca" {
+			t.Fatalf("target %q: issuer = %v, want tls-test-ca", target, res.Details["issuer"])
+		}
+		names, ok := res.Details["dns_names"].([]string)
+		if !ok || len(names) != 5 {
+			t.Fatalf("target %q: dns_names = %v, want first 5 of 7", target, res.Details["dns_names"])
+		}
+	}
+}
+
+func TestTLSExpiringSoonWarn(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	cert := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(10*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	res := CheckTLS(context.Background(), tlsTestMonitor(addr))
+	if res.Status != StatusWarn {
+		t.Fatalf("got status %q (%s), want warn", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "(warning)") {
+		t.Fatalf("warn message must carry (warning) suffix, got %q", res.Message)
+	}
+	if res.CertDays == nil || *res.CertDays < 9 || *res.CertDays > 11 {
+		t.Fatalf("CertDays = %v, want ~10", res.CertDays)
+	}
+}
+
+func TestTLSExpiringCritDown(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	cert := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(3*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	res := CheckTLS(context.Background(), tlsTestMonitor(addr))
+	if res.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "certificate expires in") || strings.Contains(res.Message, "(warning)") {
+		t.Fatalf("crit message must be plain expiry without (warning), got %q", res.Message)
+	}
+}
+
+func TestTLSExpiredStrictDown(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	cert := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(-24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	res := CheckTLS(context.Background(), tlsTestMonitor(addr))
+	if res.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down", res.Status, res.Message)
+	}
+	if !strings.Contains(strings.ToLower(res.Message), "expired") {
+		t.Fatalf("expired message must mention expiry, got %q", res.Message)
+	}
+}
+
+func TestTLSHostnameMismatch(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	// Cert is valid but names another host: no IP SAN matches 127.0.0.1.
+	cert := pki.serverCert(t, []string{"wrong.example"}, nil, time.Now().Add(90*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	res := CheckTLS(context.Background(), tlsTestMonitor(addr))
+	if res.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "hostname mismatch") {
+		t.Fatalf("mismatch message must contain %q, got %q", "hostname mismatch", res.Message)
+	}
+}
+
+func TestTLSServerNameOverride(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	cert := pki.serverCert(t, []string{"mytest.local"}, nil, time.Now().Add(90*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	m := tlsTestMonitor(addr)
+	m.Config["server_name"] = "mytest.local"
+	res := CheckTLS(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("got status %q (%s), want up via server_name override", res.Status, res.Message)
+	}
+}
+
+func TestTLSIgnoreErrorsSelfSigned(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t) // CA deliberately NOT trusted: no withTLSTestRoots.
+	cert := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(90*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	m := tlsTestMonitor(addr)
+	m.Config["ignore_tls_errors"] = true
+	res := CheckTLS(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("got status %q (%s), want up with ignore_tls_errors", res.Status, res.Message)
+	}
+	if res.Details["tls_insecure"] != true {
+		t.Fatalf("tls_insecure detail must be true, got %v", res.Details["tls_insecure"])
+	}
+	if res.CertDays == nil {
+		t.Fatalf("expiry must still be evaluated with ignore_tls_errors")
+	}
+
+	// Expiry is still enforced: an expired cert stays down even when ignored.
+	expired := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(-24*time.Hour))
+	expiredAddr := startTLSTestServer(t, expired)
+	m2 := tlsTestMonitor(expiredAddr)
+	m2.Config["ignore_tls_errors"] = true
+	res2 := CheckTLS(context.Background(), m2)
+	if res2.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down for expired cert despite ignore", res2.Status, res2.Message)
+	}
+	if !strings.Contains(res2.Message, "certificate expired") {
+		t.Fatalf("want explicit %q message, got %q", "certificate expired", res2.Message)
+	}
+}
+
+func TestTLSPrivateBlockedByDefault(t *testing.T) {
+	t.Setenv(allowPrivateNetworkEnv, "false")
+	m := tlsTestMonitor("127.0.0.1:443")
+	res := CheckTLS(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down for private target", res.Status, res.Message)
+	}
+	if !strings.Contains(strings.ToLower(res.Message), "private") {
+		t.Fatalf("block message must mention the private network, got %q", res.Message)
+	}
+}
+
+func TestTLSInvalidTargets(t *testing.T) {
+	allowPrivateNet(t)
+	for _, target := range []string{"", "   ", "https://", "127.0.0.1:99999", "127.0.0.1:0", "example.com:abc:def"} {
+		res := CheckTLS(context.Background(), tlsTestMonitor(target))
+		if res.Status != StatusDown {
+			t.Fatalf("target %q: got status %q (%s), want down", target, res.Status, res.Message)
+		}
+	}
+}
+
+func TestTLSInvalidThresholds(t *testing.T) {
+	allowPrivateNet(t)
+	m := tlsTestMonitor("example.com")
+	m.Config["warn_days"] = 7
+	m.Config["crit_days"] = 7
+	res := CheckTLS(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("got status %q (%s), want down for crit_days >= warn_days", res.Status, res.Message)
+	}
+	if !strings.Contains(res.Message, "crit_days") {
+		t.Fatalf("validation message must mention crit_days, got %q", res.Message)
+	}
+}
+
+func TestTLSUpsideDownNotApplied(t *testing.T) {
+	allowPrivateNet(t)
+	pki := newTLSTestPKI(t)
+	withTLSTestRoots(t, pki)
+	cert := pki.serverCert(t, nil, []net.IP{net.ParseIP("127.0.0.1")}, time.Now().Add(90*24*time.Hour))
+	addr := startTLSTestServer(t, cert)
+
+	m := tlsTestMonitor(addr)
+	m.UpsideDown = true
+	res := CheckTLS(context.Background(), m)
+	if res.Status != StatusUp {
+		t.Fatalf("upside_down must not be applied by CheckTLS: got %q (%s)", res.Status, res.Message)
+	}
+}

--- a/internal/hub/monitors/engine.go
+++ b/internal/hub/monitors/engine.go
@@ -1,0 +1,210 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// AlertSender delivers transition notifications. It mirrors
+// alerts.AlertManager.SendAlert over (userID, title, message, link) so the
+// engine stays decoupled from the alerts package (wired in hub.go).
+type AlertSender func(userID, title, message, link string)
+
+// Engine connects the scheduler, persistence and notifications for the
+// monitors stored in PocketBase.
+type Engine struct {
+	app    core.App
+	mgr    *Manager
+	send   AlertSender
+	link   func(monitorID string) string
+	mu     sync.Mutex
+	sentAt map[string]time.Time
+}
+
+// NewEngine creates an Engine. send may be nil (persist only, no notify).
+func NewEngine(app core.App, send AlertSender) *Engine {
+	e := &Engine{
+		app:    app,
+		sentAt: make(map[string]time.Time),
+		send:   send,
+		link:   func(id string) string { return "/monitors/" + id },
+	}
+	e.mgr = NewManager(0, nil, e.handleResult)
+	return e
+}
+
+// SetCheck replaces the check function (tests; production uses RunCheck).
+func (e *Engine) SetCheck(check CheckFunc) {
+	e.mgr.check = check
+}
+
+// SetLink replaces the notification link formatter.
+func (e *Engine) SetLink(link func(string) string) {
+	e.link = link
+}
+
+// Start loads non-paused monitors with stagger and begins scheduling. It
+// also binds record hooks so UI/API changes reschedule without restart.
+func (e *Engine) Start() error {
+	recs, err := LoadMonitors(e.app)
+	if err != nil {
+		return err
+	}
+	interval := 60 * time.Second
+	delay := StaggerDelay(interval, len(recs))
+	for i, mr := range recs {
+		if i > 0 && delay > 0 {
+			time.Sleep(delay)
+		}
+		if err := mr.ToMonitor().Validate(); err != nil {
+			slog.Warn("monitors: skipping invalid monitor", "monitor", mr.Name, "err", err)
+			continue
+		}
+		e.mgr.AddRecord(mr)
+	}
+	e.app.OnRecordAfterCreateSuccess("monitors").BindFunc(e.onCreate)
+	e.app.OnRecordAfterUpdateSuccess("monitors").BindFunc(e.onUpdate)
+	e.app.OnRecordAfterDeleteSuccess("monitors").BindFunc(e.onDelete)
+	e.app.OnTerminate().BindFunc(func(ev *core.TerminateEvent) error {
+		e.Stop()
+		return ev.Next()
+	})
+	return nil
+}
+
+func (e *Engine) onCreate(ev *core.RecordEvent) error {
+	mr := recordToMonitor(ev.Record)
+	if mr.Paused {
+		return ev.Next()
+	}
+	if err := mr.ToMonitor().Validate(); err != nil {
+		return ev.Next()
+	}
+	e.mgr.AddRecord(mr)
+	return ev.Next()
+}
+
+func (e *Engine) onUpdate(ev *core.RecordEvent) error {
+	mr := recordToMonitor(ev.Record)
+	e.mgr.Remove(mr.ID)
+	if mr.Paused {
+		return ev.Next()
+	}
+	if err := mr.ToMonitor().Validate(); err != nil {
+		return ev.Next()
+	}
+	e.mgr.AddRecord(mr)
+	return ev.Next()
+}
+
+func (e *Engine) onDelete(ev *core.RecordEvent) error {
+	e.mgr.Remove(ev.Record.Id)
+	e.mu.Lock()
+	delete(e.sentAt, ev.Record.Id)
+	e.mu.Unlock()
+	return ev.Next()
+}
+
+// SyncOne runs one persisted check cycle for a monitor id. It loads the
+// record fresh (paused monitors are skipped), runs the check with timeout,
+// folds it through a state seeded from consecutive_failures, persists the
+// cycle in one transaction, and notifies on transitions.
+func (e *Engine) SyncOne(id string) error {
+	rec, err := e.app.FindRecordById("monitors", id)
+	if err != nil {
+		return err
+	}
+	mr := recordToMonitor(rec)
+	if mr.Paused {
+		return nil
+	}
+	m := mr.ToMonitor()
+	timeout := time.Duration(m.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	check := RunCheck
+	if e.mgr.check != nil {
+		check = e.mgr.check
+	}
+	res := check(ctx, m)
+	st := newMonitorState(m)
+	st.consec = mr.ConsecutiveFailure
+	// Seed from the stored status so a fresh state still sees transitions
+	// (e.g. stored down followed by up must notify recovery).
+	switch mr.Status {
+	case StatusUp, StatusDown, StatusWarn:
+		st.current = mr.Status
+	}
+	res, transition := st.applyResult(res)
+	e.persistAndNotify(mr, res, st.failures(), transition)
+	return nil
+}
+
+// handleResult is the scheduler callback. Monitors scheduled via AddID
+// carry their record id, so the row is resolved without name lookups.
+func (e *Engine) handleResult(m Monitor, res CheckResult, transition bool, failures int) {
+	if m.ID == "" {
+		return
+	}
+	rec, err := e.app.FindRecordById("monitors", m.ID)
+	if err != nil {
+		return
+	}
+	mr := recordToMonitor(rec)
+	e.persistAndNotify(mr, res, failures, transition)
+}
+
+// persistAndNotify persists one cycle then notifies on transitions.
+// mr identifies the monitor row; res is debounced; failures is exact.
+func (e *Engine) persistAndNotify(mr MonitorRecord, res CheckResult, failures int, transition bool) {
+	if err := SaveCheckResult(e.app, mr, res, failures, transition); err != nil {
+		slog.Error("monitors: failed to save check result", "monitor", mr.Name, "err", err)
+		return
+	}
+	if !transition || !mr.Notify || e.send == nil {
+		return
+	}
+	now := time.Now()
+	e.mu.Lock()
+	if res.Status == StatusDown && mr.ResendAfter > 0 {
+		if last, ok := e.sentAt[mr.ID]; ok && now.Sub(last) < time.Duration(mr.ResendAfter)*time.Minute {
+			e.mu.Unlock()
+			return
+		}
+	}
+	if res.Status == StatusDown {
+		e.sentAt[mr.ID] = now
+	} else {
+		delete(e.sentAt, mr.ID)
+	}
+	e.mu.Unlock()
+
+	var title, message string
+	switch res.Status {
+	case StatusDown:
+		title = fmt.Sprintf("Monitor down: %s", mr.Name)
+		message = fmt.Sprintf("%s is down: %s", mr.Target, res.Message)
+	case StatusWarn:
+		title = fmt.Sprintf("Monitor warning: %s", mr.Name)
+		message = fmt.Sprintf("%s: %s", mr.Target, res.Message)
+	default:
+		title = fmt.Sprintf("Monitor recovered: %s", mr.Name)
+		message = fmt.Sprintf("%s is back up", mr.Target)
+	}
+	for _, userID := range mr.UserIDs {
+		e.send(userID, title, message, e.link(mr.ID))
+	}
+}
+
+// Stop halts all scheduled monitors.
+func (e *Engine) Stop() {
+	e.mgr.Stop()
+}

--- a/internal/hub/monitors/engine.go
+++ b/internal/hub/monitors/engine.go
@@ -124,6 +124,7 @@ func (e *Engine) onDelete(ev *core.RecordEvent) error {
 	e.mgr.Remove(ev.Record.Id)
 	e.mu.Lock()
 	delete(e.sentAt, ev.Record.Id)
+	delete(e.downSince, ev.Record.Id)
 	e.mu.Unlock()
 	return ev.Next()
 }
@@ -170,10 +171,12 @@ func (e *Engine) SyncOne(id string) error {
 // carry their record id, so the row is resolved without name lookups.
 func (e *Engine) handleResult(m Monitor, res CheckResult, transition bool, failures int) {
 	if m.ID == "" {
+		slog.Debug("monitors: dropping result without record id", "monitor", m.Name)
 		return
 	}
 	rec, err := e.app.FindRecordById("monitors", m.ID)
 	if err != nil {
+		slog.Debug("monitors: dropping result for deleted monitor", "id", m.ID, "err", err)
 		return
 	}
 	mr := recordToMonitor(rec)

--- a/internal/hub/monitors/engine.go
+++ b/internal/hub/monitors/engine.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pocketbase/pocketbase/core"
@@ -24,15 +25,20 @@ type Engine struct {
 	link   func(monitorID string) string
 	mu     sync.Mutex
 	sentAt map[string]time.Time
+	// downSince tracks when the current DOWN stretch started (for recovery
+	// duration and resend decisions).
+	downSince map[string]time.Time
+	started   atomic.Bool
 }
 
 // NewEngine creates an Engine. send may be nil (persist only, no notify).
 func NewEngine(app core.App, send AlertSender) *Engine {
 	e := &Engine{
-		app:    app,
-		sentAt: make(map[string]time.Time),
-		send:   send,
-		link:   func(id string) string { return "/monitors/" + id },
+		app:       app,
+		sentAt:    make(map[string]time.Time),
+		downSince: make(map[string]time.Time),
+		send:      send,
+		link:      func(id string) string { return "/monitors/" + id },
 	}
 	e.mgr = NewManager(0, nil, e.handleResult)
 	return e
@@ -50,7 +56,11 @@ func (e *Engine) SetLink(link func(string) string) {
 
 // Start loads non-paused monitors with stagger and begins scheduling. It
 // also binds record hooks so UI/API changes reschedule without restart.
+// Calling Start twice is a no-op for hooks (loops are replace-safe).
 func (e *Engine) Start() error {
+	if !e.started.CompareAndSwap(false, true) {
+		return nil
+	}
 	recs, err := LoadMonitors(e.app)
 	if err != nil {
 		return err
@@ -93,6 +103,14 @@ func (e *Engine) onUpdate(ev *core.RecordEvent) error {
 	mr := recordToMonitor(ev.Record)
 	e.mgr.Remove(mr.ID)
 	if mr.Paused {
+		// Pause stops the loop; drop resend/down bookkeeping. The
+		// consecutive_failures reset is written by the API PATCH handler,
+		// the only writer of the paused flag (writing here would recurse
+		// into this hook).
+		e.mu.Lock()
+		delete(e.sentAt, mr.ID)
+		delete(e.downSince, mr.ID)
+		e.mu.Unlock()
 		return ev.Next()
 	}
 	if err := mr.ToMonitor().Validate(); err != nil {
@@ -162,42 +180,63 @@ func (e *Engine) handleResult(m Monitor, res CheckResult, transition bool, failu
 	e.persistAndNotify(mr, res, failures, transition)
 }
 
-// persistAndNotify persists one cycle then notifies on transitions.
+// persistAndNotify persists one cycle then notifies.
 // mr identifies the monitor row; res is debounced; failures is exact.
+// Notification rules: transitions (up→down, down→up, warn in/out) always
+// notify when mr.Notify; a steady DOWN renotifies only after ResendAfter
+// minutes since the last DOWN notice (0 = never).
 func (e *Engine) persistAndNotify(mr MonitorRecord, res CheckResult, failures int, transition bool) {
 	if err := SaveCheckResult(e.app, mr, res, failures, transition); err != nil {
 		slog.Error("monitors: failed to save check result", "monitor", mr.Name, "err", err)
 		return
 	}
-	if !transition || !mr.Notify || e.send == nil {
+	if !mr.Notify || e.send == nil {
 		return
 	}
 	now := time.Now()
 	e.mu.Lock()
+	if _, ok := e.downSince[mr.ID]; !ok && res.Status == StatusDown {
+		e.downSince[mr.ID] = now
+	}
+	notify := transition
 	if res.Status == StatusDown && mr.ResendAfter > 0 {
-		if last, ok := e.sentAt[mr.ID]; ok && now.Sub(last) < time.Duration(mr.ResendAfter)*time.Minute {
-			e.mu.Unlock()
-			return
+		if last, ok := e.sentAt[mr.ID]; !ok || now.Sub(last) >= time.Duration(mr.ResendAfter)*time.Minute {
+			notify = true
 		}
 	}
-	if res.Status == StatusDown {
+	if notify {
 		e.sentAt[mr.ID] = now
-	} else {
+	}
+	downStart, wasDown := e.downSince[mr.ID]
+	if res.Status != StatusDown {
+		delete(e.downSince, mr.ID)
 		delete(e.sentAt, mr.ID)
 	}
 	e.mu.Unlock()
+	if !notify {
+		return
+	}
 
 	var title, message string
 	switch res.Status {
 	case StatusDown:
 		title = fmt.Sprintf("Monitor down: %s", mr.Name)
-		message = fmt.Sprintf("%s is down: %s", mr.Target, res.Message)
+		message = fmt.Sprintf("%s is down: %s (latency %.1f ms)", mr.Target, res.Message, res.LatencyMs)
 	case StatusWarn:
 		title = fmt.Sprintf("Monitor warning: %s", mr.Name)
 		message = fmt.Sprintf("%s: %s", mr.Target, res.Message)
+		if res.CertDays != nil {
+			message += fmt.Sprintf(" (%.0f days left)", *res.CertDays)
+		}
 	default:
 		title = fmt.Sprintf("Monitor recovered: %s", mr.Name)
 		message = fmt.Sprintf("%s is back up", mr.Target)
+		if wasDown {
+			message += fmt.Sprintf(" after %s", now.Sub(downStart).Round(time.Second))
+		}
+		if uptime, err := Uptime24h(e.app, mr.ID); err == nil && uptime > 0 {
+			message += fmt.Sprintf(" (24h uptime %.1f%%)", uptime)
+		}
 	}
 	for _, userID := range mr.UserIDs {
 		e.send(userID, title, message, e.link(mr.ID))

--- a/internal/hub/monitors/engine.go
+++ b/internal/hub/monitors/engine.go
@@ -54,6 +54,14 @@ func (e *Engine) SetLink(link func(string) string) {
 	e.link = link
 }
 
+// TestAdd schedules m with check (testing only: bypasses validation and
+// stagger for fast loop-driven tests).
+func (e *Engine) TestAdd(m Monitor, check CheckFunc) {
+	e.mgr.check = check
+	e.mgr.jitterMax = 0
+	e.mgr.AddID(m.ID, m)
+}
+
 // Start loads non-paused monitors with stagger and begins scheduling. It
 // also binds record hooks so UI/API changes reschedule without restart.
 // Calling Start twice is a no-op for hooks (loops are replace-safe).
@@ -67,6 +75,11 @@ func (e *Engine) Start() error {
 	}
 	interval := 60 * time.Second
 	delay := StaggerDelay(interval, len(recs))
+	// Cap total boot stagger: per-monitor loops already jitter 0-5s, so a
+	// few seconds here only avoid a thundering herd without delaying serve.
+	if d := delay * time.Duration(max(1, len(recs))); d > 5*time.Second && len(recs) > 0 {
+		delay = 5 * time.Second / time.Duration(len(recs))
+	}
 	for i, mr := range recs {
 		if i > 0 && delay > 0 {
 			time.Sleep(delay)
@@ -101,6 +114,20 @@ func (e *Engine) onCreate(ev *core.RecordEvent) error {
 
 func (e *Engine) onUpdate(ev *core.RecordEvent) error {
 	mr := recordToMonitor(ev.Record)
+	// Scheduler writes (status, last_check, latency, uptime, failures) on
+	// every cycle via SaveNoValidate: rescheduling on those would churn
+	// Remove+Add per cycle AND deadlock (Remove waits for the loop that is
+	// currently inside runOnce). Only reschedule when schedule-relevant
+	// fields changed.
+	if !scheduleRelevantChange(ev.Record) {
+		if mr.Paused {
+			e.mu.Lock()
+			delete(e.sentAt, mr.ID)
+			delete(e.downSince, mr.ID)
+			e.mu.Unlock()
+		}
+		return ev.Next()
+	}
 	e.mgr.Remove(mr.ID)
 	if mr.Paused {
 		// Pause stops the loop; drop resend/down bookkeeping. The
@@ -127,6 +154,26 @@ func (e *Engine) onDelete(ev *core.RecordEvent) error {
 	delete(e.downSince, ev.Record.Id)
 	e.mu.Unlock()
 	return ev.Next()
+}
+
+// scheduleRelevantChange reports whether schedule-driving fields changed.
+// Status/latency/uptime/failure writes from the scheduler itself must not
+// reschedule (churn + self-join deadlock via Remove's wg.Wait).
+func scheduleRelevantChange(rec *core.Record) bool {
+	orig := rec.Original()
+	if orig == nil {
+		return true
+	}
+	for _, f := range []string{"name", "type", "target", "interval", "timeout", "max_retries", "upside_down", "paused", "config"} {
+		if !recordFieldEqual(orig.Get(f), rec.Get(f)) {
+			return true
+		}
+	}
+	return false
+}
+
+func recordFieldEqual(a, b any) bool {
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
 }
 
 // SyncOne runs one persisted check cycle for a monitor id. It loads the

--- a/internal/hub/monitors/engine_internal_test.go
+++ b/internal/hub/monitors/engine_internal_test.go
@@ -1,0 +1,93 @@
+//go:build testing
+
+package monitors
+
+import (
+	"testing"
+	"time"
+
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineInternal_ResendRefiresAfterWindow(t *testing.T) {
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "re@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mon := core.NewRecord(col)
+	mon.Set("name", "refire")
+	mon.Set("type", "ping")
+	mon.Set("target", "example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("max_retries", 0)
+	mon.Set("notify", true)
+	mon.Set("resend_after", 60)
+	mon.Set("status", "down")
+	mon.Set("consecutive_failures", 1)
+	mon.Set("users", []string{user.Id})
+	require.NoError(t, app.Save(mon))
+
+	var count int
+	eng := NewEngine(app, func(userID, title, message, link string) { count++ })
+	// Pretend the last DOWN notice was 2h ago: the next steady DOWN must
+	// renotify even without a transition.
+	eng.sentAt[mon.Id] = time.Now().Add(-2 * time.Hour)
+	mr := recordToMonitor(mon)
+	res := CheckResult{Status: StatusDown, Message: "still down"}
+	eng.persistAndNotify(mr, res, 2, false)
+	assert.Equal(t, 1, count, "steady DOWN past the resend window must renotify")
+
+	// Inside the window: silent.
+	eng.persistAndNotify(mr, res, 3, false)
+	assert.Equal(t, 1, count, "steady DOWN inside the window must stay silent")
+}
+
+func TestEngineInternal_NoResendWhenZero(t *testing.T) {
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "nore@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mon := core.NewRecord(col)
+	mon.Set("name", "noresend")
+	mon.Set("type", "ping")
+	mon.Set("target", "example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("max_retries", 0)
+	mon.Set("notify", true)
+	mon.Set("resend_after", 0)
+	mon.Set("status", "down")
+	mon.Set("users", []string{user.Id})
+	require.NoError(t, app.Save(mon))
+
+	var count int
+	eng := NewEngine(app, func(userID, title, message, link string) { count++ })
+	mr := recordToMonitor(mon)
+	eng.persistAndNotify(mr, CheckResult{Status: StatusDown, Message: "x"}, 1, false)
+	eng.persistAndNotify(mr, CheckResult{Status: StatusDown, Message: "x"}, 2, false)
+	assert.Equal(t, 0, count, "resend_after=0 must never renotify steady DOWN")
+}

--- a/internal/hub/monitors/engine_test.go
+++ b/internal/hub/monitors/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/henrygd/beszel/internal/hub/monitors"
 	_ "github.com/henrygd/beszel/internal/migrations"
@@ -223,4 +224,36 @@ func TestEngine_RecoveryMessageHasDurationAndUptime(t *testing.T) {
 	assert.Contains(t, messages[0], "/monitors/"+mon.Id, "link must carry monitor id")
 	assert.Contains(t, messages[1], "after ", "recovery must carry down duration")
 	assert.Contains(t, messages[1], "uptime", "recovery must carry 24h uptime")
+}
+
+func TestEngine_LiveLoopSurvivesOwnWrites(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "live", true, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	require.NoError(t, eng.Start())
+	t.Cleanup(eng.Stop)
+
+	// Drive the scheduler loop directly with a 1s interval: each tick
+	// persists via SaveCheckResult, which fires the monitors update hook.
+	// Before the scheduleRelevantChange guard this deadlocked (Remove waits
+	// for the loop running runOnce) and wedged the semaphore.
+	m := monitors.Monitor{ID: mon.Id, Name: "live", Type: monitors.TypePing, Target: "example.com", IntervalSeconds: 1, TimeoutSeconds: 5}
+	eng.TestAdd(m, func(ctx context.Context, mm monitors.Monitor) monitors.CheckResult {
+		return monitors.CheckResult{Status: monitors.StatusUp, LatencyMs: 1}
+	})
+
+	deadline := time.Now().Add(12 * time.Second)
+	for {
+		total, err := app.CountRecords("monitor_checks")
+		require.NoError(t, err)
+		if total >= 3 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("live loop stalled: only %d cycles in 12s (hook deadlock?)", total)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
 }

--- a/internal/hub/monitors/engine_test.go
+++ b/internal/hub/monitors/engine_test.go
@@ -172,3 +172,55 @@ func TestEngine_WarnTransitionNotifies(t *testing.T) {
 
 	assert.Equal(t, 1, sender.count(), "warn entry must notify once")
 }
+
+func TestEngine_WarnExitNotifiesRecovery(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "warnexit", true, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	warn := true
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		if warn {
+			return monitors.CheckResult{Status: monitors.StatusWarn, Message: "expiring soon"}
+		}
+		return monitors.CheckResult{Status: monitors.StatusUp, LatencyMs: 2}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	warn = false
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	assert.Equal(t, 2, sender.count(), "warn entry then recovery must notify twice")
+}
+
+func TestEngine_RecoveryMessageHasDurationAndUptime(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "rich", true, 0)
+	var messages []string
+	var mu sync.Mutex
+	eng := monitors.NewEngine(app, func(userID, title, message, link string) {
+		mu.Lock()
+		messages = append(messages, title+"|"+message+"|"+link)
+		mu.Unlock()
+	})
+	down := true
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		if down {
+			return monitors.CheckResult{Status: monitors.StatusDown, Message: "boom", LatencyMs: 42}
+		}
+		return monitors.CheckResult{Status: monitors.StatusUp, LatencyMs: 1}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	down = false
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, messages, 2)
+	assert.Contains(t, messages[0], "latency 42.0 ms", "down notice must carry latency")
+	assert.Contains(t, messages[0], "/monitors/"+mon.Id, "link must carry monitor id")
+	assert.Contains(t, messages[1], "after ", "recovery must carry down duration")
+	assert.Contains(t, messages[1], "uptime", "recovery must carry 24h uptime")
+}

--- a/internal/hub/monitors/engine_test.go
+++ b/internal/hub/monitors/engine_test.go
@@ -1,0 +1,174 @@
+//go:build testing
+
+package monitors_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/henrygd/beszel/internal/hub/monitors"
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sentAlert struct {
+	userID string
+	title  string
+}
+
+type fakeSender struct {
+	mu   sync.Mutex
+	sent []sentAlert
+}
+
+func (f *fakeSender) Send(userID, title, message, link string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, sentAlert{userID: userID, title: title})
+}
+
+func (f *fakeSender) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.sent)
+}
+
+func seedEngineMonitor(t *testing.T, app *pbtests.TestApp, name string, notify bool, maxRetries int) (*core.Record, *core.Record) {
+	t.Helper()
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", name+"@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mon := core.NewRecord(col)
+	mon.Set("name", name)
+	mon.Set("type", "ping")
+	mon.Set("target", "example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("max_retries", maxRetries)
+	mon.Set("notify", notify)
+	mon.Set("status", "pending")
+	mon.Set("users", []string{user.Id})
+	require.NoError(t, app.Save(mon))
+	return mon, user
+}
+
+func newEngineTestApp(t *testing.T) *pbtests.TestApp {
+	t.Helper()
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+	return app
+}
+
+func TestEngine_DownTransitionPersistsAndNotifies(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, user := seedEngineMonitor(t, app, "eng", true, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		return monitors.CheckResult{Status: monitors.StatusDown, Message: "boom"}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	stored, err := app.FindRecordById("monitors", mon.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "down", stored.GetString("status"))
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+
+	assert.Equal(t, 1, sender.count(), "one DOWN transition must notify once")
+	sender.mu.Lock()
+	title := sender.sent[0].title
+	uid := sender.sent[0].userID
+	sender.mu.Unlock()
+	assert.Contains(t, title, "eng")
+	assert.Equal(t, user.Id, uid)
+}
+
+func TestEngine_SilentWhenNotifyFalse(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "quiet", false, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		return monitors.CheckResult{Status: monitors.StatusDown, Message: "boom"}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	assert.Equal(t, 0, sender.count(), "notify=false must stay silent")
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total, "silent monitors are still recorded")
+}
+
+func TestEngine_RecoveryNotifies(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "flap", true, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	down := true
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		if down {
+			return monitors.CheckResult{Status: monitors.StatusDown, Message: "boom"}
+		}
+		return monitors.CheckResult{Status: monitors.StatusUp, LatencyMs: 1}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	down = false
+	// Reload failures like the scheduler loop would, then sync again.
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	assert.Equal(t, 2, sender.count(), "down then recovery must notify twice")
+}
+
+func TestEngine_ResendAfterSuppressesImmediateRepeat(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "resend", true, 0)
+	mon.Set("resend_after", 60)
+	require.NoError(t, app.Save(mon))
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		return monitors.CheckResult{Status: monitors.StatusDown, Message: "boom"}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	assert.Equal(t, 1, sender.count(), "second DOWN inside resend window must not renotify")
+}
+
+func TestEngine_WarnTransitionNotifies(t *testing.T) {
+	app := newEngineTestApp(t)
+	mon, _ := seedEngineMonitor(t, app, "tlswarn", true, 0)
+	sender := &fakeSender{}
+
+	eng := monitors.NewEngine(app, sender.Send)
+	eng.SetCheck(func(ctx context.Context, m monitors.Monitor) monitors.CheckResult {
+		return monitors.CheckResult{Status: monitors.StatusWarn, Message: "expiring soon"}
+	})
+	require.NoError(t, eng.SyncOne(mon.Id))
+	eng.Stop()
+
+	assert.Equal(t, 1, sender.count(), "warn entry must notify once")
+}

--- a/internal/hub/monitors/load_test.go
+++ b/internal/hub/monitors/load_test.go
@@ -1,0 +1,91 @@
+//go:build testing
+
+package monitors_test
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/henrygd/beszel/internal/hub/monitors"
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/pocketbase/core"
+	pbtests "github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoad_ManyMonitorsRapidCycles simulates 50 monitors with fast cycles
+// and asserts: no database lock errors, bounded table growth, scheduler p99
+// under 1s. Short-mode skips the heavy variant in CI.
+func TestLoad_ManyMonitorsRapidCycles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("heavy load test, skipped in short mode")
+	}
+	app, err := pbtests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "load@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	const n = 50
+	for i := 0; i < n; i++ {
+		m := core.NewRecord(col)
+		m.Set("name", fmt.Sprintf("load-%02d", i))
+		m.Set("type", "ping")
+		m.Set("target", "example.com")
+		m.Set("interval", 60)
+		m.Set("timeout", 10)
+		m.Set("max_retries", 2)
+		m.Set("status", "up")
+		m.Set("users", []string{user.Id})
+		require.NoError(t, app.Save(m))
+	}
+
+	recs, err := monitors.LoadMonitors(app)
+	require.NoError(t, err)
+	require.Len(t, recs, n)
+
+	var lockErrors atomic.Int64
+	var wg sync.WaitGroup
+	start := time.Now()
+	const cycles = 20
+	for _, rec := range recs {
+		wg.Add(1)
+		go func(mr monitors.MonitorRecord) {
+			defer wg.Done()
+			for i := 0; i < cycles; i++ {
+				res := monitors.CheckResult{Status: monitors.StatusUp, LatencyMs: 1.5}
+				if err := monitors.SaveCheckResult(app, mr, res, 0, false); err != nil {
+					if strings.Contains(err.Error(), "database is locked") || strings.Contains(err.Error(), "busy") {
+						lockErrors.Add(1)
+					} else {
+						t.Errorf("unexpected save error: %v", err)
+						return
+					}
+				}
+			}
+		}(rec)
+	}
+	wg.Wait()
+	elapsed := time.Since(start)
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	require.EqualValues(t, n*cycles, total)
+	require.Zero(t, lockErrors.Load(), "no database lock errors allowed")
+
+	perCycleMs := float64(elapsed.Milliseconds()) / float64(n*cycles)
+	t.Logf("wrote %d rows in %s (%.2f ms/cycle)", total, elapsed, perCycleMs)
+	require.Less(t, perCycleMs, 1000.0, "scheduler budget: <1s per cycle")
+}

--- a/internal/hub/monitors/manager.go
+++ b/internal/hub/monitors/manager.go
@@ -35,11 +35,12 @@ func (r MonitorRecord) ToMonitor() Monitor {
 	}
 }
 
-// RecordStore persists check results. It is implemented by the PocketBase
-// hub (see LoadMonitors/SaveCheckResult) and faked in tests.
+// RecordStore persists check results. It mirrors the LoadMonitors and
+// SaveCheckResult free functions (failures = exact scheduler-owned count,
+// transition reserved for Task 10 notifications) and is faked in tests.
 type RecordStore interface {
 	LoadMonitors(ctx context.Context) ([]MonitorRecord, error)
-	SaveCheckResult(ctx context.Context, rec MonitorRecord, res CheckResult, transition bool) error
+	SaveCheckResult(ctx context.Context, rec MonitorRecord, res CheckResult, failures int, transition bool) error
 }
 
 // LoadMonitors reads all non-paused monitors from the monitors collection.

--- a/internal/hub/monitors/manager.go
+++ b/internal/hub/monitors/manager.go
@@ -19,6 +19,9 @@ type MonitorRecord struct {
 	MaxRetries         int
 	UpsideDown         bool
 	Paused             bool
+	Notify             bool
+	ResendAfter        int
+	Status             string
 	Config             map[string]any
 	ConsecutiveFailure int
 }
@@ -60,8 +63,10 @@ func recordToMonitor(rec *core.Record) MonitorRecord {
 		ID: rec.Id, Name: rec.GetString("name"),
 		Type: MonitorType(rec.GetString("type")), Target: rec.GetString("target"),
 		UpsideDown: rec.GetBool("upside_down"), Paused: rec.GetBool("paused"),
+		Notify: rec.GetBool("notify"), Status: rec.GetString("status"),
 		ConsecutiveFailure: int(rec.GetFloat("consecutive_failures")),
 	}
+	m.ResendAfter = int(rec.GetFloat("resend_after"))
 	m.IntervalSeconds = int(rec.GetFloat("interval"))
 	if m.IntervalSeconds <= 0 {
 		m.IntervalSeconds = 60
@@ -79,7 +84,12 @@ func recordToMonitor(rec *core.Record) MonitorRecord {
 // SaveCheckResult writes one check cycle in a single transaction: the
 // monitor_checks history row plus the monitors status update. One
 // transaction per cycle bounds SQLite single-writer pressure.
-func SaveCheckResult(app core.App, rec MonitorRecord, res CheckResult, transition bool) error {
+//
+// Ownership: the scheduler (Task 7) owns debouncing and the failure count.
+// res.Status must already be the debounced status and failures the exact
+// consecutive-failure count (state.failures()); this function persists them
+// verbatim and never recounts, so overlapping cycles cannot lose updates.
+func SaveCheckResult(app core.App, rec MonitorRecord, res CheckResult, failures int, transition bool) error {
 	_ = transition
 	return app.RunInTransaction(func(txApp core.App) error {
 		checksCol, err := txApp.FindCachedCollectionByNameOrId("monitor_checks")
@@ -114,18 +124,14 @@ func SaveCheckResult(app core.App, rec MonitorRecord, res CheckResult, transitio
 		if res.CertDays != nil {
 			mon.Set("cert_days", *res.CertDays)
 		}
-		failures := rec.ConsecutiveFailure
-		if res.Status == StatusUp {
-			failures = 0
-		} else if res.Status == StatusDown {
-			failures++
-		}
 		mon.Set("consecutive_failures", failures)
 		return txApp.SaveNoValidate(mon)
 	})
 }
 
 // Uptime24h computes the success ratio over the last 24h from history.
+// Warn counts as success: the endpoint answers (e.g. a TLS cert nearing
+// expiry is not an outage).
 func Uptime24h(app core.App, monitorID string) (float64, error) {
 	var rows []struct {
 		Status string `db:"status"`
@@ -140,7 +146,7 @@ func Uptime24h(app core.App, monitorID string) (float64, error) {
 	var up, total int
 	for _, r := range rows {
 		total += r.Count
-		if r.Status == StatusUp {
+		if r.Status == StatusUp || r.Status == StatusWarn {
 			up += r.Count
 		}
 	}

--- a/internal/hub/monitors/manager.go
+++ b/internal/hub/monitors/manager.go
@@ -22,6 +22,7 @@ type MonitorRecord struct {
 	Notify             bool
 	ResendAfter        int
 	Status             string
+	UserIDs            []string
 	Config             map[string]any
 	ConsecutiveFailure int
 }
@@ -29,11 +30,18 @@ type MonitorRecord struct {
 // ToMonitor converts a record to a scheduler Monitor.
 func (r MonitorRecord) ToMonitor() Monitor {
 	return Monitor{
+		ID:   r.ID,
 		Name: r.Name, Type: r.Type, Target: r.Target,
 		IntervalSeconds: r.IntervalSeconds, TimeoutSeconds: r.TimeoutSeconds,
 		MaxRetries: r.MaxRetries, UpsideDown: r.UpsideDown, Config: r.Config,
 	}
 }
+
+// GetID, GetStatus, GetFailures satisfy scheduler.MonitorRecordLike for
+// boot seeding without renotifying known states.
+func (r MonitorRecord) GetID() string     { return r.ID }
+func (r MonitorRecord) GetStatus() string { return r.Status }
+func (r MonitorRecord) GetFailures() int  { return r.ConsecutiveFailure }
 
 // RecordStore persists check results. It mirrors the LoadMonitors and
 // SaveCheckResult free functions (failures = exact scheduler-owned count,
@@ -65,6 +73,7 @@ func recordToMonitor(rec *core.Record) MonitorRecord {
 		Type: MonitorType(rec.GetString("type")), Target: rec.GetString("target"),
 		UpsideDown: rec.GetBool("upside_down"), Paused: rec.GetBool("paused"),
 		Notify: rec.GetBool("notify"), Status: rec.GetString("status"),
+		UserIDs:            rec.GetStringSlice("users"),
 		ConsecutiveFailure: int(rec.GetFloat("consecutive_failures")),
 	}
 	m.ResendAfter = int(rec.GetFloat("resend_after"))

--- a/internal/hub/monitors/manager.go
+++ b/internal/hub/monitors/manager.go
@@ -1,0 +1,151 @@
+package monitors
+
+import (
+	"context"
+	"time"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// MonitorRecord maps the monitors collection fields used by the scheduler.
+type MonitorRecord struct {
+	ID                 string
+	Name               string
+	Type               MonitorType
+	Target             string
+	IntervalSeconds    int
+	TimeoutSeconds     int
+	MaxRetries         int
+	UpsideDown         bool
+	Paused             bool
+	Config             map[string]any
+	ConsecutiveFailure int
+}
+
+// ToMonitor converts a record to a scheduler Monitor.
+func (r MonitorRecord) ToMonitor() Monitor {
+	return Monitor{
+		Name: r.Name, Type: r.Type, Target: r.Target,
+		IntervalSeconds: r.IntervalSeconds, TimeoutSeconds: r.TimeoutSeconds,
+		MaxRetries: r.MaxRetries, UpsideDown: r.UpsideDown, Config: r.Config,
+	}
+}
+
+// RecordStore persists check results. It is implemented by the PocketBase
+// hub (see LoadMonitors/SaveCheckResult) and faked in tests.
+type RecordStore interface {
+	LoadMonitors(ctx context.Context) ([]MonitorRecord, error)
+	SaveCheckResult(ctx context.Context, rec MonitorRecord, res CheckResult, transition bool) error
+}
+
+// LoadMonitors reads all non-paused monitors from the monitors collection.
+func LoadMonitors(app core.App) ([]MonitorRecord, error) {
+	records, err := app.FindAllRecords("monitors")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]MonitorRecord, 0, len(records))
+	for _, rec := range records {
+		if rec.GetBool("paused") {
+			continue
+		}
+		out = append(out, recordToMonitor(rec))
+	}
+	return out, nil
+}
+
+func recordToMonitor(rec *core.Record) MonitorRecord {
+	m := MonitorRecord{
+		ID: rec.Id, Name: rec.GetString("name"),
+		Type: MonitorType(rec.GetString("type")), Target: rec.GetString("target"),
+		UpsideDown: rec.GetBool("upside_down"), Paused: rec.GetBool("paused"),
+		ConsecutiveFailure: int(rec.GetFloat("consecutive_failures")),
+	}
+	m.IntervalSeconds = int(rec.GetFloat("interval"))
+	if m.IntervalSeconds <= 0 {
+		m.IntervalSeconds = 60
+	}
+	m.TimeoutSeconds = int(rec.GetFloat("timeout"))
+	if m.TimeoutSeconds <= 0 {
+		m.TimeoutSeconds = 10
+	}
+	m.MaxRetries = int(rec.GetFloat("max_retries"))
+	m.Config = map[string]any{}
+	_ = rec.UnmarshalJSONField("config", &m.Config)
+	return m
+}
+
+// SaveCheckResult writes one check cycle in a single transaction: the
+// monitor_checks history row plus the monitors status update. One
+// transaction per cycle bounds SQLite single-writer pressure.
+func SaveCheckResult(app core.App, rec MonitorRecord, res CheckResult, transition bool) error {
+	_ = transition
+	return app.RunInTransaction(func(txApp core.App) error {
+		checksCol, err := txApp.FindCachedCollectionByNameOrId("monitor_checks")
+		if err != nil {
+			return err
+		}
+		check := core.NewRecord(checksCol)
+		check.Set("monitor", rec.ID)
+		check.Set("status", res.Status)
+		check.Set("latency_ms", res.LatencyMs)
+		if res.Code != nil {
+			check.Set("code", *res.Code)
+		}
+		check.Set("message", res.Message)
+		if len(res.Details) > 0 {
+			check.Set("details", res.Details)
+		}
+		if res.CertDays != nil {
+			check.Set("cert_days", *res.CertDays)
+		}
+		if err := txApp.SaveNoValidate(check); err != nil {
+			return err
+		}
+
+		mon, err := txApp.FindRecordById("monitors", rec.ID)
+		if err != nil {
+			return err
+		}
+		mon.Set("status", res.Status)
+		mon.Set("last_check", time.Now().UTC())
+		mon.Set("last_latency_ms", res.LatencyMs)
+		if res.CertDays != nil {
+			mon.Set("cert_days", *res.CertDays)
+		}
+		failures := rec.ConsecutiveFailure
+		if res.Status == StatusUp {
+			failures = 0
+		} else if res.Status == StatusDown {
+			failures++
+		}
+		mon.Set("consecutive_failures", failures)
+		return txApp.SaveNoValidate(mon)
+	})
+}
+
+// Uptime24h computes the success ratio over the last 24h from history.
+func Uptime24h(app core.App, monitorID string) (float64, error) {
+	var rows []struct {
+		Status string `db:"status"`
+		Count  int    `db:"cnt"`
+	}
+	cutoff := time.Now().UTC().Add(-24 * time.Hour)
+	err := app.DB().NewQuery("SELECT status, COUNT(*) as cnt FROM monitor_checks WHERE monitor = {:mon} AND created >= {:cutoff} GROUP BY status").
+		Bind(dbx.Params{"mon": monitorID, "cutoff": cutoff}).All(&rows)
+	if err != nil {
+		return 0, err
+	}
+	var up, total int
+	for _, r := range rows {
+		total += r.Count
+		if r.Status == StatusUp {
+			up += r.Count
+		}
+	}
+	if total == 0 {
+		return 0, nil
+	}
+	return float64(up) / float64(total) * 100, nil
+}

--- a/internal/hub/monitors/manager_test.go
+++ b/internal/hub/monitors/manager_test.go
@@ -57,7 +57,7 @@ func TestSaveCheckResult_WritesHistoryAndStatusAtomically(t *testing.T) {
 
 	code := 200
 	res := monitors.CheckResult{Status: "up", LatencyMs: 12.5, Code: &code, Message: "ok", Details: map[string]any{"final_url": "https://example.com"}}
-	require.NoError(t, monitors.SaveCheckResult(app, recs[0], res, false))
+	require.NoError(t, monitors.SaveCheckResult(app, recs[0], res, 0, false))
 
 	updated, err := app.FindRecordById("monitors", mon.Id)
 	require.NoError(t, err)
@@ -79,14 +79,14 @@ func TestSaveCheckResult_TracksConsecutiveFailures(t *testing.T) {
 	rec := recs[0]
 
 	down := monitors.CheckResult{Status: "down", Message: "boom"}
-	require.NoError(t, monitors.SaveCheckResult(app, rec, down, false))
+	require.NoError(t, monitors.SaveCheckResult(app, rec, down, 1, false))
 	updated, err := app.FindRecordById("monitors", rec.ID)
 	require.NoError(t, err)
 	assert.EqualValues(t, 1, updated.GetFloat("consecutive_failures"))
 
 	recs, err = monitors.LoadMonitors(app)
 	require.NoError(t, err)
-	require.NoError(t, monitors.SaveCheckResult(app, recs[0], monitors.CheckResult{Status: "up"}, false))
+	require.NoError(t, monitors.SaveCheckResult(app, recs[0], monitors.CheckResult{Status: "up"}, 0, false))
 	updated, err = app.FindRecordById("monitors", rec.ID)
 	require.NoError(t, err)
 	assert.EqualValues(t, 0, updated.GetFloat("consecutive_failures"))
@@ -120,6 +120,12 @@ func TestUptime24h_ComputesRatio(t *testing.T) {
 	require.NoError(t, err)
 	assert.InDelta(t, 75.0, ratio, 0.001)
 
+	// Warn counts as success: the endpoint answers.
+	insert("warn", 1)
+	ratio, err = monitors.Uptime24h(app, mon.Id)
+	require.NoError(t, err)
+	assert.InDelta(t, 80.0, ratio, 0.001)
+
 	empty, err := monitors.Uptime24h(app, "nonexistent")
 	require.NoError(t, err)
 	assert.Equal(t, 0.0, empty)
@@ -128,7 +134,7 @@ func TestUptime24h_ComputesRatio(t *testing.T) {
 func TestSaveCheckResult_RejectsUnknownMonitor(t *testing.T) {
 	app := newMonitorTestApp(t)
 	rec := monitors.MonitorRecord{ID: "does-not-exist", Name: "x"}
-	err := monitors.SaveCheckResult(app, rec, monitors.CheckResult{Status: "up"}, false)
+	err := monitors.SaveCheckResult(app, rec, monitors.CheckResult{Status: "up"}, 0, false)
 	require.Error(t, err, "saving for unknown monitor must fail the transaction")
 
 	total, err := app.CountRecords("monitor_checks")

--- a/internal/hub/monitors/manager_test.go
+++ b/internal/hub/monitors/manager_test.go
@@ -1,0 +1,137 @@
+//go:build testing
+
+package monitors_test
+
+import (
+	"testing"
+
+	"github.com/henrygd/beszel/internal/hub/monitors"
+	_ "github.com/henrygd/beszel/internal/migrations"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMonitorTestApp(t *testing.T) *tests.TestApp {
+	t.Helper()
+	app, err := tests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { app.Cleanup() })
+	return app
+}
+
+func seedMonitor(t *testing.T, app *tests.TestApp) *core.Record {
+	t.Helper()
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "w@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	col, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mon := core.NewRecord(col)
+	mon.Set("name", "web")
+	mon.Set("type", "http")
+	mon.Set("target", "https://example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("max_retries", 2)
+	mon.Set("status", "pending")
+	mon.Set("users", []string{user.Id})
+	require.NoError(t, app.Save(mon))
+	return mon
+}
+
+func TestSaveCheckResult_WritesHistoryAndStatusAtomically(t *testing.T) {
+	app := newMonitorTestApp(t)
+	mon := seedMonitor(t, app)
+
+	recs, err := monitors.LoadMonitors(app)
+	require.NoError(t, err)
+	require.Len(t, recs, 1)
+
+	code := 200
+	res := monitors.CheckResult{Status: "up", LatencyMs: 12.5, Code: &code, Message: "ok", Details: map[string]any{"final_url": "https://example.com"}}
+	require.NoError(t, monitors.SaveCheckResult(app, recs[0], res, false))
+
+	updated, err := app.FindRecordById("monitors", mon.Id)
+	require.NoError(t, err)
+	assert.Equal(t, "up", updated.GetString("status"))
+	assert.Equal(t, 12.5, updated.GetFloat("last_latency_ms"))
+	assert.False(t, updated.GetDateTime("last_check").IsZero())
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, total)
+}
+
+func TestSaveCheckResult_TracksConsecutiveFailures(t *testing.T) {
+	app := newMonitorTestApp(t)
+	seedMonitor(t, app)
+
+	recs, err := monitors.LoadMonitors(app)
+	require.NoError(t, err)
+	rec := recs[0]
+
+	down := monitors.CheckResult{Status: "down", Message: "boom"}
+	require.NoError(t, monitors.SaveCheckResult(app, rec, down, false))
+	updated, err := app.FindRecordById("monitors", rec.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, updated.GetFloat("consecutive_failures"))
+
+	recs, err = monitors.LoadMonitors(app)
+	require.NoError(t, err)
+	require.NoError(t, monitors.SaveCheckResult(app, recs[0], monitors.CheckResult{Status: "up"}, false))
+	updated, err = app.FindRecordById("monitors", rec.ID)
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, updated.GetFloat("consecutive_failures"))
+}
+
+func TestLoadMonitors_SkipsPaused(t *testing.T) {
+	app := newMonitorTestApp(t)
+	mon := seedMonitor(t, app)
+	mon.Set("paused", true)
+	require.NoError(t, app.Save(mon))
+
+	recs, err := monitors.LoadMonitors(app)
+	require.NoError(t, err)
+	assert.Empty(t, recs)
+}
+
+func TestUptime24h_ComputesRatio(t *testing.T) {
+	app := newMonitorTestApp(t)
+	mon := seedMonitor(t, app)
+
+	insert := func(status string, n int) {
+		for range n {
+			_, err := app.DB().NewQuery("INSERT INTO monitor_checks (monitor, status, created, updated) VALUES ({:mon}, {:st}, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)").Bind(dbx.Params{"mon": mon.Id, "st": status}).Execute()
+			require.NoError(t, err)
+		}
+	}
+	insert("up", 3)
+	insert("down", 1)
+
+	ratio, err := monitors.Uptime24h(app, mon.Id)
+	require.NoError(t, err)
+	assert.InDelta(t, 75.0, ratio, 0.001)
+
+	empty, err := monitors.Uptime24h(app, "nonexistent")
+	require.NoError(t, err)
+	assert.Equal(t, 0.0, empty)
+}
+
+func TestSaveCheckResult_RejectsUnknownMonitor(t *testing.T) {
+	app := newMonitorTestApp(t)
+	rec := monitors.MonitorRecord{ID: "does-not-exist", Name: "x"}
+	err := monitors.SaveCheckResult(app, rec, monitors.CheckResult{Status: "up"}, false)
+	require.Error(t, err, "saving for unknown monitor must fail the transaction")
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, total, "failed transaction must leave no history row")
+}

--- a/internal/hub/monitors/models.go
+++ b/internal/hub/monitors/models.go
@@ -34,8 +34,10 @@ const (
 	MaxRetries         = 10
 )
 
-// Monitor describes a single uptime check configuration.
+// Monitor describes a single uptime check configuration. ID carries the
+// monitors record id when loaded from the database; checkers ignore it.
 type Monitor struct {
+	ID              string
 	Name            string
 	Type            MonitorType
 	Target          string

--- a/internal/hub/monitors/models.go
+++ b/internal/hub/monitors/models.go
@@ -1,0 +1,79 @@
+// Package monitors implements external uptime monitoring (PR1: hub-only).
+// It provides HTTP/keyword, TLS certificate, DNS and ping checkers executed
+// from the hub, with PocketBase persistence, REST API and alert transitions.
+package monitors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MonitorType identifies the kind of check a monitor performs.
+type MonitorType string
+
+// Supported monitor types.
+const (
+	TypeHTTP    MonitorType = "http"
+	TypeKeyword MonitorType = "keyword"
+	TypePing    MonitorType = "ping"
+	TypeDNS     MonitorType = "dns"
+	TypeTLS     MonitorType = "tls"
+)
+
+// Check result statuses.
+const (
+	StatusUp   = "up"
+	StatusDown = "down"
+	StatusWarn = "warn"
+)
+
+// Validation bounds shared by the API and config sync.
+const (
+	MinIntervalSeconds = 20
+	MaxIntervalSeconds = 86400
+	MaxRetries         = 10
+)
+
+// Monitor describes a single uptime check configuration.
+type Monitor struct {
+	Name            string
+	Type            MonitorType
+	Target          string
+	IntervalSeconds int
+	TimeoutSeconds  int
+	MaxRetries      int
+	UpsideDown      bool
+	Config          map[string]any
+}
+
+// CheckResult is the outcome of a single check attempt.
+type CheckResult struct {
+	Status    string
+	LatencyMs float64
+	Code      *int
+	Message   string
+	Details   map[string]any
+	CertDays  *float64
+}
+
+// Validate checks monitor configuration bounds.
+func (m Monitor) Validate() error {
+	switch m.Type {
+	case TypeHTTP, TypeKeyword, TypePing, TypeDNS, TypeTLS:
+	default:
+		return fmt.Errorf("unknown monitor type %q", m.Type)
+	}
+	if m.Target == "" {
+		return errors.New("target is required")
+	}
+	if m.IntervalSeconds < MinIntervalSeconds || m.IntervalSeconds > MaxIntervalSeconds {
+		return fmt.Errorf("interval must be %d..%d seconds", MinIntervalSeconds, MaxIntervalSeconds)
+	}
+	if m.TimeoutSeconds <= 0 || m.TimeoutSeconds >= m.IntervalSeconds {
+		return errors.New("timeout must be > 0 and < interval")
+	}
+	if m.MaxRetries < 0 || m.MaxRetries > MaxRetries {
+		return fmt.Errorf("max_retries must be 0..%d", MaxRetries)
+	}
+	return nil
+}

--- a/internal/hub/monitors/models_test.go
+++ b/internal/hub/monitors/models_test.go
@@ -1,0 +1,42 @@
+package monitors
+
+import "testing"
+
+func TestValidate_TimeoutMustBeLessThanInterval(t *testing.T) {
+	m := Monitor{Name: "t", Type: TypeHTTP, Target: "https://example.com", IntervalSeconds: 60, TimeoutSeconds: 60, MaxRetries: 2}
+	if err := m.Validate(); err == nil {
+		t.Fatal("expected error when timeout >= interval")
+	}
+}
+
+func TestValidate_ValidMonitor(t *testing.T) {
+	m := Monitor{Name: "t", Type: TypeHTTP, Target: "https://example.com", IntervalSeconds: 60, TimeoutSeconds: 10, MaxRetries: 2}
+	if err := m.Validate(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidate_UnknownType(t *testing.T) {
+	m := Monitor{Name: "t", Type: "gopher", Target: "example.com", IntervalSeconds: 60, TimeoutSeconds: 10}
+	if err := m.Validate(); err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+}
+
+func TestValidate_IntervalBounds(t *testing.T) {
+	for _, interval := range []int{0, 19, 86401} {
+		m := Monitor{Name: "t", Type: TypePing, Target: "example.com", IntervalSeconds: interval, TimeoutSeconds: 10}
+		if err := m.Validate(); err == nil {
+			t.Fatalf("expected error for interval %d", interval)
+		}
+	}
+}
+
+func TestValidate_MaxRetriesBounds(t *testing.T) {
+	for _, retries := range []int{-1, 11} {
+		m := Monitor{Name: "t", Type: TypePing, Target: "example.com", IntervalSeconds: 60, TimeoutSeconds: 10, MaxRetries: retries}
+		if err := m.Validate(); err == nil {
+			t.Fatalf("expected error for max_retries %d", retries)
+		}
+	}
+}

--- a/internal/hub/monitors/scheduler.go
+++ b/internal/hub/monitors/scheduler.go
@@ -111,7 +111,7 @@ type Manager struct {
 	sem       chan struct{}
 	maxConc   int
 	check     CheckFunc
-	onResult  func(m Monitor, res CheckResult, transition bool)
+	onResult  func(m Monitor, res CheckResult, transition bool, failures int)
 	jitterMax time.Duration
 }
 
@@ -137,6 +137,8 @@ type managedMonitor struct {
 	ctx     context.Context
 	cancel  context.CancelFunc
 	wg      sync.WaitGroup
+	// key is the manager map key (record id via AddID, else monitor name).
+	key     string
 	running atomic.Bool
 	skipped atomic.Uint64
 	// saturated counts ticks dropped because the global semaphore was full
@@ -147,7 +149,7 @@ type managedMonitor struct {
 // NewManager creates a Manager. maxConcurrent <= 0 selects
 // DefaultMaxConcurrent; the MONITORS_MAX_CONCURRENT env var overrides,
 // clamped to [1, MaxConcurrentCap].
-func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res CheckResult, transition bool)) *Manager {
+func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res CheckResult, transition bool, failures int)) *Manager {
 	maxConcurrent = resolveMaxConcurrent(maxConcurrent)
 	if check == nil {
 		check = RunCheck
@@ -165,15 +167,58 @@ func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res
 // Add starts scheduling checks for m, keyed by name. Re-adding cancels the
 // previous entry and waits for its loop before replacing it, so no orphaned
 // goroutine survives. Callers loading many monitors at boot should stagger
-// Add calls (see StaggerDelay); Task 8 keys by monitor ID instead to avoid
-// same-name collisions across users.
+// Add calls (see StaggerDelay). Prefer AddID (stable across renames and
+// users) when a record id is available.
 func (mgr *Manager) Add(m Monitor) {
+	mgr.add(m.Name, m)
+}
+
+// AddID is Add keyed by an external id (the monitors record id). Same-name
+// monitors from different users no longer collide.
+func (mgr *Manager) AddID(id string, m Monitor) {
+	mgr.add(id, m)
+}
+
+// AddRecord schedules a monitor seeded from its stored state, so a restart
+// neither renotifies a known DOWN nor loses the failure count.
+func (mgr *Manager) AddRecord(mr MonitorRecordLike) {
+	m := mr.ToMonitor()
+	mm := &managedMonitor{monitor: m, state: newMonitorState(m)}
+	mm.state.consec = mr.GetFailures()
+	switch mr.GetStatus() {
+	case StatusUp, StatusDown, StatusWarn:
+		mm.state.current = mr.GetStatus()
+	}
+	mm.ctx, mm.cancel = context.WithCancel(context.Background())
+	mm.wg.Add(1)
+	mm.key = mr.GetID()
+	mgr.mu.Lock()
+	old, dup := mgr.monitors[mr.GetID()]
+	mgr.monitors[mr.GetID()] = mm
+	mgr.mu.Unlock()
+	if dup {
+		old.cancel()
+		old.wg.Wait()
+	}
+	go mgr.loop(mm)
+}
+
+// MonitorRecordLike is the stored-state subset needed to seed scheduling.
+type MonitorRecordLike interface {
+	GetID() string
+	GetStatus() string
+	GetFailures() int
+	ToMonitor() Monitor
+}
+
+func (mgr *Manager) add(key string, m Monitor) {
 	mm := &managedMonitor{monitor: m, state: newMonitorState(m)}
 	mm.ctx, mm.cancel = context.WithCancel(context.Background())
 	mm.wg.Add(1)
+	mm.key = key
 	mgr.mu.Lock()
-	old, dup := mgr.monitors[m.Name]
-	mgr.monitors[m.Name] = mm
+	old, dup := mgr.monitors[key]
+	mgr.monitors[key] = mm
 	mgr.mu.Unlock()
 	if dup {
 		old.cancel()
@@ -322,14 +367,14 @@ func (mgr *Manager) runOnce(mm *managedMonitor) {
 		// Skip delivery if the monitor was removed mid-run: the loop may
 		// still be inside runOnce when Remove/Stop cancels.
 		mgr.mu.Lock()
-		current, ok := mgr.monitors[mm.monitor.Name]
+		current, ok := mgr.monitors[mm.key]
 		stale := !ok || current != mm
 		mgr.mu.Unlock()
 		if stale {
 			return
 		}
 		if mgr.onResult != nil {
-			mgr.onResult(mm.monitor, res, transition)
+			mgr.onResult(mm.monitor, res, transition, mm.state.failures())
 		}
 	}()
 }

--- a/internal/hub/monitors/scheduler.go
+++ b/internal/hub/monitors/scheduler.go
@@ -304,29 +304,32 @@ func (mgr *Manager) runOnce(mm *managedMonitor) {
 	}
 	ctx, cancel := context.WithTimeout(mm.ctx, timeout)
 	defer cancel()
-	// The recover covers check, state fold and delivery so a panicking
-	// onResult (e.g. a failing DB write in Task 8) degrades to a failed
+	// The recover covers check, state fold and delivery so a panicking check
+	// or onResult (e.g. a failing DB write in Task 8) degrades to a failed
 	// attempt instead of killing the monitor's loop silently.
-	res, transition := func() (res CheckResult, transition bool) {
+	func() {
+		var res CheckResult
+		var transition bool
 		defer func() {
 			if r := recover(); r != nil {
+				slog.Error("monitors: check panic recovered", "monitor", mm.monitor.Name, "panic", r)
 				res = CheckResult{Status: StatusDown, Message: fmt.Sprintf("checker panic: %v", r)}
 				res, transition = mm.state.applyResult(res)
 			}
 		}()
 		res = mgr.check(ctx, mm.monitor)
-		return mm.state.applyResult(res)
+		res, transition = mm.state.applyResult(res)
+		// Skip delivery if the monitor was removed mid-run: the loop may
+		// still be inside runOnce when Remove/Stop cancels.
+		mgr.mu.Lock()
+		current, ok := mgr.monitors[mm.monitor.Name]
+		stale := !ok || current != mm
+		mgr.mu.Unlock()
+		if stale {
+			return
+		}
+		if mgr.onResult != nil {
+			mgr.onResult(mm.monitor, res, transition)
+		}
 	}()
-	// Skip delivery if the monitor was removed mid-run: the loop may still
-	// be inside runOnce when Remove/Stop cancels.
-	mgr.mu.Lock()
-	current, ok := mgr.monitors[mm.monitor.Name]
-	stale := !ok || current != mm
-	mgr.mu.Unlock()
-	if stale {
-		return
-	}
-	if mgr.onResult != nil {
-		mgr.onResult(mm.monitor, res, transition)
-	}
 }

--- a/internal/hub/monitors/scheduler.go
+++ b/internal/hub/monitors/scheduler.go
@@ -1,0 +1,239 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DefaultMaxConcurrent caps simultaneous check runs across all monitors.
+const DefaultMaxConcurrent = 10
+
+// monitorState tracks consecutive failures and the current status of one
+// monitor. It is the single place where raw check results become a status,
+// including upside_down inversion.
+type monitorState struct {
+	mu      sync.Mutex
+	monitor Monitor
+	consec  int
+	current string
+	warn    bool
+}
+
+// newMonitorState creates state starting from up (fresh monitor).
+func newMonitorState(m Monitor) *monitorState {
+	return &monitorState{monitor: m, current: StatusUp}
+}
+
+// applyResult folds a raw check result into the state and returns the
+// effective result after upside_down inversion and retry counting.
+func (s *monitorState) applyResult(res CheckResult) CheckResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.monitor.UpsideDown {
+		switch res.Status {
+		case StatusUp:
+			res.Status = StatusDown
+		case StatusDown:
+			res.Status = StatusUp
+		}
+	}
+	switch res.Status {
+	case StatusUp:
+		s.consec = 0
+		s.current = StatusUp
+		s.warn = false
+	case StatusWarn:
+		s.consec = 0
+		s.current = StatusWarn
+		s.warn = true
+	default:
+		s.consec++
+		if s.consec > s.monitor.MaxRetries {
+			s.current = StatusDown
+		}
+	}
+	return res
+}
+
+func (s *monitorState) status() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current
+}
+
+func (s *monitorState) failures() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.consec
+}
+
+// RunCheck dispatches to the checker matching the monitor type.
+func RunCheck(ctx context.Context, m Monitor) CheckResult {
+	switch m.Type {
+	case TypeHTTP, TypeKeyword:
+		return CheckHTTP(ctx, m)
+	case TypeTLS:
+		return CheckTLS(ctx, m)
+	case TypeDNS:
+		return CheckDNS(ctx, m)
+	case TypePing:
+		return CheckPing(ctx, m)
+	default:
+		return CheckResult{Status: StatusDown, Message: fmt.Sprintf("unknown monitor type %q", m.Type)}
+	}
+}
+
+// CheckFunc performs one check attempt. It defaults to RunCheck and is
+// replaceable in tests.
+type CheckFunc func(ctx context.Context, m Monitor) CheckResult
+
+// Manager schedules periodic checks for a set of monitors.
+type Manager struct {
+	mu        sync.Mutex
+	monitors  map[string]*managedMonitor
+	sem       chan struct{}
+	maxConc   int
+	check     CheckFunc
+	onResult  func(m Monitor, res CheckResult)
+	jitterMax time.Duration
+}
+
+type managedMonitor struct {
+	monitor Monitor
+	state   *monitorState
+	ctx     context.Context
+	cancel  context.CancelFunc
+	running atomic.Bool
+	skipped uint64
+}
+
+// NewManager creates a Manager. maxConcurrent <= 0 selects DefaultMaxConcurrent.
+func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res CheckResult)) *Manager {
+	if maxConcurrent <= 0 {
+		maxConcurrent = DefaultMaxConcurrent
+	}
+	if check == nil {
+		check = RunCheck
+	}
+	return &Manager{
+		monitors:  make(map[string]*managedMonitor),
+		sem:       make(chan struct{}, maxConcurrent),
+		maxConc:   maxConcurrent,
+		check:     check,
+		onResult:  onResult,
+		jitterMax: 5 * time.Second,
+	}
+}
+
+// Add starts scheduling checks for m (keyed by name+target). Re-adding
+// replaces the previous entry.
+func (mgr *Manager) Add(m Monitor) {
+	mgr.Remove(m.Name)
+	ctx, cancel := context.WithCancel(context.Background())
+	mm := &managedMonitor{monitor: m, state: newMonitorState(m), ctx: ctx, cancel: cancel}
+	mgr.mu.Lock()
+	mgr.monitors[m.Name] = mm
+	mgr.mu.Unlock()
+	go mgr.loop(mm)
+}
+
+// Remove stops scheduling for the named monitor.
+func (mgr *Manager) Remove(name string) {
+	mgr.mu.Lock()
+	mm, ok := mgr.monitors[name]
+	if ok {
+		delete(mgr.monitors, name)
+	}
+	mgr.mu.Unlock()
+	if ok {
+		mm.cancel()
+	}
+}
+
+// Stop cancels all scheduled monitors.
+func (mgr *Manager) Stop() {
+	mgr.mu.Lock()
+	mms := make([]*managedMonitor, 0, len(mgr.monitors))
+	for _, mm := range mgr.monitors {
+		mms = append(mms, mm)
+	}
+	mgr.monitors = make(map[string]*managedMonitor)
+	mgr.mu.Unlock()
+	for _, mm := range mms {
+		mm.cancel()
+	}
+}
+
+// Skipped returns the number of ticks skipped due to overlap for a monitor.
+func (mgr *Manager) Skipped(name string) uint64 {
+	mgr.mu.Lock()
+	mm, ok := mgr.monitors[name]
+	mgr.mu.Unlock()
+	if !ok {
+		return 0
+	}
+	return atomic.LoadUint64(&mm.skipped)
+}
+
+func (mgr *Manager) loop(mm *managedMonitor) {
+	interval := time.Duration(mm.monitor.IntervalSeconds) * time.Second
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	// Initial jitter spreads load when many monitors start together.
+	if mgr.jitterMax > 0 {
+		select {
+		case <-mm.ctx.Done():
+			return
+		case <-time.After(time.Duration(rand.Int64N(int64(mgr.jitterMax)))):
+		}
+	}
+	mgr.runOnce(mm)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-mm.ctx.Done():
+			return
+		case <-ticker.C:
+			mgr.runOnce(mm)
+		}
+	}
+}
+
+func (mgr *Manager) runOnce(mm *managedMonitor) {
+	if !mm.running.CompareAndSwap(false, true) {
+		atomic.AddUint64(&mm.skipped, 1)
+		return
+	}
+	defer mm.running.Store(false)
+	select {
+	case mgr.sem <- struct{}{}:
+		defer func() { <-mgr.sem }()
+	default:
+		atomic.AddUint64(&mm.skipped, 1)
+		return
+	}
+	timeout := time.Duration(mm.monitor.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = defaultCheckTimeout
+	}
+	ctx, cancel := context.WithTimeout(mm.ctx, timeout)
+	defer cancel()
+	res := func() (res CheckResult) {
+		defer func() {
+			if r := recover(); r != nil {
+				res = CheckResult{Status: StatusDown, Message: fmt.Sprintf("checker panic: %v", r)}
+			}
+		}()
+		return mgr.check(ctx, mm.monitor)
+	}()
+	res = mm.state.applyResult(res)
+	if mgr.onResult != nil {
+		mgr.onResult(mm.monitor, res)
+	}
+}

--- a/internal/hub/monitors/scheduler.go
+++ b/internal/hub/monitors/scheduler.go
@@ -3,14 +3,22 @@ package monitors
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"math/rand/v2"
+	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
 // DefaultMaxConcurrent caps simultaneous check runs across all monitors.
-const DefaultMaxConcurrent = 10
+const (
+	DefaultMaxConcurrent = 10
+	MaxConcurrentCap     = 50
+	// maxConcurrentEnv overrides the semaphore size (admin-only, lab use).
+	maxConcurrentEnv = "MONITORS_MAX_CONCURRENT"
+)
 
 // monitorState tracks consecutive failures and the current status of one
 // monitor. It is the single place where raw check results become a status,
@@ -29,8 +37,11 @@ func newMonitorState(m Monitor) *monitorState {
 }
 
 // applyResult folds a raw check result into the state and returns the
-// effective result after upside_down inversion and retry counting.
-func (s *monitorState) applyResult(res CheckResult) CheckResult {
+// effective result after upside_down inversion and retry debouncing: the
+// returned Status is the debounced state, so transient single failures do
+// not surface as down while failures <= max_retries. It also reports
+// whether the debounced status changed on this attempt (for transitions).
+func (s *monitorState) applyResult(res CheckResult) (CheckResult, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.monitor.UpsideDown {
@@ -41,6 +52,7 @@ func (s *monitorState) applyResult(res CheckResult) CheckResult {
 			res.Status = StatusUp
 		}
 	}
+	prev := s.current
 	switch res.Status {
 	case StatusUp:
 		s.consec = 0
@@ -56,7 +68,8 @@ func (s *monitorState) applyResult(res CheckResult) CheckResult {
 			s.current = StatusDown
 		}
 	}
-	return res
+	res.Status = s.current
+	return res, s.current != prev
 }
 
 func (s *monitorState) status() string {
@@ -98,8 +111,24 @@ type Manager struct {
 	sem       chan struct{}
 	maxConc   int
 	check     CheckFunc
-	onResult  func(m Monitor, res CheckResult)
+	onResult  func(m Monitor, res CheckResult, transition bool)
 	jitterMax time.Duration
+}
+
+// resolveMaxConcurrent applies the admin env override, default and cap.
+func resolveMaxConcurrent(n int) int {
+	if env, ok := os.LookupEnv(maxConcurrentEnv); ok {
+		if parsed, err := strconv.Atoi(env); err == nil {
+			n = parsed
+		}
+	}
+	if n <= 0 {
+		n = DefaultMaxConcurrent
+	}
+	if n > MaxConcurrentCap {
+		n = MaxConcurrentCap
+	}
+	return n
 }
 
 type managedMonitor struct {
@@ -107,15 +136,19 @@ type managedMonitor struct {
 	state   *monitorState
 	ctx     context.Context
 	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 	running atomic.Bool
-	skipped uint64
+	skipped atomic.Uint64
+	// saturated counts ticks dropped because the global semaphore was full
+	// (kept separate from overlap skips).
+	saturated atomic.Uint64
 }
 
-// NewManager creates a Manager. maxConcurrent <= 0 selects DefaultMaxConcurrent.
-func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res CheckResult)) *Manager {
-	if maxConcurrent <= 0 {
-		maxConcurrent = DefaultMaxConcurrent
-	}
+// NewManager creates a Manager. maxConcurrent <= 0 selects
+// DefaultMaxConcurrent; the MONITORS_MAX_CONCURRENT env var overrides,
+// clamped to [1, MaxConcurrentCap].
+func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res CheckResult, transition bool)) *Manager {
+	maxConcurrent = resolveMaxConcurrent(maxConcurrent)
 	if check == nil {
 		check = RunCheck
 	}
@@ -129,19 +162,41 @@ func NewManager(maxConcurrent int, check CheckFunc, onResult func(m Monitor, res
 	}
 }
 
-// Add starts scheduling checks for m (keyed by name+target). Re-adding
-// replaces the previous entry.
+// Add starts scheduling checks for m, keyed by name. Re-adding cancels the
+// previous entry and waits for its loop before replacing it, so no orphaned
+// goroutine survives. Callers loading many monitors at boot should stagger
+// Add calls (see StaggerDelay); Task 8 keys by monitor ID instead to avoid
+// same-name collisions across users.
 func (mgr *Manager) Add(m Monitor) {
-	mgr.Remove(m.Name)
-	ctx, cancel := context.WithCancel(context.Background())
-	mm := &managedMonitor{monitor: m, state: newMonitorState(m), ctx: ctx, cancel: cancel}
+	mm := &managedMonitor{monitor: m, state: newMonitorState(m)}
+	mm.ctx, mm.cancel = context.WithCancel(context.Background())
+	mm.wg.Add(1)
 	mgr.mu.Lock()
+	old, dup := mgr.monitors[m.Name]
 	mgr.monitors[m.Name] = mm
 	mgr.mu.Unlock()
+	if dup {
+		old.cancel()
+		old.wg.Wait()
+	}
 	go mgr.loop(mm)
 }
 
-// Remove stops scheduling for the named monitor.
+// StaggerDelay returns the boot stagger between Add calls for n monitors,
+// mirroring SystemManager: interval/n capped at 2 seconds.
+func StaggerDelay(interval time.Duration, n int) time.Duration {
+	if n <= 0 {
+		return 0
+	}
+	d := interval / time.Duration(n)
+	if d > 2*time.Second {
+		d = 2 * time.Second
+	}
+	return d
+}
+
+// Remove stops scheduling for the named monitor and waits for its loop,
+// so no stale onResult delivery happens after return.
 func (mgr *Manager) Remove(name string) {
 	mgr.mu.Lock()
 	mm, ok := mgr.monitors[name]
@@ -151,10 +206,11 @@ func (mgr *Manager) Remove(name string) {
 	mgr.mu.Unlock()
 	if ok {
 		mm.cancel()
+		mm.wg.Wait()
 	}
 }
 
-// Stop cancels all scheduled monitors.
+// Stop cancels all scheduled monitors and waits for every loop.
 func (mgr *Manager) Stop() {
 	mgr.mu.Lock()
 	mms := make([]*managedMonitor, 0, len(mgr.monitors))
@@ -166,30 +222,54 @@ func (mgr *Manager) Stop() {
 	for _, mm := range mms {
 		mm.cancel()
 	}
+	for _, mm := range mms {
+		mm.wg.Wait()
+	}
 }
 
-// Skipped returns the number of ticks skipped due to overlap for a monitor.
+// Skipped returns overlap skips for a monitor.
 func (mgr *Manager) Skipped(name string) uint64 {
+	return mgr.skipped(name, false)
+}
+
+// Saturated returns semaphore-saturation drops for a monitor.
+func (mgr *Manager) Saturated(name string) uint64 {
+	return mgr.skipped(name, true)
+}
+
+func (mgr *Manager) skipped(name string, saturated bool) uint64 {
 	mgr.mu.Lock()
 	mm, ok := mgr.monitors[name]
 	mgr.mu.Unlock()
 	if !ok {
 		return 0
 	}
-	return atomic.LoadUint64(&mm.skipped)
+	if saturated {
+		return mm.saturated.Load()
+	}
+	return mm.skipped.Load()
 }
 
 func (mgr *Manager) loop(mm *managedMonitor) {
+	defer mm.wg.Done()
+	// Recover so one bad callback never kills a monitor silently.
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("monitors: loop panic recovered", "monitor", mm.monitor.Name, "panic", r)
+		}
+	}()
 	interval := time.Duration(mm.monitor.IntervalSeconds) * time.Second
 	if interval <= 0 {
 		interval = time.Minute
 	}
 	// Initial jitter spreads load when many monitors start together.
 	if mgr.jitterMax > 0 {
+		timer := time.NewTimer(time.Duration(rand.Int64N(int64(mgr.jitterMax))))
 		select {
 		case <-mm.ctx.Done():
+			timer.Stop()
 			return
-		case <-time.After(time.Duration(rand.Int64N(int64(mgr.jitterMax)))):
+		case <-timer.C:
 		}
 	}
 	mgr.runOnce(mm)
@@ -207,7 +287,7 @@ func (mgr *Manager) loop(mm *managedMonitor) {
 
 func (mgr *Manager) runOnce(mm *managedMonitor) {
 	if !mm.running.CompareAndSwap(false, true) {
-		atomic.AddUint64(&mm.skipped, 1)
+		mm.skipped.Add(1)
 		return
 	}
 	defer mm.running.Store(false)
@@ -215,7 +295,7 @@ func (mgr *Manager) runOnce(mm *managedMonitor) {
 	case mgr.sem <- struct{}{}:
 		defer func() { <-mgr.sem }()
 	default:
-		atomic.AddUint64(&mm.skipped, 1)
+		mm.saturated.Add(1)
 		return
 	}
 	timeout := time.Duration(mm.monitor.TimeoutSeconds) * time.Second
@@ -224,16 +304,29 @@ func (mgr *Manager) runOnce(mm *managedMonitor) {
 	}
 	ctx, cancel := context.WithTimeout(mm.ctx, timeout)
 	defer cancel()
-	res := func() (res CheckResult) {
+	// The recover covers check, state fold and delivery so a panicking
+	// onResult (e.g. a failing DB write in Task 8) degrades to a failed
+	// attempt instead of killing the monitor's loop silently.
+	res, transition := func() (res CheckResult, transition bool) {
 		defer func() {
 			if r := recover(); r != nil {
 				res = CheckResult{Status: StatusDown, Message: fmt.Sprintf("checker panic: %v", r)}
+				res, transition = mm.state.applyResult(res)
 			}
 		}()
-		return mgr.check(ctx, mm.monitor)
+		res = mgr.check(ctx, mm.monitor)
+		return mm.state.applyResult(res)
 	}()
-	res = mm.state.applyResult(res)
+	// Skip delivery if the monitor was removed mid-run: the loop may still
+	// be inside runOnce when Remove/Stop cancels.
+	mgr.mu.Lock()
+	current, ok := mgr.monitors[mm.monitor.Name]
+	stale := !ok || current != mm
+	mgr.mu.Unlock()
+	if stale {
+		return
+	}
 	if mgr.onResult != nil {
-		mgr.onResult(mm.monitor, res)
+		mgr.onResult(mm.monitor, res, transition)
 	}
 }

--- a/internal/hub/monitors/scheduler_test.go
+++ b/internal/hub/monitors/scheduler_test.go
@@ -18,12 +18,12 @@ func downResult() CheckResult { return CheckResult{Status: StatusDown, Message: 
 func TestStateMachine_DownAfterMaxRetriesPlusOne(t *testing.T) {
 	st := newMonitorState(testMonitor())
 	for i := 0; i < 2; i++ {
-		st.applyResult(downResult())
+		_, _ = st.applyResult(downResult())
 		if st.status() != StatusUp {
 			t.Fatalf("run %d: expected still up, got %q", i+1, st.status())
 		}
 	}
-	st.applyResult(downResult())
+	_, _ = st.applyResult(downResult())
 	if st.status() != StatusDown {
 		t.Fatalf("expected down after 3rd failure, got %q", st.status())
 	}
@@ -31,8 +31,8 @@ func TestStateMachine_DownAfterMaxRetriesPlusOne(t *testing.T) {
 
 func TestStateMachine_SuccessResetsFailures(t *testing.T) {
 	st := newMonitorState(testMonitor())
-	st.applyResult(downResult())
-	st.applyResult(upResult())
+	_, _ = st.applyResult(downResult())
+	_, _ = st.applyResult(upResult())
 	if st.failures() != 0 {
 		t.Fatalf("expected failures reset, got %d", st.failures())
 	}
@@ -45,7 +45,7 @@ func TestStateMachine_ZeroRetriesDownImmediately(t *testing.T) {
 	m := testMonitor()
 	m.MaxRetries = 0
 	st := newMonitorState(m)
-	st.applyResult(downResult())
+	_, _ = st.applyResult(downResult())
 	if st.status() != StatusDown {
 		t.Fatalf("expected immediate down, got %q", st.status())
 	}
@@ -55,26 +55,47 @@ func TestStateMachine_UpsideDownInverts(t *testing.T) {
 	m := testMonitor()
 	m.UpsideDown = true
 	st := newMonitorState(m)
-	st.applyResult(upResult())
+	// Raw successes invert to failures: debounced status stays up for the
+	// first max_retries inverted failures, then flips to down.
 	for i := 0; i < 2; i++ {
-		if st.status() != StatusUp {
-			t.Fatalf("expected still up, got %q", st.status())
+		res, _ := st.applyResult(upResult())
+		if res.Status != StatusUp {
+			t.Fatalf("run %d: expected still up, got %q", i+1, res.Status)
 		}
 	}
-	if got := st.applyResult(upResult()); got.Status != StatusDown {
+	if got, _ := st.applyResult(upResult()); got.Status != StatusDown {
 		t.Fatalf("expected inverted down, got %q", got.Status)
 	}
 }
 
 func TestStateMachine_WarnDoesNotFlipUpDown(t *testing.T) {
 	st := newMonitorState(testMonitor())
-	st.applyResult(CheckResult{Status: StatusWarn, Message: "expiring"})
+	_, _ = st.applyResult(CheckResult{Status: StatusWarn, Message: "expiring"})
 	if st.status() != StatusWarn {
 		t.Fatalf("expected warn, got %q", st.status())
 	}
-	st.applyResult(upResult())
+	_, _ = st.applyResult(upResult())
 	if st.status() != StatusUp {
 		t.Fatalf("expected up after warn, got %q", st.status())
+	}
+}
+
+func TestStateMachine_DeliversDebouncedStatus(t *testing.T) {
+	st := newMonitorState(testMonitor())
+	res, changed := st.applyResult(downResult())
+	if res.Status != StatusUp {
+		t.Fatalf("single failure must still deliver up, got %q", res.Status)
+	}
+	if changed {
+		t.Fatal("no transition expected on first failure")
+	}
+	_, _ = st.applyResult(downResult())
+	res, changed = st.applyResult(downResult())
+	if res.Status != StatusDown {
+		t.Fatalf("expected debounced down, got %q", res.Status)
+	}
+	if !changed {
+		t.Fatal("transition expected on flip to down")
 	}
 }
 
@@ -92,7 +113,7 @@ func TestManager_RunOnceDeliversDown(t *testing.T) {
 	m.MaxRetries = 0
 	m.IntervalSeconds = 3600
 	gotCh := make(chan CheckResult, 1)
-	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return downResult() }, func(mon Monitor, res CheckResult) { gotCh <- res })
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return downResult() }, func(mon Monitor, res CheckResult, _ bool) { gotCh <- res })
 	mgr.jitterMax = 0
 	defer mgr.Stop()
 	mgr.Add(m)

--- a/internal/hub/monitors/scheduler_test.go
+++ b/internal/hub/monitors/scheduler_test.go
@@ -1,0 +1,208 @@
+package monitors
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func testMonitor() Monitor {
+	return Monitor{Name: "t", Type: TypeHTTP, Target: "https://example.com", IntervalSeconds: 60, TimeoutSeconds: 10, MaxRetries: 2}
+}
+
+func upResult() CheckResult   { return CheckResult{Status: StatusUp, LatencyMs: 12} }
+func downResult() CheckResult { return CheckResult{Status: StatusDown, Message: "boom"} }
+
+func TestStateMachine_DownAfterMaxRetriesPlusOne(t *testing.T) {
+	st := newMonitorState(testMonitor())
+	for i := 0; i < 2; i++ {
+		st.applyResult(downResult())
+		if st.status() != StatusUp {
+			t.Fatalf("run %d: expected still up, got %q", i+1, st.status())
+		}
+	}
+	st.applyResult(downResult())
+	if st.status() != StatusDown {
+		t.Fatalf("expected down after 3rd failure, got %q", st.status())
+	}
+}
+
+func TestStateMachine_SuccessResetsFailures(t *testing.T) {
+	st := newMonitorState(testMonitor())
+	st.applyResult(downResult())
+	st.applyResult(upResult())
+	if st.failures() != 0 {
+		t.Fatalf("expected failures reset, got %d", st.failures())
+	}
+	if st.status() != StatusUp {
+		t.Fatalf("expected up, got %q", st.status())
+	}
+}
+
+func TestStateMachine_ZeroRetriesDownImmediately(t *testing.T) {
+	m := testMonitor()
+	m.MaxRetries = 0
+	st := newMonitorState(m)
+	st.applyResult(downResult())
+	if st.status() != StatusDown {
+		t.Fatalf("expected immediate down, got %q", st.status())
+	}
+}
+
+func TestStateMachine_UpsideDownInverts(t *testing.T) {
+	m := testMonitor()
+	m.UpsideDown = true
+	st := newMonitorState(m)
+	st.applyResult(upResult())
+	for i := 0; i < 2; i++ {
+		if st.status() != StatusUp {
+			t.Fatalf("expected still up, got %q", st.status())
+		}
+	}
+	if got := st.applyResult(upResult()); got.Status != StatusDown {
+		t.Fatalf("expected inverted down, got %q", got.Status)
+	}
+}
+
+func TestStateMachine_WarnDoesNotFlipUpDown(t *testing.T) {
+	st := newMonitorState(testMonitor())
+	st.applyResult(CheckResult{Status: StatusWarn, Message: "expiring"})
+	if st.status() != StatusWarn {
+		t.Fatalf("expected warn, got %q", st.status())
+	}
+	st.applyResult(upResult())
+	if st.status() != StatusUp {
+		t.Fatalf("expected up after warn, got %q", st.status())
+	}
+}
+
+func TestStateMachine_RunCheckDispatches(t *testing.T) {
+	m := testMonitor()
+	m.Type = "nope"
+	res := RunCheck(context.Background(), m)
+	if res.Status != StatusDown {
+		t.Fatalf("expected down for unknown type, got %q", res.Status)
+	}
+}
+
+func TestManager_RunOnceDeliversDown(t *testing.T) {
+	m := testMonitor()
+	m.MaxRetries = 0
+	m.IntervalSeconds = 3600
+	gotCh := make(chan CheckResult, 1)
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return downResult() }, func(mon Monitor, res CheckResult) { gotCh <- res })
+	mgr.jitterMax = 0
+	defer mgr.Stop()
+	mgr.Add(m)
+	mgr.mu.Lock()
+	mm := mgr.monitors[m.Name]
+	mgr.mu.Unlock()
+	mgr.runOnce(mm)
+	select {
+	case got := <-gotCh:
+		if got.Status != StatusDown {
+			t.Fatalf("expected down via onResult, got %q", got.Status)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected down result via onResult")
+	}
+}
+
+func TestManager_SkipsOverlap(t *testing.T) {
+	m := testMonitor()
+	// Long interval + zero jitter: the background loop never fires during
+	// the test, so only the manually driven runs below exist.
+	m.IntervalSeconds = 3600
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult {
+		started <- struct{}{}
+		<-release
+		return upResult()
+	}, nil)
+	mgr.jitterMax = 0
+	defer mgr.Stop()
+	mgr.Add(m)
+	mgr.mu.Lock()
+	mm := mgr.monitors[m.Name]
+	mgr.mu.Unlock()
+	// First run blocks inside check; second must skip on the busy flag.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		mgr.runOnce(mm)
+	}()
+	<-started
+	mgr.runOnce(mm)
+	close(release)
+	<-done
+	if n := mgr.Skipped(m.Name); n == 0 {
+		t.Fatal("expected skipped runs from overlap")
+	}
+}
+
+func TestManager_RecoversCheckerPanic(t *testing.T) {
+	m := testMonitor()
+	m.IntervalSeconds = 3600
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { panic("boom") }, nil)
+	mgr.jitterMax = 0
+	defer mgr.Stop()
+	mgr.Add(m)
+	time.Sleep(100 * time.Millisecond)
+	mgr.mu.Lock()
+	mm := mgr.monitors[m.Name]
+	mgr.mu.Unlock()
+	mgr.runOnce(mm)
+	if got := mm.state.status(); got != StatusUp {
+		t.Fatalf("panic should count as failure without flipping yet, got %q", got)
+	}
+	// The background loop may also have run once (immediate first run), so
+	// assert at least one recorded failure rather than an exact count.
+	if n := mm.state.failures(); n < 1 {
+		t.Fatalf("expected >= 1 failure after panic, got %d", n)
+	}
+}
+
+func TestManager_SemaphoreBoundsConcurrency(t *testing.T) {
+	var current, peak atomic.Int32
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult {
+		n := current.Add(1)
+		for {
+			p := peak.Load()
+			if n <= p || peak.CompareAndSwap(p, n) {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+		current.Add(-1)
+		return upResult()
+	}, nil)
+	defer mgr.Stop()
+	names := make([]string, 0, 5)
+	for i := 0; i < 5; i++ {
+		m := testMonitor()
+		m.Name = "c" + string(rune('a'+i))
+		m.IntervalSeconds = 3600
+		names = append(names, m.Name)
+		mgr.Add(m)
+	}
+	// Drive all five runs concurrently by hand; the semaphore must cap
+	// simultaneous check executions at 2.
+	var wg sync.WaitGroup
+	for _, name := range names {
+		mgr.mu.Lock()
+		mm := mgr.monitors[name]
+		mgr.mu.Unlock()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			mgr.runOnce(mm)
+		}()
+	}
+	wg.Wait()
+	if p := peak.Load(); p > 2 {
+		t.Fatalf("expected peak concurrency <= 2, got %d", p)
+	}
+}

--- a/internal/hub/monitors/scheduler_test.go
+++ b/internal/hub/monitors/scheduler_test.go
@@ -227,3 +227,34 @@ func TestManager_SemaphoreBoundsConcurrency(t *testing.T) {
 		t.Fatalf("expected peak concurrency <= 2, got %d", p)
 	}
 }
+
+func TestManager_SurvivesOnResultPanic(t *testing.T) {
+	m := testMonitor()
+	m.MaxRetries = 0
+	m.IntervalSeconds = 3600
+	calls := make(chan struct{}, 4)
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return upResult() }, func(mon Monitor, res CheckResult, _ bool) {
+		calls <- struct{}{}
+		panic("db write failed")
+	})
+	mgr.jitterMax = 0
+	defer mgr.Stop()
+	mgr.Add(m)
+	mgr.mu.Lock()
+	mm := mgr.monitors[m.Name]
+	mgr.mu.Unlock()
+	// A panicking onResult must degrade to a failed attempt, and the monitor
+	// must still accept subsequent runs (loop alive).
+	mgr.runOnce(mm)
+	select {
+	case <-calls:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected first onResult call")
+	}
+	mgr.runOnce(mm)
+	select {
+	case <-calls:
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop died after onResult panic: second run never delivered")
+	}
+}

--- a/internal/hub/monitors/scheduler_test.go
+++ b/internal/hub/monitors/scheduler_test.go
@@ -113,7 +113,7 @@ func TestManager_RunOnceDeliversDown(t *testing.T) {
 	m.MaxRetries = 0
 	m.IntervalSeconds = 3600
 	gotCh := make(chan CheckResult, 1)
-	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return downResult() }, func(mon Monitor, res CheckResult, _ bool) { gotCh <- res })
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return downResult() }, func(mon Monitor, res CheckResult, _ bool, _ int) { gotCh <- res })
 	mgr.jitterMax = 0
 	defer mgr.Stop()
 	mgr.Add(m)
@@ -233,7 +233,7 @@ func TestManager_SurvivesOnResultPanic(t *testing.T) {
 	m.MaxRetries = 0
 	m.IntervalSeconds = 3600
 	calls := make(chan struct{}, 4)
-	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return upResult() }, func(mon Monitor, res CheckResult, _ bool) {
+	mgr := NewManager(2, func(ctx context.Context, mon Monitor) CheckResult { return upResult() }, func(mon Monitor, res CheckResult, _ bool, _ int) {
 		calls <- struct{}{}
 		panic("db write failed")
 	})

--- a/internal/hub/monitors/ssrf.go
+++ b/internal/hub/monitors/ssrf.go
@@ -1,0 +1,136 @@
+package monitors
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// allowPrivateNetworkEnv is the admin-only override permitting checks
+// against private network addresses (lab use). It is read on every call
+// so tests can toggle it with t.Setenv.
+const allowPrivateNetworkEnv = "MONITORS_ALLOW_PRIVATE_NETWORK"
+
+// privateCIDRs lists the address ranges blocked by default.
+var privateCIDRs = []string{
+	"127.0.0.0/8",  // loopback
+	"10.0.0.0/8",   // RFC 1918
+	"172.16.0.0/12", // RFC 1918
+	"192.168.0.0/16", // RFC 1918
+	"169.254.0.0/16", // link-local / cloud metadata
+	"::1/128",      // loopback
+	"fe80::/10",    // link-local
+	"fc00::/7",     // unique-local
+	"0.0.0.0/32",   // unspecified
+	"::/128",       // unspecified
+}
+
+var privateNets []*net.IPNet
+
+func init() {
+	for _, cidr := range privateCIDRs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("monitors: invalid private CIDR %q: %v", cidr, err))
+		}
+		privateNets = append(privateNets, n)
+	}
+}
+
+// IsPrivateIP reports whether ip falls in a range blocked by default.
+// The classifier is pure: the env override only relaxes GuardDialContext.
+func IsPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsUnspecified() || ip.IsLinkLocalUnicast() {
+		return true
+	}
+	for _, n := range privateNets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParsePortOrDefault splits host[:port], defaulting the port when absent.
+func ParsePortOrDefault(hostport string, def int) (string, int, error) {
+	if def <= 0 || def > 65535 {
+		return "", 0, fmt.Errorf("invalid default port %d", def)
+	}
+	if hostport == "" {
+		return "", 0, fmt.Errorf("empty address")
+	}
+	if host, portStr, err := net.SplitHostPort(hostport); err == nil {
+		if host == "" {
+			return "", 0, fmt.Errorf("empty host in %q", hostport)
+		}
+		port, err := strconv.Atoi(portStr)
+		if err != nil || port <= 0 || port > 65535 {
+			return "", 0, fmt.Errorf("invalid port in %q", hostport)
+		}
+		return strings.Trim(host, "[]"), port, nil
+	}
+	// No explicit port: hostport must be a bare host, not malformed input.
+	trimmed := strings.Trim(hostport, "[]")
+	if strings.HasPrefix(hostport, "[") || strings.ContainsAny(trimmed, " /") {
+		return "", 0, fmt.Errorf("invalid address %q", hostport)
+	}
+	if ip := net.ParseIP(trimmed); ip != nil && strings.Contains(trimmed, ":") {
+		// Bare IPv6 literal without brackets and without port.
+		return trimmed, def, nil
+	}
+	if strings.Count(trimmed, ":") > 1 {
+		return "", 0, fmt.Errorf("invalid address %q", hostport)
+	}
+	return trimmed, def, nil
+}
+
+// GuardDialContext dials network/address after verifying every resolved IP
+// against the private-network blocklist. It pins the first allowed IP for
+// the attempt, mitigating DNS-rebinding races within a single check.
+func GuardDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := ParsePortOrDefault(address, 0)
+	if err != nil || port == 0 {
+		// ParsePortOrDefault needs a default; re-split strictly requiring a port.
+		h, pStr, splitErr := net.SplitHostPort(address)
+		if splitErr != nil || h == "" {
+			return nil, fmt.Errorf("invalid address %q", address)
+		}
+		p, convErr := strconv.Atoi(pStr)
+		if convErr != nil || p <= 0 || p > 65535 {
+			return nil, fmt.Errorf("invalid port in %q", address)
+		}
+		host, port = h, p
+	}
+	_ = host
+
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", stripBrackets(host))
+	if err != nil || len(ips) == 0 {
+		return nil, fmt.Errorf("cannot resolve %q: %v", host, err)
+	}
+	allowPrivate := os.Getenv(allowPrivateNetworkEnv) == "true"
+	var first *net.IP
+	for _, ip := range ips {
+		if !allowPrivate && IsPrivateIP(ip) {
+			continue
+		}
+		ipCopy := ip
+		first = &ipCopy
+		break
+	}
+	if first == nil {
+		return nil, fmt.Errorf("all resolved addresses for %q are private network (set %s=true to allow)", host, allowPrivateNetworkEnv)
+	}
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(first.String(), strconv.Itoa(port)))
+}
+
+func stripBrackets(h string) string {
+	return strings.Trim(h, "[]")
+}

--- a/internal/hub/monitors/ssrf.go
+++ b/internal/hub/monitors/ssrf.go
@@ -95,22 +95,17 @@ func ParsePortOrDefault(hostport string, def int) (string, int, error) {
 // against the private-network blocklist. It pins the first allowed IP for
 // the attempt, mitigating DNS-rebinding races within a single check.
 func GuardDialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	host, port, err := ParsePortOrDefault(address, 0)
-	if err != nil || port == 0 {
-		// ParsePortOrDefault needs a default; re-split strictly requiring a port.
-		h, pStr, splitErr := net.SplitHostPort(address)
-		if splitErr != nil || h == "" {
-			return nil, fmt.Errorf("invalid address %q", address)
-		}
-		p, convErr := strconv.Atoi(pStr)
-		if convErr != nil || p <= 0 || p > 65535 {
-			return nil, fmt.Errorf("invalid port in %q", address)
-		}
-		host, port = h, p
+	host, portStr, err := net.SplitHostPort(address)
+	if err != nil || host == "" {
+		return nil, fmt.Errorf("invalid address %q", address)
 	}
-	_ = host
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port <= 0 || port > 65535 {
+		return nil, fmt.Errorf("invalid port in %q", address)
+	}
+	host = stripBrackets(host)
 
-	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", stripBrackets(host))
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
 	if err != nil || len(ips) == 0 {
 		return nil, fmt.Errorf("cannot resolve %q: %v", host, err)
 	}
@@ -132,5 +127,6 @@ func GuardDialContext(ctx context.Context, network, address string) (net.Conn, e
 }
 
 func stripBrackets(h string) string {
-	return strings.Trim(h, "[]")
+	h = strings.TrimPrefix(h, "[")
+	return strings.TrimSuffix(h, "]")
 }

--- a/internal/hub/monitors/ssrf.go
+++ b/internal/hub/monitors/ssrf.go
@@ -17,16 +17,16 @@ const allowPrivateNetworkEnv = "MONITORS_ALLOW_PRIVATE_NETWORK"
 
 // privateCIDRs lists the address ranges blocked by default.
 var privateCIDRs = []string{
-	"127.0.0.0/8",  // loopback
-	"10.0.0.0/8",   // RFC 1918
-	"172.16.0.0/12", // RFC 1918
+	"127.0.0.0/8",    // loopback
+	"10.0.0.0/8",     // RFC 1918
+	"172.16.0.0/12",  // RFC 1918
 	"192.168.0.0/16", // RFC 1918
 	"169.254.0.0/16", // link-local / cloud metadata
-	"::1/128",      // loopback
-	"fe80::/10",    // link-local
-	"fc00::/7",     // unique-local
-	"0.0.0.0/32",   // unspecified
-	"::/128",       // unspecified
+	"::1/128",        // loopback
+	"fe80::/10",      // link-local
+	"fc00::/7",       // unique-local
+	"0.0.0.0/32",     // unspecified
+	"::/128",         // unspecified
 }
 
 var privateNets []*net.IPNet

--- a/internal/hub/monitors/ssrf_test.go
+++ b/internal/hub/monitors/ssrf_test.go
@@ -1,0 +1,196 @@
+package monitors
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func ssrfCtx(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestSSRFIsPrivateIPBlockedRanges(t *testing.T) {
+	blocked := []string{
+		// Loopback.
+		"127.0.0.1", "127.255.255.255", "::1",
+		// RFC 1918.
+		"10.0.0.1", "10.255.255.255",
+		"172.16.0.1", "172.31.255.255",
+		"192.168.0.1", "192.168.255.255",
+		// Cloud metadata.
+		"169.254.169.254", "169.254.0.1",
+		// IPv6 link-local / unique-local.
+		"fe80::1", "fc00::1", "fd00::1",
+		// Unspecified.
+		"0.0.0.0", "::",
+	}
+	for _, s := range blocked {
+		if !IsPrivateIP(net.ParseIP(s)) {
+			t.Errorf("IsPrivateIP(%q) = false, want true", s)
+		}
+	}
+}
+
+func TestSSRFIsPrivateIPPublicOK(t *testing.T) {
+	public := []string{
+		"8.8.8.8", "1.1.1.1", "9.9.9.9", "93.184.216.34",
+		"2001:4860:4860::8888", "2606:4700:4700::1111",
+		// Boundaries just outside the blocked ranges.
+		"172.15.255.255", "172.32.0.1", "11.0.0.1",
+		"192.167.255.255", "169.253.255.255", "169.255.0.1",
+	}
+	for _, s := range public {
+		if IsPrivateIP(net.ParseIP(s)) {
+			t.Errorf("IsPrivateIP(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestSSRFIsPrivateIPIgnoresEnvOverride(t *testing.T) {
+	// The env override only relaxes GuardDialContext; the classifier stays pure.
+	t.Setenv("MONITORS_ALLOW_PRIVATE_NETWORK", "true")
+	if !IsPrivateIP(net.ParseIP("10.0.0.1")) {
+		t.Error("IsPrivateIP(10.0.0.1) = false with override set, want true")
+	}
+}
+
+func TestSSRFParsePortOrDefault(t *testing.T) {
+	cases := []struct {
+		name     string
+		hostport string
+		def      int
+		wantHost string
+		wantPort int
+		wantErr  bool
+	}{
+		{"host with port", "example.com:8080", 443, "example.com", 8080, false},
+		{"bare host uses default", "example.com", 443, "example.com", 443, false},
+		{"ipv4 with port", "127.0.0.1:80", 443, "127.0.0.1", 80, false},
+		{"bracketed ipv6 with port", "[::1]:80", 443, "::1", 80, false},
+		{"bare ipv6 uses default", "::1", 443, "::1", 443, false},
+		{"non-numeric port", "example.com:http", 443, "", 0, true},
+		{"port zero", "example.com:0", 443, "", 0, true},
+		{"port too large", "example.com:99999", 443, "", 0, true},
+		{"empty input", "", 443, "", 0, true},
+		{"invalid default zero", "example.com", 0, "", 0, true},
+		{"invalid default large", "example.com", 99999, "", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			host, port, err := ParsePortOrDefault(tc.hostport, tc.def)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("ParsePortOrDefault(%q, %d) = no error, want error", tc.hostport, tc.def)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParsePortOrDefault(%q, %d) error: %v", tc.hostport, tc.def, err)
+			}
+			if host != tc.wantHost || port != tc.wantPort {
+				t.Errorf("ParsePortOrDefault(%q, %d) = (%q, %d), want (%q, %d)",
+					tc.hostport, tc.def, host, port, tc.wantHost, tc.wantPort)
+			}
+		})
+	}
+}
+
+func TestSSRFGuardDialContextBlocksLiteralPrivateIP(t *testing.T) {
+	// No env override: dialing a private literal must fail before connecting.
+	conn, err := GuardDialContext(ssrfCtx(t), "tcp", "127.0.0.1:80")
+	if err == nil {
+		conn.Close()
+		t.Fatal("GuardDialContext to 127.0.0.1:80 succeeded, want private-network block")
+	}
+	if !strings.Contains(err.Error(), "private") {
+		t.Errorf("error %q does not mention private network", err)
+	}
+}
+
+func TestSSRFGuardDialContextBlocksResolvedLoopback(t *testing.T) {
+	// Per-hop verification: a hostname resolving to loopback must be blocked.
+	conn, err := GuardDialContext(ssrfCtx(t), "tcp", "localhost:80")
+	if err == nil {
+		conn.Close()
+		t.Fatal("GuardDialContext to localhost:80 succeeded, want private-network block")
+	}
+	if !strings.Contains(err.Error(), "private") {
+		t.Errorf("error %q does not mention private network", err)
+	}
+}
+
+func TestSSRFGuardDialContextRejectsBadAddress(t *testing.T) {
+	for _, addr := range []string{"", "not-an-address", "[::1"} {
+		if conn, err := GuardDialContext(ssrfCtx(t), "tcp", addr); err == nil {
+			conn.Close()
+			t.Errorf("GuardDialContext(%q) succeeded, want error", addr)
+		}
+	}
+}
+
+func TestSSRFGuardDialContextUnresolvableHost(t *testing.T) {
+	if conn, err := GuardDialContext(ssrfCtx(t), "tcp", "does-not-exist.invalid:80"); err == nil {
+		conn.Close()
+		t.Error("GuardDialContext to unresolvable host succeeded, want error")
+	}
+}
+
+func TestSSRFGuardDialContextLocalServerBlockedByDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conn, err := GuardDialContext(ssrfCtx(t), "tcp", u.Host); err == nil {
+		conn.Close()
+		t.Fatal("GuardDialContext to local httptest server succeeded without override, want block")
+	}
+}
+
+func TestSSRFGuardDialContextLocalServerAllowedWithOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Env is read on every call, so Setenv takes effect immediately.
+	t.Setenv("MONITORS_ALLOW_PRIVATE_NETWORK", "true")
+	conn, err := GuardDialContext(ssrfCtx(t), "tcp", u.Host)
+	if err != nil {
+		t.Fatalf("GuardDialContext with override failed: %v", err)
+	}
+	conn.Close()
+}
+
+func TestSSRFEnvReadOnEveryCall(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default: blocked.
+	if conn, err := GuardDialContext(ssrfCtx(t), "tcp", u.Host); err == nil {
+		conn.Close()
+		t.Fatal("expected block by default")
+	}
+	// Enabled: allowed.
+	t.Setenv("MONITORS_ALLOW_PRIVATE_NETWORK", "true")
+	conn, err := GuardDialContext(ssrfCtx(t), "tcp", u.Host)
+	if err != nil {
+		t.Fatalf("expected dial with override, got: %v", err)
+	}
+	conn.Close()
+}

--- a/internal/migrations/1_monitors.go
+++ b/internal/migrations/1_monitors.go
@@ -79,8 +79,8 @@ func init() {
 		// History is server-written; no public create/update/delete.
 		checks.ListRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
 		checks.ViewRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
-		checks.AddIndex("idx_monitor_checks_monitor_created", false, "monitor", "created")
 		// AddIndex(name, unique, columns, where): "" where = no condition.
+		checks.AddIndex("idx_monitor_checks_monitor_created", false, "monitor, created", "")
 		checks.AddIndex("idx_monitor_checks_created", false, "created", "")
 		return app.Save(checks)
 	}, func(app core.App) error {

--- a/internal/migrations/1_monitors.go
+++ b/internal/migrations/1_monitors.go
@@ -54,7 +54,7 @@ func init() {
 		// Write: set by API layer; base rules require auth.
 		monitors.ListRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id")
 		monitors.ViewRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id")
-		monitors.CreateRule = types.Pointer("@request.auth.id != \"\" && @request.auth.role != \"readonly\"")
+		monitors.CreateRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id && @request.auth.role != \"readonly\"")
 		monitors.UpdateRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id && @request.auth.role != \"readonly\"")
 		monitors.DeleteRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id && @request.auth.role != \"readonly\"")
 		if err := app.Save(monitors); err != nil {
@@ -80,6 +80,7 @@ func init() {
 		checks.ListRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
 		checks.ViewRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
 		checks.AddIndex("idx_monitor_checks_monitor_created", false, "monitor", "created")
+		// AddIndex(name, unique, columns, where): "" where = no condition.
 		checks.AddIndex("idx_monitor_checks_created", false, "created", "")
 		return app.Save(checks)
 	}, func(app core.App) error {

--- a/internal/migrations/1_monitors.go
+++ b/internal/migrations/1_monitors.go
@@ -1,0 +1,96 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+// 1_monitors.go creates the monitors and monitor_checks collections for
+// external uptime monitoring (PR1: hub-only). The agent field is reserved
+// nullable for PR2 (distributed checks) and must stay unset in PR1.
+func init() {
+	m.Register(func(app core.App) error {
+		usersCollection, err := app.FindCollectionByNameOrId("users")
+		if err != nil {
+			return err
+		}
+		systemsCollection, err := app.FindCollectionByNameOrId("systems")
+		if err != nil {
+			return err
+		}
+
+		monitors := core.NewBaseCollection("monitors")
+		monitors.Fields.Add(
+			&core.TextField{Name: "name", Required: true, Max: 100},
+			&core.SelectField{Name: "type", Required: true, MaxSelect: 1, Values: []string{"http", "keyword", "ping", "dns", "tls"}},
+			&core.TextField{Name: "target", Required: true, Max: 500},
+			&core.NumberField{Name: "interval", Required: true, OnlyInt: true, Min: types.Pointer(20.0), Max: types.Pointer(86400.0)},
+			&core.NumberField{Name: "timeout", Required: true, OnlyInt: true, Min: types.Pointer(1.0)},
+			&core.NumberField{Name: "max_retries", OnlyInt: true, Min: types.Pointer(0.0), Max: types.Pointer(10.0)},
+			&core.BoolField{Name: "upside_down"},
+			&core.BoolField{Name: "paused"},
+			&core.BoolField{Name: "notify"},
+			&core.NumberField{Name: "resend_after", OnlyInt: true, Min: types.Pointer(0.0), Max: types.Pointer(1440.0)},
+			&core.JSONField{Name: "config", MaxSize: 2000000},
+			&core.SelectField{Name: "status", MaxSelect: 1, Values: []string{"up", "down", "warn", "paused", "pending"}},
+			&core.DateField{Name: "last_check"},
+			&core.NumberField{Name: "last_latency_ms"},
+			&core.NumberField{Name: "uptime_24h"},
+			&core.NumberField{Name: "cert_days"},
+			&core.NumberField{Name: "consecutive_failures", OnlyInt: true},
+			&core.AutodateField{Name: "created", OnCreate: true},
+			&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true},
+		)
+		monitors.Fields.Add(&core.RelationField{
+			Name: "users", Required: true, MaxSelect: 0,
+			CollectionId: usersCollection.Id,
+		})
+		monitors.Fields.Add(&core.RelationField{
+			Name: "agent", MaxSelect: 1, MinSelect: 0,
+			CollectionId: systemsCollection.Id,
+		})
+		// Read: members or SHARE_ALL (refined at serve time like systems).
+		// Write: set by API layer; base rules require auth.
+		monitors.ListRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id")
+		monitors.ViewRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id")
+		monitors.CreateRule = types.Pointer("@request.auth.id != \"\" && @request.auth.role != \"readonly\"")
+		monitors.UpdateRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id && @request.auth.role != \"readonly\"")
+		monitors.DeleteRule = types.Pointer("@request.auth.id != \"\" && users.id ?= @request.auth.id && @request.auth.role != \"readonly\"")
+		if err := app.Save(monitors); err != nil {
+			return err
+		}
+
+		checks := core.NewBaseCollection("monitor_checks")
+		checks.Fields.Add(
+			&core.SelectField{Name: "status", Required: true, MaxSelect: 1, Values: []string{"up", "down", "warn"}},
+			&core.NumberField{Name: "latency_ms"},
+			&core.NumberField{Name: "code"},
+			&core.TextField{Name: "message", Max: 500},
+			&core.JSONField{Name: "details", MaxSize: 2000000},
+			&core.NumberField{Name: "cert_days"},
+			&core.AutodateField{Name: "created", OnCreate: true},
+			&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true},
+		)
+		checks.Fields.Add(&core.RelationField{
+			Name: "monitor", Required: true, MaxSelect: 1,
+			CollectionId: monitors.Id, CascadeDelete: true,
+		})
+		// History is server-written; no public create/update/delete.
+		checks.ListRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
+		checks.ViewRule = types.Pointer("@request.auth.id != \"\" && monitor.users.id ?= @request.auth.id")
+		checks.AddIndex("idx_monitor_checks_monitor_created", false, "monitor", "created")
+		checks.AddIndex("idx_monitor_checks_created", false, "created", "")
+		return app.Save(checks)
+	}, func(app core.App) error {
+		if checks, err := app.FindCollectionByNameOrId("monitor_checks"); err == nil {
+			if err := app.Delete(checks); err != nil {
+				return err
+			}
+		}
+		if monitors, err := app.FindCollectionByNameOrId("monitors"); err == nil {
+			return app.Delete(monitors)
+		}
+		return nil
+	})
+}

--- a/internal/migrations/monitors_test.go
+++ b/internal/migrations/monitors_test.go
@@ -1,0 +1,98 @@
+//go:build testing
+
+package migrations_test
+
+import (
+	"testing"
+
+	_ "github.com/henrygd/beszel/internal/migrations"
+	"github.com/henrygd/beszel/internal/records"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitorCollectionsExist(t *testing.T) {
+	app, err := tests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	defer app.Cleanup()
+
+	monitors, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err, "monitors collection must exist")
+	assert.NotEmpty(t, monitors.Fields)
+
+	checks, err := app.FindCachedCollectionByNameOrId("monitor_checks")
+	require.NoError(t, err, "monitor_checks collection must exist")
+	assert.NotEmpty(t, checks.Fields)
+}
+
+func createMonitorRecord(t *testing.T, app *tests.TestApp, userID string) *core.Record {
+	t.Helper()
+	monitors, err := app.FindCachedCollectionByNameOrId("monitors")
+	require.NoError(t, err)
+	mon := core.NewRecord(monitors)
+	mon.Set("name", "cascade")
+	mon.Set("type", "ping")
+	mon.Set("target", "example.com")
+	mon.Set("interval", 60)
+	mon.Set("timeout", 10)
+	mon.Set("users", []string{userID})
+	require.NoError(t, app.Save(mon))
+	return mon
+}
+
+func TestMonitorChecksCascadeOnMonitorDelete(t *testing.T) {
+	app, err := tests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	defer app.Cleanup()
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "mon@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+
+	mon := createMonitorRecord(t, app, user.Id)
+
+	checksCol, err := app.FindCachedCollectionByNameOrId("monitor_checks")
+	require.NoError(t, err)
+	check := core.NewRecord(checksCol)
+	check.Set("monitor", mon.Id)
+	check.Set("status", "up")
+	check.Set("latency_ms", 1.5)
+	require.NoError(t, app.Save(check))
+
+	require.NoError(t, app.Delete(mon))
+	remaining, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, remaining, "checks must cascade-delete with monitor")
+}
+
+func TestMonitorChecksRetention(t *testing.T) {
+	app, err := tests.NewTestApp(t.TempDir())
+	require.NoError(t, err)
+	defer app.Cleanup()
+
+	users, err := app.FindCachedCollectionByNameOrId("users")
+	require.NoError(t, err)
+	user := core.NewRecord(users)
+	user.Set("email", "ret@example.com")
+	user.Set("password", "password12345")
+	require.NoError(t, app.Save(user))
+	mon := createMonitorRecord(t, app, user.Id)
+
+	// 40 days old (beyond 30d retention) + 1h old (kept).
+	old := "2020-01-01 00:00:00.000Z"
+	_, err = app.DB().NewQuery("INSERT INTO monitor_checks (monitor, status, created, updated) VALUES ({:mon}, 'up', {:old}, {:old})").Bind(dbx.Params{"mon": mon.Id, "old": old}).Execute()
+	require.NoError(t, err)
+
+	require.NoError(t, records.DeleteOldMonitorChecks(app))
+
+	total, err := app.CountRecords("monitor_checks")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, total, "old checks must be purged")
+}

--- a/internal/migrations/monitors_test.go
+++ b/internal/migrations/monitors_test.go
@@ -85,14 +85,16 @@ func TestMonitorChecksRetention(t *testing.T) {
 	require.NoError(t, app.Save(user))
 	mon := createMonitorRecord(t, app, user.Id)
 
-	// 40 days old (beyond 30d retention) + 1h old (kept).
+	// 40 days old (beyond 30d retention) + one fresh row (must survive).
 	old := "2020-01-01 00:00:00.000Z"
 	_, err = app.DB().NewQuery("INSERT INTO monitor_checks (monitor, status, created, updated) VALUES ({:mon}, 'up', {:old}, {:old})").Bind(dbx.Params{"mon": mon.Id, "old": old}).Execute()
+	require.NoError(t, err)
+	_, err = app.DB().NewQuery("INSERT INTO monitor_checks (monitor, status, created, updated) VALUES ({:mon}, 'down', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)").Bind(dbx.Params{"mon": mon.Id}).Execute()
 	require.NoError(t, err)
 
 	require.NoError(t, records.DeleteOldMonitorChecks(app))
 
 	total, err := app.CountRecords("monitor_checks")
 	require.NoError(t, err)
-	assert.EqualValues(t, 0, total, "old checks must be purged")
+	assert.EqualValues(t, 1, total, "old checks purged, recent kept")
 }

--- a/internal/records/records.go
+++ b/internal/records/records.go
@@ -155,6 +155,14 @@ func (rm *RecordManager) CreateLongerRecords() {
 		return nil
 	})
 
+	// Refresh monitor uptime ratios in the same 10-minute cron (no new cron).
+	rm.app.RunInTransaction(func(txApp core.App) error {
+		if err := refreshMonitorUptime(txApp); err != nil {
+			slog.Error("Error refreshing monitor uptime", "err", err)
+		}
+		return nil
+	})
+
 	// log.Println("finished creating longer records", "time (ms)", time.Since(start).Milliseconds())
 }
 

--- a/internal/records/records_deletion.go
+++ b/internal/records/records_deletion.go
@@ -34,6 +34,10 @@ func (rm *RecordManager) DeleteOldRecords() {
 		if err != nil {
 			slog.Error("Error deleting old quiet hours", "err", err)
 		}
+		err = deleteOldMonitorChecks(txApp)
+		if err != nil {
+			slog.Error("Error deleting old monitor checks", "err", err)
+		}
 		return nil
 	})
 }
@@ -135,5 +139,38 @@ func deleteOldQuietHours(app core.App) error {
 		return err
 	}
 
+	return nil
+}
+
+// Monitor checks retention bounds (spec section 9).
+const (
+	monitorChecksRetention  = 30 * 24 * time.Hour
+	monitorChecksSafetyCap  = 500_000
+	monitorChecksSafetyKeep = 400_000
+)
+
+// Deletes monitor_checks records older than the retention window and
+// enforces a safety cap so an interval misconfiguration cannot grow the
+// table (and SQLite write pressure) without bound.
+func deleteOldMonitorChecks(app core.App) error {
+	return DeleteOldMonitorChecks(app)
+}
+
+// DeleteOldMonitorChecks purges expired monitor check history. Exported for
+// use by tests outside the records package.
+func DeleteOldMonitorChecks(app core.App) error {
+	cutoff := time.Now().UTC().Add(-monitorChecksRetention)
+	if _, err := app.DB().NewQuery("DELETE FROM monitor_checks WHERE created < {:cutoff}").Bind(dbx.Params{"cutoff": cutoff}).Execute(); err != nil {
+		return fmt.Errorf("failed to delete old monitor checks: %v", err)
+	}
+	var total int
+	if err := app.DB().NewQuery("SELECT COUNT(*) FROM monitor_checks").Row(&total); err != nil {
+		return err
+	}
+	if total > monitorChecksSafetyCap {
+		if _, err := app.DB().NewQuery("DELETE FROM monitor_checks WHERE id NOT IN (SELECT id FROM monitor_checks ORDER BY created DESC LIMIT {:keep})").Bind(dbx.Params{"keep": monitorChecksSafetyKeep}).Execute(); err != nil {
+			return fmt.Errorf("failed to enforce monitor checks cap: %v", err)
+		}
+	}
 	return nil
 }

--- a/internal/records/records_deletion.go
+++ b/internal/records/records_deletion.go
@@ -168,6 +168,7 @@ func DeleteOldMonitorChecks(app core.App) error {
 		return err
 	}
 	if total > monitorChecksSafetyCap {
+		slog.Warn("Monitor checks table exceeded safety cap, purging oldest", "total", total, "cap", monitorChecksSafetyCap, "keep", monitorChecksSafetyKeep)
 		if _, err := app.DB().NewQuery("DELETE FROM monitor_checks WHERE id NOT IN (SELECT id FROM monitor_checks ORDER BY created DESC LIMIT {:keep})").Bind(dbx.Params{"keep": monitorChecksSafetyKeep}).Execute(); err != nil {
 			return fmt.Errorf("failed to enforce monitor checks cap: %v", err)
 		}

--- a/internal/records/records_monitors.go
+++ b/internal/records/records_monitors.go
@@ -1,0 +1,45 @@
+package records
+
+import (
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+// refreshMonitorUptime recomputes monitors.uptime_24h from monitor_checks.
+// It runs inside the existing "create longer records" cron (every 10 min),
+// so no new cron is needed. Checks from manual test runs are never written
+// to monitor_checks, so they cannot skew the ratio.
+func refreshMonitorUptime(app core.App) error {
+	var ids []struct {
+		ID string `db:"id"`
+	}
+	if err := app.DB().NewQuery("SELECT id FROM monitors").All(&ids); err != nil {
+		return err
+	}
+	for _, m := range ids {
+		var rows []struct {
+			Status string `db:"status"`
+			Count  int    `db:"cnt"`
+		}
+		if err := app.DB().NewQuery("SELECT status, COUNT(*) as cnt FROM monitor_checks WHERE monitor = {:mon} AND created >= datetime('now', '-1 day') GROUP BY status").
+			Bind(dbx.Params{"mon": m.ID}).All(&rows); err != nil {
+			return err
+		}
+		var up, total int
+		for _, r := range rows {
+			total += r.Count
+			if r.Status == "up" || r.Status == "warn" {
+				up += r.Count
+			}
+		}
+		var ratio float64
+		if total > 0 {
+			ratio = float64(up) / float64(total) * 100
+		}
+		if _, err := app.DB().NewQuery("UPDATE monitors SET uptime_24h = {:ratio} WHERE id = {:id}").
+			Bind(dbx.Params{"ratio": ratio, "id": m.ID}).Execute(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/site/src/components/monitors-summary.tsx
+++ b/internal/site/src/components/monitors-summary.tsx
@@ -1,0 +1,36 @@
+import { useLingui } from "@lingui/react/macro"
+import { useStore } from "@nanostores/react"
+import { memo } from "react"
+import { Card, CardContent } from "@/components/ui/card"
+import { $router, Link } from "@/components/router"
+import { getPagePath } from "@nanostores/router"
+import { $monitorsSummary } from "@/lib/monitors"
+
+export const MonitorsSummary = memo(() => {
+	const { t } = useLingui()
+	const summary = useStore($monitorsSummary)
+	if (!summary) {
+		return null
+	}
+	const total = Object.values(summary.counts).reduce((a, b) => a + b, 0)
+	if (total === 0) {
+		return null
+	}
+	return (
+		<Card>
+			<CardContent className="flex flex-wrap items-center gap-x-4 gap-y-1 py-3 text-sm">
+				<Link href={getPagePath($router, "monitors")} className="font-medium hover:underline">
+					{t`Monitors`}
+				</Link>
+				{summary.counts.up > 0 && (
+					<span className="text-green-600">{t`${summary.counts.up} up`}</span>
+				)}
+				{summary.counts.down > 0 && (
+					<span className="font-medium text-red-600">{t`${summary.counts.down} down`}</span>
+				)}
+				{summary.counts.warn > 0 && <span className="text-yellow-600">{t`${summary.counts.warn} warning`}</span>}
+				{summary.counts.paused > 0 && <span className="text-muted-foreground">{t`${summary.counts.paused} paused`}</span>}
+			</CardContent>
+		</Card>
+	)
+})

--- a/internal/site/src/components/navbar.tsx
+++ b/internal/site/src/components/navbar.tsx
@@ -2,6 +2,7 @@ import { t } from "@lingui/core/macro"
 import { Trans } from "@lingui/react/macro"
 import { getPagePath } from "@nanostores/router"
 import {
+	ActivityIcon,
 	ContainerIcon,
 	DatabaseBackupIcon,
 	HardDriveIcon,
@@ -108,6 +109,10 @@ export default function Navbar() {
 								<HardDriveIcon className="h-4 w-4 me-2.5" strokeWidth={1.5} />
 								<span>S.M.A.R.T.</span>
 							</DropdownMenuItem>
+							<DropdownMenuItem onClick={() => navigate(getPagePath($router, "monitors"))} className="flex items-center">
+								<ActivityIcon className="h-4 w-4 me-2.5" strokeWidth={1.5} />
+								<Trans>Monitors</Trans>
+							</DropdownMenuItem>
 							<DropdownMenuItem
 								onClick={() => navigate(getPagePath($router, "settings", { name: "general" }))}
 								className="flex items-center"
@@ -178,6 +183,21 @@ export default function Navbar() {
 						</Link>
 					</TooltipTrigger>
 					<TooltipContent>S.M.A.R.T.</TooltipContent>
+				</Tooltip>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Link
+							href={getPagePath($router, "monitors")}
+							className={cn("hidden md:grid", buttonVariants({ variant: "ghost", size: "icon" }))}
+							aria-label="Monitors"
+							onMouseEnter={runOnce(() => import("@/components/routes/monitors"))}
+						>
+							<ActivityIcon className="h-[1.2rem] w-[1.2rem]" strokeWidth={1.5} />
+						</Link>
+					</TooltipTrigger>
+					<TooltipContent>
+						<Trans>Monitors</Trans>
+					</TooltipContent>
 				</Tooltip>
 				<ModeToggle />
 				<Tooltip>

--- a/internal/site/src/components/router.tsx
+++ b/internal/site/src/components/router.tsx
@@ -5,6 +5,7 @@ const routes = {
 	containers: "/containers",
 	smart: "/smart",
 	monitors: "/monitors",
+	monitor: "/monitors/:id",
 	system: `/system/:id`,
 	settings: `/settings/:name?`,
 	forgot_password: `/forgot-password`,

--- a/internal/site/src/components/router.tsx
+++ b/internal/site/src/components/router.tsx
@@ -4,6 +4,7 @@ const routes = {
 	home: "/",
 	containers: "/containers",
 	smart: "/smart",
+	monitors: "/monitors",
 	system: `/system/:id`,
 	settings: `/settings/:name?`,
 	forgot_password: `/forgot-password`,

--- a/internal/site/src/components/routes/home.tsx
+++ b/internal/site/src/components/routes/home.tsx
@@ -2,6 +2,7 @@ import { useLingui } from "@lingui/react/macro"
 import { memo, Suspense, useEffect, useMemo } from "react"
 import SystemsTable from "@/components/systems-table/systems-table"
 import { ActiveAlerts } from "@/components/active-alerts"
+import { MonitorsSummary } from "@/components/monitors-summary"
 import { FooterRepoLink } from "@/components/footer-repo-link"
 
 export default memo(() => {
@@ -14,12 +15,13 @@ export default memo(() => {
 	return useMemo(
 		() => (
 			<>
-				<div className="flex flex-col gap-4">
-					<ActiveAlerts />
-					<Suspense>
-						<SystemsTable />
-					</Suspense>
-				</div>
+			<div className="flex flex-col gap-4">
+				<ActiveAlerts />
+				<MonitorsSummary />
+				<Suspense>
+					<SystemsTable />
+				</Suspense>
+			</div>
 				<FooterRepoLink />
 			</>
 		),

--- a/internal/site/src/components/routes/monitor-dialog.tsx
+++ b/internal/site/src/components/routes/monitor-dialog.tsx
@@ -1,5 +1,5 @@
-import { t } from "@lingui/core/macro"
-import { useState } from "react"
+import { useLingui } from "@lingui/react/macro"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
 	Dialog,
@@ -19,15 +19,15 @@ import {
 	SelectValue,
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
-import { pb } from "@/lib/api"
+import { isReadOnlyUser, pb } from "@/lib/api"
 import type { MonitorRecord, MonitorType } from "@/types"
 
-const TYPES: { value: MonitorType; label: string; placeholder: string; hint: string }[] = [
-	{ value: "http", label: "HTTP(S)", placeholder: "https://example.com", hint: t`Full URL. Accepts 2xx by default.` },
-	{ value: "keyword", label: "Keyword", placeholder: "https://example.com", hint: t`HTTP check that also looks for text in the response.` },
-	{ value: "ping", label: "Ping", placeholder: "example.com", hint: t`ICMP echo. The hub may need NET_RAW capability in Docker.` },
-	{ value: "dns", label: "DNS", placeholder: "example.com", hint: t`Resolves a record type, optionally against a custom resolver.` },
-	{ value: "tls", label: "TLS cert", placeholder: "example.com:443", hint: t`Checks certificate expiry without an HTTP request.` },
+const TYPES: { value: MonitorType; label: string; placeholder: string }[] = [
+	{ value: "http", label: "HTTP(S)", placeholder: "https://example.com" },
+	{ value: "keyword", label: "Keyword", placeholder: "https://example.com" },
+	{ value: "ping", label: "Ping", placeholder: "example.com" },
+	{ value: "dns", label: "DNS", placeholder: "example.com" },
+	{ value: "tls", label: "TLS cert", placeholder: "example.com:443" },
 ]
 
 interface FormState {
@@ -36,25 +36,66 @@ interface FormState {
 	target: string
 	interval: string
 	timeout: string
+	maxRetries: string
+	resendAfter: string
 	keyword: string
+	invertKeyword: boolean
+	method: string
+	acceptedCodes: string
+	authType: string
+	authUser: string
+	authSecret: string
+	ignoreTls: boolean
+	checkCert: boolean
+	warnDays: string
+	critDays: string
 	qtype: string
 	resolver: string
+	protocol: string
+	expectedAnswer: string
+	count: string
+	packetSize: string
 	port: string
+	upsideDown: boolean
 	notify: boolean
 }
 
+function str(v: unknown, def: string): string {
+	if (v === undefined || v === null) {
+		return def
+	}
+	return String(v)
+}
+
 function initialState(monitor?: MonitorRecord): FormState {
-	const cfg = monitor?.config ?? {}
+	const cfg = (monitor?.config ?? {}) as Record<string, unknown>
 	return {
 		name: monitor?.name ?? "",
 		type: monitor?.type ?? "http",
 		target: monitor?.target ?? "",
 		interval: String(monitor?.interval ?? 60),
 		timeout: String(monitor?.timeout ?? 10),
-		keyword: String(cfg.keyword ?? ""),
-		qtype: String(cfg.qtype ?? "A"),
-		resolver: String(cfg.resolver ?? ""),
-		port: String(cfg.port ?? ""),
+		maxRetries: String(monitor?.max_retries ?? 2),
+		resendAfter: String(monitor?.resend_after ?? 0),
+		keyword: str(cfg.keyword, ""),
+		invertKeyword: Boolean(cfg.invert_keyword ?? false),
+		method: str(cfg.method, "GET"),
+		acceptedCodes: str(cfg.accepted_status_codes, "200-299"),
+		authType: str(cfg.auth_type, "none"),
+		authUser: str(cfg.username, ""),
+		authSecret: "",
+		ignoreTls: Boolean(cfg.ignore_tls_errors ?? false),
+		checkCert: cfg.check_cert_expiry === undefined ? true : Boolean(cfg.check_cert_expiry),
+		warnDays: str(cfg.warn_days, "21"),
+		critDays: str(cfg.crit_days, "7"),
+		qtype: str(cfg.qtype, "A"),
+		resolver: str(cfg.resolver, ""),
+		protocol: str(cfg.protocol, "udp"),
+		expectedAnswer: str(cfg.expected_answer, ""),
+		count: str(cfg.count, "3"),
+		packetSize: str(cfg.packet_size, "56"),
+		port: str(cfg.port, ""),
+		upsideDown: Boolean(monitor?.upside_down ?? false),
 		notify: monitor?.notify ?? true,
 	}
 }
@@ -70,6 +111,7 @@ export function MonitorDialog({
 	monitor?: MonitorRecord
 	onSaved: () => void
 }) {
+	const { t } = useLingui()
 	const [form, setForm] = useState<FormState>(() => initialState(monitor))
 	const [error, setError] = useState("")
 	const [saving, setSaving] = useState(false)
@@ -79,12 +121,10 @@ export function MonitorDialog({
 	}
 
 	// Refresh defaults when switching between monitors.
-	const [lastId, setLastId] = useState(monitor?.id)
-	if (monitor?.id !== lastId) {
-		setLastId(monitor?.id)
+	useEffect(() => {
 		setForm(initialState(monitor))
 		setError("")
-	}
+	}, [monitor?.id])
 
 	const save = async () => {
 		setError("")
@@ -106,19 +146,86 @@ export function MonitorDialog({
 			setError(t`Timeout must be positive and less than the interval.`)
 			return
 		}
-		const config: Record<string, unknown> = {}
-		if (form.type === "keyword") {
-			if (!form.keyword) {
+	// Merge form keys over the stored config so settings made via API or
+		// YAML survive a UI save. Secrets are never shown here; the API keeps
+		// stored secrets when they are absent from the patch.
+		const config: Record<string, unknown> = { ...(monitor?.config ?? {}) }
+		const num = (v: string) => Number.parseInt(v, 10)
+		if (form.type === "keyword" || (form.type === "http" && form.keyword.trim())) {
+			if (form.type === "keyword" && !form.keyword) {
 				setError(t`Keyword is required for keyword monitors.`)
 				return
 			}
 			config.keyword = form.keyword
+			config.invert_keyword = form.invertKeyword
+		} else {
+			delete config.keyword
+			delete config.invert_keyword
+		}
+		if (form.type === "http" || form.type === "keyword" || form.type === "tls") {
+			config.method = form.method || "GET"
+			if (form.acceptedCodes.trim()) {
+				config.accepted_status_codes = form.acceptedCodes.trim()
+			}
+			config.auth_type = form.authType
+			if (form.authType === "basic") {
+				config.username = form.authUser.trim()
+				if (form.authSecret) {
+					config.password = form.authSecret
+				}
+			} else {
+				delete config.username
+			}
+			if (form.authType === "bearer") {
+				if (form.authSecret) {
+					config.token = form.authSecret
+				}
+			} else {
+				delete config.token
+			}
+			if (form.authType === "none") {
+				delete config.password
+			}
+			config.ignore_tls_errors = form.ignoreTls
+		}
+		if (form.type === "http" || form.type === "keyword" || form.type === "tls") {
+			config.check_cert_expiry = form.checkCert
+			const warn = num(form.warnDays)
+			const crit = num(form.critDays)
+			if (form.checkCert && (!(warn > 0) || !(crit > 0) || !(crit < warn))) {
+				setError(t`Cert thresholds must be positive with critical below warning.`)
+				return
+			}
+			config.warn_days = warn
+			config.crit_days = crit
 		}
 		if (form.type === "dns") {
 			config.qtype = form.qtype || "A"
+			config.protocol = form.protocol || "udp"
 			if (form.resolver.trim()) {
 				config.resolver = form.resolver.trim()
+			} else {
+				delete config.resolver
 			}
+			if (form.expectedAnswer.trim()) {
+				config.expected_answer = form.expectedAnswer.trim()
+			} else {
+				delete config.expected_answer
+			}
+		}
+		if (form.type === "ping") {
+			const count = num(form.count)
+			const size = num(form.packetSize)
+			if (!(count >= 1 && count <= 10)) {
+				setError(t`Ping count must be between 1 and 10.`)
+				return
+			}
+			if (!(size >= 0 && size <= 65400)) {
+				setError(t`Packet size must be between 0 and 65400.`)
+				return
+			}
+			config.count = count
+			config.packet_size = size
 		}
 		if (form.type === "tls" && form.port.trim()) {
 			const port = Number.parseInt(form.port, 10)
@@ -127,6 +234,18 @@ export function MonitorDialog({
 				return
 			}
 			config.port = port
+		} else {
+			delete config.port
+		}
+		const maxRetries = num(form.maxRetries)
+		const resendAfter = num(form.resendAfter)
+		if (!(maxRetries >= 0 && maxRetries <= 10)) {
+			setError(t`Retries must be between 0 and 10.`)
+			return
+		}
+		if (!(resendAfter >= 0 && resendAfter <= 1440)) {
+			setError(t`Resend delay must be between 0 and 1440 minutes.`)
+			return
 		}
 		setSaving(true)
 		try {
@@ -136,6 +255,9 @@ export function MonitorDialog({
 				target: form.target.trim(),
 				interval,
 				timeout,
+				max_retries: maxRetries,
+				resend_after: resendAfter,
+				upside_down: form.upsideDown,
 				notify: form.notify,
 				config,
 			}
@@ -153,6 +275,10 @@ export function MonitorDialog({
 	}
 
 	const activeType = TYPES.find((x) => x.value === form.type) ?? TYPES[0]
+
+	if (isReadOnlyUser()) {
+		return null
+	}
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -197,7 +323,13 @@ export function MonitorDialog({
 							/>
 						</div>
 					</div>
-					<p className="-mt-2 text-xs text-muted-foreground">{activeType.hint}</p>
+					<p className="-mt-2 text-xs text-muted-foreground">
+						{form.type === "http" && t`Full URL. Accepts 2xx by default.`}
+						{form.type === "keyword" && t`HTTP check that also looks for text in the first 2 MB of the response.`}
+						{form.type === "ping" && t`ICMP echo. The hub may need NET_RAW capability in Docker.`}
+						{form.type === "dns" && t`Resolves a record type, optionally against a custom resolver.`}
+						{form.type === "tls" && t`Checks certificate expiry without an HTTP request.`}
+					</p>
 					{form.type === "keyword" && (
 						<div className="grid gap-2">
 							<Label htmlFor="mon-keyword">{t`Keyword`}</Label>
@@ -207,7 +339,122 @@ export function MonitorDialog({
 								onChange={(e) => set("keyword", e.target.value)}
 								placeholder="Welcome"
 							/>
+							<div className="flex items-center justify-between">
+								<Label htmlFor="mon-invert">{t`Alert when keyword is missing`}</Label>
+								<Switch
+									id="mon-invert"
+									checked={!form.invertKeyword}
+									onCheckedChange={(v) => set("invertKeyword", !v)}
+								/>
+							</div>
 						</div>
+					)}
+					{(form.type === "http" || form.type === "keyword") && (
+						<>
+							<div className="grid grid-cols-2 gap-4">
+								<div className="grid gap-2">
+									<Label htmlFor="mon-method">{t`Method`}</Label>
+									<Select value={form.method} onValueChange={(v) => set("method", v)}>
+										<SelectTrigger id="mon-method">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"].map((m) => (
+												<SelectItem key={m} value={m}>
+													{m}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="grid gap-2">
+									<Label htmlFor="mon-codes">{t`Accepted codes`}</Label>
+									<Input
+										id="mon-codes"
+										value={form.acceptedCodes}
+										onChange={(e) => set("acceptedCodes", e.target.value)}
+										placeholder="200-299"
+									/>
+								</div>
+							</div>
+							<div className="grid grid-cols-2 gap-4">
+								<div className="grid gap-2">
+									<Label htmlFor="mon-auth">{t`Auth`}</Label>
+									<Select value={form.authType} onValueChange={(v) => set("authType", v)}>
+										<SelectTrigger id="mon-auth">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="none">{t`None`}</SelectItem>
+											<SelectItem value="basic">{t`Basic`}</SelectItem>
+											<SelectItem value="bearer">{t`Bearer token`}</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
+								{form.authType === "basic" && (
+									<div className="grid gap-2">
+										<Label htmlFor="mon-auth-user">{t`Username`}</Label>
+										<Input
+											id="mon-auth-user"
+											value={form.authUser}
+											onChange={(e) => set("authUser", e.target.value)}
+											autoComplete="off"
+										/>
+									</div>
+								)}
+							</div>
+							{(form.authType === "basic" || form.authType === "bearer") && (
+								<div className="grid gap-2">
+									<Label htmlFor="mon-auth-secret">
+										{form.authType === "basic" ? t`Password` : t`Token`}
+										{monitor && (
+											<span className="ml-1 font-normal text-muted-foreground">{t`(leave empty to keep)`}</span>
+										)}
+									</Label>
+									<Input
+										id="mon-auth-secret"
+										type="password"
+										value={form.authSecret}
+										onChange={(e) => set("authSecret", e.target.value)}
+										autoComplete="new-password"
+									/>
+								</div>
+							)}
+							<div className="flex items-center justify-between">
+								<Label htmlFor="mon-ignore-tls">{t`Ignore TLS errors (insecure)`}</Label>
+								<Switch id="mon-ignore-tls" checked={form.ignoreTls} onCheckedChange={(v) => set("ignoreTls", v)} />
+							</div>
+						</>
+					)}
+					{(form.type === "http" || form.type === "keyword" || form.type === "tls") && (
+						<>
+							<div className="flex items-center justify-between">
+								<Label htmlFor="mon-check-cert">{t`Watch certificate expiry`}</Label>
+								<Switch id="mon-check-cert" checked={form.checkCert} onCheckedChange={(v) => set("checkCert", v)} />
+							</div>
+							{form.checkCert && (
+								<div className="grid grid-cols-2 gap-4">
+									<div className="grid gap-2">
+										<Label htmlFor="mon-warn">{t`Warn below (days)`}</Label>
+										<Input
+											id="mon-warn"
+											value={form.warnDays}
+											onChange={(e) => set("warnDays", e.target.value)}
+											inputMode="numeric"
+										/>
+									</div>
+									<div className="grid gap-2">
+										<Label htmlFor="mon-crit">{t`Critical below (days)`}</Label>
+										<Input
+											id="mon-crit"
+											value={form.critDays}
+											onChange={(e) => set("critDays", e.target.value)}
+											inputMode="numeric"
+										/>
+									</div>
+								</div>
+							)}
+						</>
 					)}
 					{form.type === "dns" && (
 						<div className="grid grid-cols-2 gap-4">
@@ -227,12 +474,55 @@ export function MonitorDialog({
 								</Select>
 							</div>
 							<div className="grid gap-2">
+								<Label htmlFor="mon-proto">{t`Protocol`}</Label>
+								<Select value={form.protocol} onValueChange={(v) => set("protocol", v)}>
+									<SelectTrigger id="mon-proto">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="udp">UDP</SelectItem>
+										<SelectItem value="tcp">TCP</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="grid gap-2">
 								<Label htmlFor="mon-resolver">{t`Resolver (optional)`}</Label>
 								<Input
 									id="mon-resolver"
 									value={form.resolver}
 									onChange={(e) => set("resolver", e.target.value)}
 									placeholder="1.1.1.1"
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="mon-expected">{t`Expected answer (optional)`}</Label>
+								<Input
+									id="mon-expected"
+									value={form.expectedAnswer}
+									onChange={(e) => set("expectedAnswer", e.target.value)}
+									placeholder="mail.example.com"
+								/>
+							</div>
+						</div>
+					)}
+					{form.type === "ping" && (
+						<div className="grid grid-cols-2 gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="mon-count">{t`Packets`}</Label>
+								<Input
+									id="mon-count"
+									value={form.count}
+									onChange={(e) => set("count", e.target.value)}
+									inputMode="numeric"
+								/>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="mon-size">{t`Packet size`}</Label>
+								<Input
+									id="mon-size"
+									value={form.packetSize}
+									onChange={(e) => set("packetSize", e.target.value)}
+									inputMode="numeric"
 								/>
 							</div>
 						</div>
@@ -268,6 +558,28 @@ export function MonitorDialog({
 								inputMode="numeric"
 							/>
 						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="mon-retries">{t`Retries before down`}</Label>
+							<Input
+								id="mon-retries"
+								value={form.maxRetries}
+								onChange={(e) => set("maxRetries", e.target.value)}
+								inputMode="numeric"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="mon-resend">{t`Resend every (minutes, 0 = never)`}</Label>
+							<Input
+								id="mon-resend"
+								value={form.resendAfter}
+								onChange={(e) => set("resendAfter", e.target.value)}
+								inputMode="numeric"
+							/>
+						</div>
+					</div>
+					<div className="flex items-center justify-between">
+						<Label htmlFor="mon-upside">{t`Invert status (upside down)`}</Label>
+						<Switch id="mon-upside" checked={form.upsideDown} onCheckedChange={(v) => set("upsideDown", v)} />
 					</div>
 					<div className="flex items-center justify-between">
 						<Label htmlFor="mon-notify">{t`Send notifications`}</Label>

--- a/internal/site/src/components/routes/monitor-dialog.tsx
+++ b/internal/site/src/components/routes/monitor-dialog.tsx
@@ -1,0 +1,289 @@
+import { t } from "@lingui/core/macro"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { pb } from "@/lib/api"
+import type { MonitorRecord, MonitorType } from "@/types"
+
+const TYPES: { value: MonitorType; label: string; placeholder: string; hint: string }[] = [
+	{ value: "http", label: "HTTP(S)", placeholder: "https://example.com", hint: t`Full URL. Accepts 2xx by default.` },
+	{ value: "keyword", label: "Keyword", placeholder: "https://example.com", hint: t`HTTP check that also looks for text in the response.` },
+	{ value: "ping", label: "Ping", placeholder: "example.com", hint: t`ICMP echo. The hub may need NET_RAW capability in Docker.` },
+	{ value: "dns", label: "DNS", placeholder: "example.com", hint: t`Resolves a record type, optionally against a custom resolver.` },
+	{ value: "tls", label: "TLS cert", placeholder: "example.com:443", hint: t`Checks certificate expiry without an HTTP request.` },
+]
+
+interface FormState {
+	name: string
+	type: MonitorType
+	target: string
+	interval: string
+	timeout: string
+	keyword: string
+	qtype: string
+	resolver: string
+	port: string
+	notify: boolean
+}
+
+function initialState(monitor?: MonitorRecord): FormState {
+	const cfg = monitor?.config ?? {}
+	return {
+		name: monitor?.name ?? "",
+		type: monitor?.type ?? "http",
+		target: monitor?.target ?? "",
+		interval: String(monitor?.interval ?? 60),
+		timeout: String(monitor?.timeout ?? 10),
+		keyword: String(cfg.keyword ?? ""),
+		qtype: String(cfg.qtype ?? "A"),
+		resolver: String(cfg.resolver ?? ""),
+		port: String(cfg.port ?? ""),
+		notify: monitor?.notify ?? true,
+	}
+}
+
+export function MonitorDialog({
+	open,
+	setOpen,
+	monitor,
+	onSaved,
+}: {
+	open: boolean
+	setOpen: (open: boolean) => void
+	monitor?: MonitorRecord
+	onSaved: () => void
+}) {
+	const [form, setForm] = useState<FormState>(() => initialState(monitor))
+	const [error, setError] = useState("")
+	const [saving, setSaving] = useState(false)
+
+	const set = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+		setForm((prev) => ({ ...prev, [key]: value }))
+	}
+
+	// Refresh defaults when switching between monitors.
+	const [lastId, setLastId] = useState(monitor?.id)
+	if (monitor?.id !== lastId) {
+		setLastId(monitor?.id)
+		setForm(initialState(monitor))
+		setError("")
+	}
+
+	const save = async () => {
+		setError("")
+		const interval = Number.parseInt(form.interval, 10)
+		const timeout = Number.parseInt(form.timeout, 10)
+		if (!form.name.trim()) {
+			setError(t`Name is required.`)
+			return
+		}
+		if (!form.target.trim()) {
+			setError(t`Target is required.`)
+			return
+		}
+		if (!(interval >= 20)) {
+			setError(t`Interval must be at least 20 seconds.`)
+			return
+		}
+		if (!(timeout > 0 && timeout < interval)) {
+			setError(t`Timeout must be positive and less than the interval.`)
+			return
+		}
+		const config: Record<string, unknown> = {}
+		if (form.type === "keyword") {
+			if (!form.keyword) {
+				setError(t`Keyword is required for keyword monitors.`)
+				return
+			}
+			config.keyword = form.keyword
+		}
+		if (form.type === "dns") {
+			config.qtype = form.qtype || "A"
+			if (form.resolver.trim()) {
+				config.resolver = form.resolver.trim()
+			}
+		}
+		if (form.type === "tls" && form.port.trim()) {
+			const port = Number.parseInt(form.port, 10)
+			if (!(port > 0 && port <= 65535)) {
+				setError(t`Port must be between 1 and 65535.`)
+				return
+			}
+			config.port = port
+		}
+		setSaving(true)
+		try {
+			const body = {
+				name: form.name.trim(),
+				type: form.type,
+				target: form.target.trim(),
+				interval,
+				timeout,
+				notify: form.notify,
+				config,
+			}
+			if (monitor) {
+				await pb.collection("monitors").update(monitor.id, body)
+			} else {
+				await pb.collection("monitors").create(body)
+			}
+			onSaved()
+		} catch (e) {
+			setError(e instanceof Error ? e.message : String(e))
+		} finally {
+			setSaving(false)
+		}
+	}
+
+	const activeType = TYPES.find((x) => x.value === form.type) ?? TYPES[0]
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogContent className="sm:max-w-md">
+				<DialogHeader>
+					<DialogTitle>{monitor ? t`Edit monitor` : t`Add monitor`}</DialogTitle>
+					<DialogDescription>{t`External uptime check executed from the hub.`}</DialogDescription>
+				</DialogHeader>
+				<div className="grid gap-4">
+					<div className="grid gap-2">
+						<Label htmlFor="mon-name">{t`Name`}</Label>
+						<Input
+							id="mon-name"
+							value={form.name}
+							onChange={(e) => set("name", e.target.value)}
+							placeholder="Homepage"
+						/>
+					</div>
+					<div className="grid grid-cols-2 gap-4">
+						<div className="grid gap-2">
+							<Label htmlFor="mon-type">{t`Type`}</Label>
+							<Select value={form.type} onValueChange={(v) => set("type", v as MonitorType)}>
+								<SelectTrigger id="mon-type">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{TYPES.map((x) => (
+										<SelectItem key={x.value} value={x.value}>
+											{x.label}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="mon-target">{t`Target`}</Label>
+							<Input
+								id="mon-target"
+								value={form.target}
+								onChange={(e) => set("target", e.target.value)}
+								placeholder={activeType.placeholder}
+							/>
+						</div>
+					</div>
+					<p className="-mt-2 text-xs text-muted-foreground">{activeType.hint}</p>
+					{form.type === "keyword" && (
+						<div className="grid gap-2">
+							<Label htmlFor="mon-keyword">{t`Keyword`}</Label>
+							<Input
+								id="mon-keyword"
+								value={form.keyword}
+								onChange={(e) => set("keyword", e.target.value)}
+								placeholder="Welcome"
+							/>
+						</div>
+					)}
+					{form.type === "dns" && (
+						<div className="grid grid-cols-2 gap-4">
+							<div className="grid gap-2">
+								<Label htmlFor="mon-qtype">{t`Record type`}</Label>
+								<Select value={form.qtype} onValueChange={(v) => set("qtype", v)}>
+									<SelectTrigger id="mon-qtype">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{["A", "AAAA", "CNAME", "MX", "TXT", "NS", "SOA", "SRV", "CAA", "PTR"].map((q) => (
+											<SelectItem key={q} value={q}>
+												{q}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="grid gap-2">
+								<Label htmlFor="mon-resolver">{t`Resolver (optional)`}</Label>
+								<Input
+									id="mon-resolver"
+									value={form.resolver}
+									onChange={(e) => set("resolver", e.target.value)}
+									placeholder="1.1.1.1"
+								/>
+							</div>
+						</div>
+					)}
+					{form.type === "tls" && (
+						<div className="grid gap-2">
+							<Label htmlFor="mon-port">{t`Port (default 443)`}</Label>
+							<Input
+								id="mon-port"
+								value={form.port}
+								onChange={(e) => set("port", e.target.value)}
+								placeholder="443"
+								inputMode="numeric"
+							/>
+						</div>
+					)}
+					<div className="grid grid-cols-2 gap-4">
+						<div className="grid gap-2">
+							<Label htmlFor="mon-interval">{t`Interval (seconds)`}</Label>
+							<Input
+								id="mon-interval"
+								value={form.interval}
+								onChange={(e) => set("interval", e.target.value)}
+								inputMode="numeric"
+							/>
+						</div>
+						<div className="grid gap-2">
+							<Label htmlFor="mon-timeout">{t`Timeout (seconds)`}</Label>
+							<Input
+								id="mon-timeout"
+								value={form.timeout}
+								onChange={(e) => set("timeout", e.target.value)}
+								inputMode="numeric"
+							/>
+						</div>
+					</div>
+					<div className="flex items-center justify-between">
+						<Label htmlFor="mon-notify">{t`Send notifications`}</Label>
+						<Switch id="mon-notify" checked={form.notify} onCheckedChange={(v) => set("notify", v)} />
+					</div>
+					{error && <p className="text-sm text-destructive">{error}</p>}
+				</div>
+				<DialogFooter>
+					<Button variant="outline" onClick={() => setOpen(false)}>
+						{t`Cancel`}
+					</Button>
+					<Button onClick={save} disabled={saving}>
+						{t`Save`}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/internal/site/src/components/routes/monitor-dialog.tsx
+++ b/internal/site/src/components/routes/monitor-dialog.tsx
@@ -151,6 +151,32 @@ export function MonitorDialog({
 		// stored secrets when they are absent from the patch.
 		const config: Record<string, unknown> = { ...(monitor?.config ?? {}) }
 		const num = (v: string) => Number.parseInt(v, 10)
+		// Drop keys that belong to other monitor types so switching type
+		// cannot leave behind invisible behavior (e.g. a keyword check on
+		// an http monitor, or a qtype on a ping monitor).
+		for (const key of [
+			"keyword",
+			"invert_keyword",
+			"method",
+			"accepted_status_codes",
+			"auth_type",
+			"username",
+			"password",
+			"token",
+			"ignore_tls_errors",
+			"check_cert_expiry",
+			"warn_days",
+			"crit_days",
+			"qtype",
+			"protocol",
+			"resolver",
+			"expected_answer",
+			"count",
+			"packet_size",
+			"port",
+		]) {
+			delete config[key]
+		}
 		if (form.type === "keyword" || (form.type === "http" && form.keyword.trim())) {
 			if (form.type === "keyword" && !form.keyword) {
 				setError(t`Keyword is required for keyword monitors.`)

--- a/internal/site/src/components/routes/monitor.tsx
+++ b/internal/site/src/components/routes/monitor.tsx
@@ -1,0 +1,195 @@
+import { useLingui } from "@lingui/react/macro"
+import { useStore } from "@nanostores/react"
+import { memo, useEffect, useState } from "react"
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import { ActiveAlerts } from "@/components/active-alerts"
+import { FooterRepoLink } from "@/components/footer-repo-link"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import Spinner from "@/components/spinner"
+import { $router, Link } from "@/components/router"
+import { getPagePath } from "@nanostores/router"
+import { pb } from "@/lib/api"
+import type { MonitorCheckRecord, MonitorRecord, MonitorStatus } from "@/types"
+
+const STATUS_STYLES: Record<MonitorStatus, string> = {
+	up: "bg-green-500",
+	down: "bg-red-500",
+	warn: "bg-yellow-500",
+	paused: "bg-primary/40",
+	pending: "bg-yellow-500",
+}
+
+function formatTime(iso: string): string {
+	const d = new Date(iso)
+	return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+export default memo(({ id }: { id: string }) => {
+	const { t } = useLingui()
+	const [monitor, setMonitor] = useState<MonitorRecord | null>(null)
+	const [checks, setChecks] = useState<MonitorCheckRecord[] | null>(null)
+	const [error, setError] = useState("")
+	const router = useStore($router)
+
+	useEffect(() => {
+		let cancelled = false
+		pb.collection<MonitorRecord>("monitors")
+			.getOne(id)
+			.then((m) => {
+				if (cancelled) {
+					return
+				}
+				setMonitor(m)
+				document.title = `${m.name} / Beszel`
+			})
+			.catch((e: unknown) => {
+				if (!cancelled) {
+					setError(e instanceof Error ? e.message : String(e))
+				}
+			})
+		pb.send<MonitorCheckRecord[]>(`/api/beszel/monitors/${id}/checks?limit=200`, {})
+			.then((rows) => {
+				if (!cancelled) {
+					setChecks(rows)
+				}
+			})
+			.catch(() => {
+				if (!cancelled) {
+					setChecks([])
+				}
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [id, router])
+
+	if (error) {
+		return (
+			<Card>
+				<CardContent className="py-10 text-center text-destructive">{error}</CardContent>
+			</Card>
+		)
+	}
+	if (!monitor) {
+		return (
+			<div className="relative h-40">
+				<Spinner />
+			</div>
+		)
+	}
+
+	const latencies = (checks ?? [])
+		.filter((c) => c.latency_ms > 0)
+		.slice(-120)
+		.reverse()
+		.map((c) => ({ time: formatTime(c.created), ms: c.latency_ms }))
+
+	return (
+		<>
+			<div className="flex flex-col gap-4">
+				<ActiveAlerts />
+				<div className="flex items-center gap-3">
+					<Link href={getPagePath($router, "monitors")} className="text-sm text-muted-foreground hover:underline">
+						{t`Monitors`}
+					</Link>
+					<span className="text-sm text-muted-foreground">/</span>
+					<h1 className="text-xl font-semibold">{monitor.name}</h1>
+					<Badge className={STATUS_STYLES[monitor.status]}>{monitor.status}</Badge>
+				</div>
+				<div className="grid gap-4 md:grid-cols-3">
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-sm font-medium">{t`Target`}</CardTitle>
+						</CardHeader>
+						<CardContent className="font-mono text-xs break-all">{monitor.target}</CardContent>
+					</Card>
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-sm font-medium">{t`Uptime 24h`}</CardTitle>
+						</CardHeader>
+						<CardContent className="text-2xl font-semibold">
+							{monitor.uptime_24h > 0 ? `${monitor.uptime_24h.toFixed(1)}%` : "—"}
+						</CardContent>
+					</Card>
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-sm font-medium">{t`Last latency`}</CardTitle>
+						</CardHeader>
+						<CardContent className="text-2xl font-semibold">
+							{monitor.last_latency_ms > 0 ? `${monitor.last_latency_ms.toFixed(0)} ms` : "—"}
+						</CardContent>
+					</Card>
+				</div>
+				{(monitor.type === "tls" || monitor.target.startsWith("https")) && monitor.cert_days >= 0 && (
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-sm font-medium">{t`Certificate`}</CardTitle>
+						</CardHeader>
+						<CardContent className="text-sm text-muted-foreground">
+							{t`Expires in ${monitor.cert_days.toFixed(0)} days`}
+						</CardContent>
+					</Card>
+				)}
+				{latencies.length > 1 && (
+					<Card>
+						<CardHeader className="pb-2">
+							<CardTitle className="text-sm font-medium">{t`Latency (ms)`}</CardTitle>
+						</CardHeader>
+						<CardContent className="h-48">
+							<ResponsiveContainer width="100%" height="100%">
+								<AreaChart data={latencies}>
+									<CartesianGrid strokeDasharray="3 3" />
+									<XAxis dataKey="time" tick={false} />
+									<YAxis width={40} />
+									<Tooltip />
+									<Area type="monotone" dataKey="ms" stroke="#22c55e" fill="#22c55e33" />
+								</AreaChart>
+							</ResponsiveContainer>
+						</CardContent>
+					</Card>
+				)}
+				<Card>
+					<CardHeader className="pb-2">
+						<CardTitle className="text-sm font-medium">{t`Recent checks`}</CardTitle>
+					</CardHeader>
+					<CardContent>
+						{!checks ? (
+							<div className="relative h-24">
+								<Spinner />
+							</div>
+						) : checks.length === 0 ? (
+							<p className="py-4 text-center text-sm text-muted-foreground">{t`No checks recorded yet.`}</p>
+						) : (
+							<div className="max-h-96 overflow-auto">
+								<table className="w-full text-sm">
+									<thead className="sticky top-0 bg-background text-left text-muted-foreground">
+										<tr>
+											<th className="py-1 pr-2 font-medium">{t`Time`}</th>
+											<th className="py-1 pr-2 font-medium">{t`Status`}</th>
+											<th className="py-1 pr-2 font-medium">{t`Latency`}</th>
+											<th className="py-1 font-medium">{t`Message`}</th>
+										</tr>
+									</thead>
+									<tbody>
+										{checks.map((c) => (
+											<tr key={c.id} className="border-t">
+												<td className="py-1 pr-2 whitespace-nowrap text-xs">{formatTime(c.created)}</td>
+												<td className="py-1 pr-2">
+													<Badge className={STATUS_STYLES[c.status]}>{c.status}</Badge>
+												</td>
+												<td className="py-1 pr-2">{c.latency_ms > 0 ? `${c.latency_ms.toFixed(0)} ms` : "—"}</td>
+												<td className="py-1 text-xs text-muted-foreground">{c.message}</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
+						)}
+					</CardContent>
+				</Card>
+			</div>
+			<FooterRepoLink />
+		</>
+	)
+})

--- a/internal/site/src/components/routes/monitor.tsx
+++ b/internal/site/src/components/routes/monitor.tsx
@@ -81,7 +81,7 @@ export default memo(({ id }: { id: string }) => {
 
 	const latencies = (checks ?? [])
 		.filter((c) => c.latency_ms > 0)
-		.slice(-120)
+		.slice(0, 120)
 		.reverse()
 		.map((c) => ({ time: formatTime(c.created), ms: c.latency_ms }))
 

--- a/internal/site/src/components/routes/monitors.tsx
+++ b/internal/site/src/components/routes/monitors.tsx
@@ -1,0 +1,205 @@
+import { t } from "@lingui/core/macro"
+import { useLingui } from "@lingui/react/macro"
+import { useStore } from "@nanostores/react"
+import {
+	BellIcon,
+	BellOffIcon,
+	PauseIcon,
+	PlayIcon,
+	PlusIcon,
+	RotateCwIcon,
+	Trash2Icon,
+} from "lucide-react"
+import { memo, useEffect, useState } from "react"
+import { ActiveAlerts } from "@/components/active-alerts"
+import { FooterRepoLink } from "@/components/footer-repo-link"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import Spinner from "@/components/spinner"
+import { isReadOnlyUser, pb } from "@/lib/api"
+import { $monitors } from "@/lib/monitors"
+import type { MonitorRecord, MonitorStatus } from "@/types"
+import { MonitorDialog } from "./monitor-dialog"
+
+const STATUS_STYLES: Record<MonitorStatus, string> = {
+	up: "bg-green-500",
+	down: "bg-red-500",
+	warn: "bg-yellow-500",
+	paused: "bg-primary/40",
+	pending: "bg-yellow-500",
+}
+
+const TYPE_LABELS: Record<string, string> = {
+	http: "HTTP",
+	keyword: "Keyword",
+	ping: "Ping",
+	dns: "DNS",
+	tls: "TLS",
+}
+
+function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: MonitorRecord) => void }) {
+	const readonly = isReadOnlyUser()
+	const [testing, setTesting] = useState(false)
+
+	const update = async (body: object) => {
+		await pb.collection("monitors").update(monitor.id, body)
+	}
+
+	const runTest = async () => {
+		setTesting(true)
+		try {
+			await pb.send(`/api/beszel/monitors/${monitor.id}/test`, { method: "POST" })
+		} finally {
+			setTesting(false)
+		}
+	}
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+				<CardTitle className="text-base font-medium">
+					<button type="button" className="hover:underline" onClick={() => onEdit(monitor)}>
+						{monitor.name}
+					</button>
+				</CardTitle>
+				<div className="flex items-center gap-2">
+					<Badge className={STATUS_STYLES[monitor.status]}>{monitor.status}</Badge>
+					<Badge variant="outline">{TYPE_LABELS[monitor.type] ?? monitor.type}</Badge>
+				</div>
+			</CardHeader>
+			<CardContent className="text-sm text-muted-foreground">
+				<div className="truncate font-mono text-xs">{monitor.target}</div>
+				<div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+					{monitor.uptime_24h > 0 && <span>{t`Uptime 24h`} {monitor.uptime_24h.toFixed(1)}%</span>}
+					{monitor.last_latency_ms > 0 && <span>{monitor.last_latency_ms.toFixed(0)} ms</span>}
+					{monitor.cert_days > 0 && (
+						<span>
+							{t`Cert`} {monitor.cert_days.toFixed(0)} {t`days`}
+						</span>
+					)}
+				</div>
+				{!readonly && (
+					<div className="mt-3 flex flex-wrap gap-2">
+						<Button variant="outline" size="sm" disabled={testing} onClick={runTest} title={t`Run check now`}>
+							<RotateCwIcon className={testing ? "animate-spin" : ""} />
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => update({ paused: !monitor.paused })}
+							title={monitor.paused ? t`Resume` : t`Pause`}
+						>
+							{monitor.paused ? <PlayIcon /> : <PauseIcon />}
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => pb.collection("monitors").delete(monitor.id)}
+							title={t`Delete`}
+						>
+							<Trash2Icon />
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => update({ notify: !monitor.notify })}
+							title={monitor.notify ? t`Mute notifications` : t`Unmute notifications`}
+						>
+							{monitor.notify ? <BellIcon /> : <BellOffIcon />}
+						</Button>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	)
+}
+
+export default memo(() => {
+	const { t } = useLingui()
+	const monitors = useStore($monitors)
+	const [dialogOpen, setDialogOpen] = useState(false)
+	const [editing, setEditing] = useState<MonitorRecord | undefined>(undefined)
+	const [loaded, setLoaded] = useState(false)
+	const readonly = isReadOnlyUser()
+
+	useEffect(() => {
+		document.title = `${t`Monitors`} / Beszel`
+		pb.collection<MonitorRecord>("monitors")
+			.getFullList()
+			.then((records) => {
+				$monitors.set(Object.fromEntries(records.map((m) => [m.id, m])))
+				setLoaded(true)
+			})
+			.catch(() => setLoaded(true))
+		const unsub = pb.collection("monitors").subscribe("*", (e) => {
+			const record = e.record as unknown as MonitorRecord
+			const current = $monitors.get()
+			if (e.action === "delete") {
+				const next = { ...current }
+				delete next[record.id]
+				$monitors.set(next)
+			} else {
+				$monitors.set({ ...current, [record.id]: record })
+			}
+		})
+		return () => {
+			unsub.then((fn) => (typeof fn === "function" ? fn() : undefined))
+		}
+	}, [t])
+
+	const list = Object.values(monitors).sort((a, b) => a.name.localeCompare(b.name))
+
+	return (
+		<>
+			<div className="flex flex-col gap-4">
+				<ActiveAlerts />
+				<div className="flex items-center justify-between">
+					<h1 className="text-xl font-semibold">{t`Monitors`}</h1>
+					{!readonly && (
+						<Button
+							size="sm"
+							onClick={() => {
+								setEditing(undefined)
+								setDialogOpen(true)
+							}}
+						>
+							<PlusIcon /> {t`Add monitor`}
+						</Button>
+					)}
+				</div>
+				{!loaded ? (
+					<div className="relative h-40">
+						<Spinner />
+					</div>
+				) : list.length === 0 ? (
+					<Card>
+						<CardContent className="py-10 text-center text-muted-foreground">
+							{t`No monitors yet. Add your first HTTP, DNS, ping or TLS check.`}
+						</CardContent>
+					</Card>
+				) : (
+					<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+						{list.map((m) => (
+							<MonitorCard
+								key={m.id}
+								monitor={m}
+								onEdit={(mon) => {
+									setEditing(mon)
+									setDialogOpen(true)
+								}}
+							/>
+						))}
+					</div>
+				)}
+			</div>
+			<FooterRepoLink />
+			<MonitorDialog
+				open={dialogOpen}
+				setOpen={setDialogOpen}
+				monitor={editing}
+				onSaved={() => setDialogOpen(false)}
+			/>
+		</>
+	)
+})

--- a/internal/site/src/components/routes/monitors.tsx
+++ b/internal/site/src/components/routes/monitors.tsx
@@ -1,24 +1,30 @@
-import { t } from "@lingui/core/macro"
 import { useLingui } from "@lingui/react/macro"
 import { useStore } from "@nanostores/react"
-import {
-	BellIcon,
-	BellOffIcon,
-	PauseIcon,
-	PlayIcon,
-	PlusIcon,
-	RotateCwIcon,
-	Trash2Icon,
-} from "lucide-react"
 import { memo, useEffect, useState } from "react"
 import { ActiveAlerts } from "@/components/active-alerts"
 import { FooterRepoLink } from "@/components/footer-repo-link"
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Spinner from "@/components/spinner"
+import { toast } from "@/components/ui/use-toast"
+import { cn } from "@/lib/utils"
+import { Trans } from "@lingui/react/macro"
+import { BellIcon, BellOffIcon, PauseIcon, PencilIcon, PlayIcon, PlusIcon, RotateCwIcon, Trash2Icon } from "lucide-react"
+import { getPagePath } from "@nanostores/router"
+import { $router, Link } from "@/components/router"
 import { isReadOnlyUser, pb } from "@/lib/api"
-import { $monitors } from "@/lib/monitors"
+import { $monitors, cleanup, init } from "@/lib/monitors"
 import type { MonitorRecord, MonitorStatus } from "@/types"
 import { MonitorDialog } from "./monitor-dialog"
 
@@ -39,30 +45,43 @@ const TYPE_LABELS: Record<string, string> = {
 }
 
 function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: MonitorRecord) => void }) {
+	const { t } = useLingui()
 	const readonly = isReadOnlyUser()
 	const [testing, setTesting] = useState(false)
+	const [deleteOpen, setDeleteOpen] = useState(false)
 
-	const update = async (body: object) => {
-		await pb.collection("monitors").update(monitor.id, body)
+	const update = async (body: object, label: string) => {
+		try {
+			await pb.collection("monitors").update(monitor.id, body)
+		} catch (e) {
+			toast({ title: label, description: e instanceof Error ? e.message : String(e), variant: "destructive" })
+		}
 	}
 
 	const runTest = async () => {
 		setTesting(true)
 		try {
 			await pb.send(`/api/beszel/monitors/${monitor.id}/test`, { method: "POST" })
+			toast({ title: t`Check completed` })
+		} catch (e) {
+			toast({ title: t`Check failed`, description: e instanceof Error ? e.message : String(e), variant: "destructive" })
 		} finally {
 			setTesting(false)
 		}
 	}
 
+	const title = readonly ? (
+		<span>{monitor.name}</span>
+	) : (
+		<Link href={getPagePath($router, "monitor", { id: monitor.id })} className="hover:underline">
+			{monitor.name}
+		</Link>
+	)
+
 	return (
 		<Card>
 			<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-				<CardTitle className="text-base font-medium">
-					<button type="button" className="hover:underline" onClick={() => onEdit(monitor)}>
-						{monitor.name}
-					</button>
-				</CardTitle>
+				<CardTitle className="text-base font-medium">{title}</CardTitle>
 				<div className="flex items-center gap-2">
 					<Badge className={STATUS_STYLES[monitor.status]}>{monitor.status}</Badge>
 					<Badge variant="outline">{TYPE_LABELS[monitor.type] ?? monitor.type}</Badge>
@@ -71,12 +90,10 @@ function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: 
 			<CardContent className="text-sm text-muted-foreground">
 				<div className="truncate font-mono text-xs">{monitor.target}</div>
 				<div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
-					{monitor.uptime_24h > 0 && <span>{t`Uptime 24h`} {monitor.uptime_24h.toFixed(1)}%</span>}
-					{monitor.last_latency_ms > 0 && <span>{monitor.last_latency_ms.toFixed(0)} ms</span>}
-					{monitor.cert_days > 0 && (
-						<span>
-							{t`Cert`} {monitor.cert_days.toFixed(0)} {t`days`}
-						</span>
+					<span>{t`Uptime 24h: ${monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"}%`}</span>
+					{monitor.last_latency_ms > 0 && <span>{t`${monitor.last_latency_ms.toFixed(0)} ms`}</span>}
+					{monitor.cert_days >= 0 && monitor.cert_days < 60 && (
+						<span>{t`Cert expires in ${monitor.cert_days.toFixed(0)} days`}</span>
 					)}
 				</div>
 				{!readonly && (
@@ -87,23 +104,21 @@ function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: 
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => update({ paused: !monitor.paused })}
+							onClick={() => update({ paused: !monitor.paused }, t`Pause toggled`)}
 							title={monitor.paused ? t`Resume` : t`Pause`}
 						>
 							{monitor.paused ? <PlayIcon /> : <PauseIcon />}
 						</Button>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => pb.collection("monitors").delete(monitor.id)}
-							title={t`Delete`}
-						>
+						<Button variant="outline" size="sm" onClick={() => onEdit(monitor)} title={t`Edit`}>
+							<PencilIcon />
+						</Button>
+						<Button variant="outline" size="sm" onClick={() => setDeleteOpen(true)} title={t`Delete`}>
 							<Trash2Icon />
 						</Button>
 						<Button
 							variant="outline"
 							size="sm"
-							onClick={() => update({ notify: !monitor.notify })}
+							onClick={() => update({ notify: !monitor.notify }, t`Notifications toggled`)}
 							title={monitor.notify ? t`Mute notifications` : t`Unmute notifications`}
 						>
 							{monitor.notify ? <BellIcon /> : <BellOffIcon />}
@@ -111,6 +126,40 @@ function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: 
 					</div>
 				)}
 			</CardContent>
+			<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>
+							<Trans>Are you sure you want to delete {monitor.name}?</Trans>
+						</AlertDialogTitle>
+						<AlertDialogDescription>
+							<Trans>This action cannot be undone. This will permanently delete the monitor and its check history.</Trans>
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>
+							<Trans>Cancel</Trans>
+						</AlertDialogCancel>
+						<AlertDialogAction
+							className={cn(buttonVariants({ variant: "destructive" }))}
+							onClick={() =>
+								pb
+									.collection("monitors")
+									.delete(monitor.id)
+									.catch((e: unknown) =>
+										toast({
+											title: t`Delete failed`,
+											description: e instanceof Error ? e.message : String(e),
+											variant: "destructive",
+										})
+									)
+							}
+						>
+							<Trans>Continue</Trans>
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
 		</Card>
 	)
 }
@@ -121,32 +170,34 @@ export default memo(() => {
 	const [dialogOpen, setDialogOpen] = useState(false)
 	const [editing, setEditing] = useState<MonitorRecord | undefined>(undefined)
 	const [loaded, setLoaded] = useState(false)
+	const [loadError, setLoadError] = useState("")
 	const readonly = isReadOnlyUser()
 
 	useEffect(() => {
 		document.title = `${t`Monitors`} / Beszel`
+	}, [])
+
+	useEffect(() => {
+		init()
+		let cancelled = false
 		pb.collection<MonitorRecord>("monitors")
 			.getFullList()
-			.then((records) => {
-				$monitors.set(Object.fromEntries(records.map((m) => [m.id, m])))
-				setLoaded(true)
+			.then(() => {
+				if (!cancelled) {
+					setLoaded(true)
+				}
 			})
-			.catch(() => setLoaded(true))
-		const unsub = pb.collection("monitors").subscribe("*", (e) => {
-			const record = e.record as unknown as MonitorRecord
-			const current = $monitors.get()
-			if (e.action === "delete") {
-				const next = { ...current }
-				delete next[record.id]
-				$monitors.set(next)
-			} else {
-				$monitors.set({ ...current, [record.id]: record })
-			}
-		})
+			.catch((e: unknown) => {
+				if (!cancelled) {
+					setLoadError(e instanceof Error ? e.message : String(e))
+					setLoaded(true)
+				}
+			})
 		return () => {
-			unsub.then((fn) => (typeof fn === "function" ? fn() : undefined))
+			cancelled = true
+			cleanup()
 		}
-	}, [t])
+	}, [])
 
 	const list = Object.values(monitors).sort((a, b) => a.name.localeCompare(b.name))
 
@@ -172,6 +223,10 @@ export default memo(() => {
 					<div className="relative h-40">
 						<Spinner />
 					</div>
+				) : loadError ? (
+					<Card>
+						<CardContent className="py-10 text-center text-destructive">{loadError}</CardContent>
+					</Card>
 				) : list.length === 0 ? (
 					<Card>
 						<CardContent className="py-10 text-center text-muted-foreground">
@@ -194,12 +249,14 @@ export default memo(() => {
 				)}
 			</div>
 			<FooterRepoLink />
-			<MonitorDialog
-				open={dialogOpen}
-				setOpen={setDialogOpen}
-				monitor={editing}
-				onSaved={() => setDialogOpen(false)}
-			/>
+			{!readonly && (
+				<MonitorDialog
+					open={dialogOpen}
+					setOpen={setDialogOpen}
+					monitor={editing}
+					onSaved={() => setDialogOpen(false)}
+				/>
+			)}
 		</>
 	)
 })

--- a/internal/site/src/components/routes/monitors.tsx
+++ b/internal/site/src/components/routes/monitors.tsx
@@ -92,7 +92,7 @@ function MonitorCard({ monitor, onEdit }: { monitor: MonitorRecord; onEdit: (m: 
 				<div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
 					<span>{t`Uptime 24h: ${monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"}%`}</span>
 					{monitor.last_latency_ms > 0 && <span>{t`${monitor.last_latency_ms.toFixed(0)} ms`}</span>}
-					{monitor.cert_days >= 0 && monitor.cert_days < 60 && (
+					{monitor.cert_days > 0 && monitor.cert_days < 60 && (
 						<span>{t`Cert expires in ${monitor.cert_days.toFixed(0)} days`}</span>
 					)}
 				</div>

--- a/internal/site/src/components/routes/monitors.tsx
+++ b/internal/site/src/components/routes/monitors.tsx
@@ -24,7 +24,7 @@ import { BellIcon, BellOffIcon, PauseIcon, PencilIcon, PlayIcon, PlusIcon, Rotat
 import { getPagePath } from "@nanostores/router"
 import { $router, Link } from "@/components/router"
 import { isReadOnlyUser, pb } from "@/lib/api"
-import { $monitors, cleanup, init } from "@/lib/monitors"
+import { $monitors, init } from "@/lib/monitors"
 import type { MonitorRecord, MonitorStatus } from "@/types"
 import { MonitorDialog } from "./monitor-dialog"
 
@@ -178,10 +178,8 @@ export default memo(() => {
 	}, [])
 
 	useEffect(() => {
-		init()
 		let cancelled = false
-		pb.collection<MonitorRecord>("monitors")
-			.getFullList()
+		init()
 			.then(() => {
 				if (!cancelled) {
 					setLoaded(true)
@@ -195,7 +193,6 @@ export default memo(() => {
 			})
 		return () => {
 			cancelled = true
-			cleanup()
 		}
 	}, [])
 

--- a/internal/site/src/components/routes/settings/config-yaml.tsx
+++ b/internal/site/src/components/routes/settings/config-yaml.tsx
@@ -45,8 +45,8 @@ export default function ConfigYaml() {
 					<Trans>YAML Configuration</Trans>
 				</h3>
 				<p className="text-sm text-muted-foreground leading-relaxed">
-					<Trans>Export your current systems configuration.</Trans>
-				</p>
+						<Trans>Export your current systems and monitors configuration.</Trans>
+					</p>
 			</div>
 			<Separator className="my-4" />
 			<div className="space-y-2">
@@ -57,11 +57,13 @@ export default function ConfigYaml() {
 							inside your data directory.
 						</Trans>
 					</p>
-					<p className="text-sm text-muted-foreground leading-relaxed">
-						<Trans>
-							On each restart, systems in the database will be updated to match the systems defined in the file.
-						</Trans>
-					</p>
+						<p className="text-sm text-muted-foreground leading-relaxed">
+							<Trans>
+								On each restart, systems in the database will be updated to match the systems defined in the file.
+								Monitors defined under the <code className="bg-muted rounded-sm px-1 text-primary">monitors</code> key
+								are created or updated the same way, but monitors missing from the file are never deleted.
+							</Trans>
+						</p>
 					<Alert className="my-4 border-destructive text-destructive w-auto table md:pe-6">
 						<AlertCircleIcon className="size-4.5 stroke-destructive" />
 						<AlertTitle>

--- a/internal/site/src/lib/monitors.ts
+++ b/internal/site/src/lib/monitors.ts
@@ -7,6 +7,7 @@ export const $monitorsSummary = map<MonitorsSummary | null>(null)
 
 let initialized = false
 let unsub: (() => void) | null = null
+let loadedOnce: Promise<void> | null = null
 
 async function refresh() {
 	try {
@@ -27,13 +28,15 @@ async function refreshSummary() {
 	}
 }
 
-/** Initialize the monitors store and realtime subscription (call once). */
-export function init() {
+/** Initialize the monitors store and realtime subscription (call once).
+ * Returns a promise that resolves after the first load. Pages must NOT
+ * call cleanup() (app-lifetime subscription owned by main.tsx). */
+export function init(): Promise<void> {
 	if (initialized) {
-		return
+		return loadedOnce ?? Promise.resolve()
 	}
 	initialized = true
-	refresh()
+	loadedOnce = refresh()
 	pb.collection("monitors")
 		.subscribe("*", (e) => {
 			const record = e.record as unknown as MonitorRecord
@@ -53,6 +56,7 @@ export function init() {
 		.catch(() => {
 			unsub = null
 		})
+	return loadedOnce
 }
 
 export function cleanup() {

--- a/internal/site/src/lib/monitors.ts
+++ b/internal/site/src/lib/monitors.ts
@@ -6,7 +6,7 @@ export const $monitors = map<Record<string, MonitorRecord>>({})
 export const $monitorsSummary = map<MonitorsSummary | null>(null)
 
 let initialized = false
-let unsub: (() => void) | undefined | void
+let unsub: (() => void) | null = null
 
 async function refresh() {
 	try {
@@ -15,33 +15,7 @@ async function refresh() {
 	} catch {
 		// collection may not exist on older hubs; stay empty
 	}
-	try {
-		const summary = await pb.send<MonitorsSummary>("/api/beszel/monitors/summary", {})
-		$monitorsSummary.set(summary)
-	} catch {
-		// ignore
-	}
-}
-
-/** Initialize the monitors store and realtime subscription */
-export function init() {
-	if (initialized) {
-		return
-	}
-	initialized = true
-	refresh()
-	unsub = pb.collection("monitors").subscribe("*", (e) => {
-		const record = e.record as unknown as MonitorRecord
-	 const current = $monitors.get()
-		if (e.action === "delete") {
-			const next = { ...current }
-			delete next[record.id]
-			$monitors.set(next)
-		} else {
-			$monitors.set({ ...current, [record.id]: record })
-		}
-		refreshSummary()
-	}) as unknown as void
+	await refreshSummary()
 }
 
 async function refreshSummary() {
@@ -53,8 +27,36 @@ async function refreshSummary() {
 	}
 }
 
+/** Initialize the monitors store and realtime subscription (call once). */
+export function init() {
+	if (initialized) {
+		return
+	}
+	initialized = true
+	refresh()
+	pb.collection("monitors")
+		.subscribe("*", (e) => {
+			const record = e.record as unknown as MonitorRecord
+			const current = $monitors.get()
+			if (e.action === "delete") {
+				const next = { ...current }
+				delete next[record.id]
+				$monitors.set(next)
+			} else {
+				$monitors.set({ ...current, [record.id]: record })
+			}
+			refreshSummary()
+		})
+		.then((fn) => {
+			unsub = fn
+		})
+		.catch(() => {
+			unsub = null
+		})
+}
+
 export function cleanup() {
 	unsub?.()
-	unsub = undefined
+	unsub = null
 	initialized = false
 }

--- a/internal/site/src/lib/monitors.ts
+++ b/internal/site/src/lib/monitors.ts
@@ -1,0 +1,60 @@
+import { map } from "nanostores"
+import { pb } from "@/lib/api"
+import type { MonitorRecord, MonitorsSummary } from "@/types"
+
+export const $monitors = map<Record<string, MonitorRecord>>({})
+export const $monitorsSummary = map<MonitorsSummary | null>(null)
+
+let initialized = false
+let unsub: (() => void) | undefined | void
+
+async function refresh() {
+	try {
+		const records = await pb.collection<MonitorRecord>("monitors").getFullList()
+		$monitors.set(Object.fromEntries(records.map((m) => [m.id, m])))
+	} catch {
+		// collection may not exist on older hubs; stay empty
+	}
+	try {
+		const summary = await pb.send<MonitorsSummary>("/api/beszel/monitors/summary", {})
+		$monitorsSummary.set(summary)
+	} catch {
+		// ignore
+	}
+}
+
+/** Initialize the monitors store and realtime subscription */
+export function init() {
+	if (initialized) {
+		return
+	}
+	initialized = true
+	refresh()
+	unsub = pb.collection("monitors").subscribe("*", (e) => {
+		const record = e.record as unknown as MonitorRecord
+	 const current = $monitors.get()
+		if (e.action === "delete") {
+			const next = { ...current }
+			delete next[record.id]
+			$monitors.set(next)
+		} else {
+			$monitors.set({ ...current, [record.id]: record })
+		}
+		refreshSummary()
+	}) as unknown as void
+}
+
+async function refreshSummary() {
+	try {
+		const summary = await pb.send<MonitorsSummary>("/api/beszel/monitors/summary", {})
+		$monitorsSummary.set(summary)
+	} catch {
+		// ignore
+	}
+}
+
+export function cleanup() {
+	unsub?.()
+	unsub = undefined
+	initialized = false
+}

--- a/internal/site/src/locales/ar/ar.po
+++ b/internal/site/src/locales/ar/ar.po
@@ -126,6 +126,11 @@ msgstr "الحالة النشطة"
 msgid "Add {foo}"
 msgstr "إضافة {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "إضافة رابط"
@@ -327,6 +332,7 @@ msgstr "يمكن البدء"
 msgid "Can stop"
 msgstr "يمكن الإيقاف"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "تحذير - فقدان محتمل للبيانات"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "درجة مئوية (°م)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "تحقق من خدمة المراقبة الخاصة بك"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "تحقق من خدمة الإشعارات الخاصة بك"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "الدورات"
 msgid "Daily"
 msgstr "يوميًا"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "افتراضي"
 msgid "Default time period"
 msgstr "الفترة الزمنية الافتراضية"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "تعديل"
 msgid "Edit {foo}"
 msgstr "إضافة {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "تصدير التكوين"
 msgid "Export your current systems configuration."
 msgstr "تصدير تكوين الأنظمة الحالية الخاصة بك."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "فهرنهايت (°ف)"
@@ -916,6 +943,10 @@ msgstr "أمر FreeBSD"
 msgid "Full"
 msgstr "ممتلئة"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "أمر Homebrew"
 msgid "Host / IP"
 msgstr "مضيف / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "طريقة HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "استخدام الإدخال والإخراج"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "غير نشط"
 msgid "Interval"
 msgstr "الفاصل الزمني"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "عنوان البريد الإشباكي غير صالح."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "استخدام الذاكرة للحاويات"
 msgid "Model"
 msgstr "الموديل"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "نقطة الربط"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "الاسم"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "لا"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "لا تتوفر بيانات تفصيلية لمجموعة التخزين هذه."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "تم استلام طلب إعادة تعيين كلمة المرور"
 msgid "Past"
 msgstr "الماضي"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "إيقاف مؤقت"
@@ -1391,6 +1467,14 @@ msgstr "استخدام مجموعة التخزين"
 msgid "Port"
 msgstr "المنفذ"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "أخطاء القراءة"
 msgid "Received"
 msgstr "تم الاستلام"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "إعادة تعيين كلمة المرور"
 msgid "Resolved"
 msgstr "تم حلها"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "إعادة التشغيل"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "استئناف"
@@ -1511,6 +1608,10 @@ msgstr "تدوير الرمز المميز"
 msgid "Rows per page"
 msgstr "صفوف لكل صفحة"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "مقاييس وقت التشغيل"
@@ -1522,6 +1623,10 @@ msgstr "تفاصيل S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "اختبار S.M.A.R.T. الذاتي"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "تحديد {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "أرسل ping نبضة قلب واحدة للتحقق من أن نقطة النهاية الخاصة بك تعمل."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "تبويبات"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "المهام"
@@ -1779,6 +1896,14 @@ msgstr "معدل نقل البيانات لمجموعة ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "تنسيق الوقت"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "يتم التفعيل عندما يتغير الحالة بين التش
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "يتم التفعيل عندما يتجاوز استخدام أي قرص عتبة معينة"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "غير معروفة"
 msgid "Unlimited"
 msgstr "غير محدود"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "رفع"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "مدة التشغيل"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ar/ar.po
+++ b/internal/site/src/locales/ar/ar.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} متاح"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "تم تحديد {0} من {1} صف"
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 يومًا"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 دقائق"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "وكيل"
 msgid "Alert History"
 msgstr "سجل التنبيهات"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "جميع الحاويات"
 msgid "All Systems"
 msgstr "جميع الأنظمة"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "هل أنت متأكد أنك تريد حذف {name}؟"
@@ -196,6 +238,10 @@ msgstr "هل أنت متأكد أنك تريد حذف {name}؟"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "هل أنت متأكد؟"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "النسخ الاحتياطية"
 msgid "Bandwidth"
 msgstr "عرض النطاق الترددي"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "بطارية"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "البطارية"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "يمكن الإيقاف"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "درجة مئوية (°م)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "عرض الرسم البياني"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "تحقق من {email} للحصول على رابط إعادة التعيين."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "صحة الحاوية"
 msgid "Containers"
 msgstr "حاويات"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "أنشئت"
 msgid "Critical (%)"
 msgstr "حرج (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "إجمالي البيانات المقروءة منذ الإقلاع"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "يوميًا"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "الفترة الزمنية الافتراضية"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "حذف"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "تنزيل"
 msgid "Duration"
 msgstr "المدة"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "سيتم حذف الأنظمة الحالية غير المعرفة في
 msgid "Exited active"
 msgstr "خرج نشطًا"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "ينتهي بعد ساعة واحدة أو عند إعادة تشغيل المحور."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "تصدير التكوين"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "تصدير تكوين الأنظمة الحالية الخاصة بك."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "تصدير تكوين الأنظمة الحالية الخاصة بك."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "مضيف / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "خاملة"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "إذا فقدت كلمة المرور لحساب المسؤول الخاص بك، يمكنك إعادة تعيينها باستخدام الأمر التالي."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "عنوان البريد الإشباكي غير صالح."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "اللغة"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "استخدام الذاكرة"
 msgid "Memory usage of containers"
 msgstr "استخدام الذاكرة للحاويات"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "الموديل"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "وحدة الشبكة"
 msgid "No"
 msgstr "لا"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "لا تتوفر بيانات تفصيلية لمجموعة التخزين هذه."
@@ -1287,6 +1424,7 @@ msgstr "لا توجد سمات S.M.A.R.T. متاحة لهذا الجهاز."
 msgid "No systems found."
 msgstr "لم يتم العثور على أنظمة."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "لا شيء"
@@ -1301,13 +1439,21 @@ msgstr "الإشعارات"
 msgid "Notifications may include recent container log excerpts."
 msgstr "قد تتضمن الإشعارات مقتطفات حديثة من سجلات الحاويات."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "دعم OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "في كل إعادة تشغيل، سيتم تحديث الأنظمة في قاعدة البيانات لتتطابق مع الأنظمة المعرفة في الملف."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "في كل إعادة تشغيل، سيتم تحديث الأنظمة في قاعدة البيانات لتتطابق مع الأنظمة المعرفة في الملف."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "أخرى"
 msgid "Overwrite existing alerts"
 msgstr "الكتابة فوق التنبيهات الحالية"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "الصفحات / الإعدادات"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "كلمة المرور"
 
@@ -1388,6 +1547,10 @@ msgstr "الماضي"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "إيقاف مؤقت"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "دائم"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "الاستمرارية"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "اللغة المفضلة"
 msgid "Process started"
 msgstr "تم بدء العملية"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "أخطاء القراءة"
 msgid "Received"
 msgstr "تم الاستلام"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "مطلوب من قبل"
 msgid "Requires"
 msgstr "يتطلب"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "إعادة تعيين كلمة المرور"
@@ -1592,6 +1775,14 @@ msgstr "إعادة التشغيل"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "استئناف"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "الحالة"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "تبويبات"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "ثم قم بتسجيل الدخول إلى الواجهة الخلفية
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "لا يمكن التراجع عن هذا الإجراء. سيؤدي ذلك إلى حذف جميع السجلات الحالية لـ {name} من قاعدة البيانات بشكل دائم."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "سيؤدي هذا إلى حذف جميع السجلات المحددة من قاعدة البيانات بشكل دائم."
@@ -1892,6 +2089,10 @@ msgstr "معدل نقل {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "معدل نقل البيانات لمجموعة ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "إلى البريد الإشباكي"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "رمز مميز"
@@ -2093,8 +2295,13 @@ msgstr "رفع"
 msgid "Uptime"
 msgstr "مدة التشغيل"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "استخدام مجموعة ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "مستخدم"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "هل تريد مساعدتنا في تحسين ترجماتنا؟ تحق
 msgid "Wants"
 msgstr "يريد"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "تحذير (%)"
@@ -2170,6 +2385,10 @@ msgstr "تحذير (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "عتبات التحذير"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/bg/bg.po
+++ b/internal/site/src/locales/bg/bg.po
@@ -126,6 +126,11 @@ msgstr "Активно състояние"
 msgid "Add {foo}"
 msgstr "Добави {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Добави URL"
@@ -327,6 +332,7 @@ msgstr "Може да се стартира"
 msgid "Can stop"
 msgstr "Може да се спре"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Внимание - възможност за загуба на данн�
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Целзий (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Проверете мониторинг услугата си"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Провери услугата си за удостоверяване"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Цикли"
 msgid "Daily"
 msgstr "Дневно"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Подредба"
 msgid "Default time period"
 msgstr "Времеви диапазон по подразбиране"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Редактирай"
 msgid "Edit {foo}"
 msgstr "Редактиране на {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Експортирай конфигурация"
 msgid "Export your current systems configuration."
 msgstr "Експортирай конфигурацията на системите."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Фаренхайт (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD команда"
 msgid "Full"
 msgstr "Пълна"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Команда Homebrew"
 msgid "Host / IP"
 msgstr "Хост / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP метод"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O натоварване"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Неактивен"
 msgid "Interval"
 msgstr "Интервал"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Невалиден имейл адрес."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Използване на паметта от контейнерите"
 msgid "Model"
 msgstr "Модел"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Точка на монтиране"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Име"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Не"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Няма подробни данни за този пул."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Получено е искането за нулиране на паро
 msgid "Past"
 msgstr "Минал"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Пауза"
@@ -1391,6 +1467,14 @@ msgstr "Използване на пула"
 msgid "Port"
 msgstr "Порт"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Грешки при четене"
 msgid "Received"
 msgstr "Получени"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Нулиране на парола"
 msgid "Resolved"
 msgstr "Решен"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Рестартирания"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Възобнови"
@@ -1511,6 +1608,10 @@ msgstr "Пресъздаване на идентификатора"
 msgid "Rows per page"
 msgstr "Редове на страница"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Метрики на изпълнение"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. Детайли"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Самотест"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Избери {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Изпратете единичен heartbeat пинг, за да се уверите, че крайната Ви точка работи."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Табове"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Задачи"
@@ -1779,6 +1896,14 @@ msgstr "Пропускателна способност на ZFS пул {poolNam
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Формат на времето"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Задейства се, когато статуса превключв�
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Задейства се, когато употребата на някой диск надивши зададен праг"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Неизвестна"
 msgid "Unlimited"
 msgstr "Неограничено"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Качване"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Време на работа"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/bg/bg.po
+++ b/internal/site/src/locales/bg/bg.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "Версия {0} е налична"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} от {1} селектирани."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 дни"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 минути"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Агент"
 msgid "Alert History"
 msgstr "История на нотификациите"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Всички контейнери"
 msgid "All Systems"
 msgstr "Всички системи"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Сигурен ли си, че искаш да изтриеш {name}?"
@@ -196,6 +238,10 @@ msgstr "Сигурен ли си, че искаш да изтриеш {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Сигурни ли сте?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Архиви"
 msgid "Bandwidth"
 msgstr "Bandwidth на мрежата"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Бат"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Батерия"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Може да се спре"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Целзий (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Ширина на графиката"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Провери {email} за линк за нулиране."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Здраве на контейнера"
 msgid "Containers"
 msgstr "Контейнери"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Създаден"
 msgid "Critical (%)"
 msgstr "Критично (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Натрупани прочетени данни от стартирането"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Дневно"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Времеви диапазон по подразбиране"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Изтрий"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Изтегляне"
 msgid "Duration"
 msgstr "Продължителност"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Съществуващи системи които не са дефин�
 msgid "Exited active"
 msgstr "Излезе активно"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Изтича след един час или при рестартиране на хъба."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Експортирай конфигурация"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Експортирай конфигурацията на системите."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Експортирай конфигурацията на системите."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Хост / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Неактивна"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Ако си загубил паролата до администраторския акаунт, можеш да я нулираш със следващата команда."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Невалиден имейл адрес."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Език"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Употреба на паметта"
 msgid "Memory usage of containers"
 msgstr "Използване на паметта от контейнерите"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Модел"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Единица за измерване на скорост"
 msgid "No"
 msgstr "Не"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Няма подробни данни за този пул."
@@ -1287,6 +1424,7 @@ msgstr "Няма налични S.M.A.R.T. атрибути за това уст
 msgid "No systems found."
 msgstr "Няма намерени системи."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Няма"
@@ -1301,13 +1439,21 @@ msgstr "Нотификации"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Известията може да включват скорошни откъси от регистрационните файлове на контейнерите."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Поддръжка на OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "На всеки рестарт, системите в датабазата ще бъдат обновени да съвпадат със системите зададени във файла."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "На всеки рестарт, системите в датабазата ще бъдат обновени да съвпадат със системите зададени във файла."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Други"
 msgid "Overwrite existing alerts"
 msgstr "Презапиши съществуващи тревоги"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Страници / Настройки"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Парола"
 
@@ -1388,6 +1547,10 @@ msgstr "Минал"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Пауза"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Постоянен"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Устойчивост"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Предпочитан език"
 msgid "Process started"
 msgstr "Процесът стартира"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Грешки при четене"
 msgid "Received"
 msgstr "Получени"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Изисква се от"
 msgid "Requires"
 msgstr "Изисква"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Нулиране на парола"
@@ -1592,6 +1775,14 @@ msgstr "Рестартирания"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Възобнови"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Състояние"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Табове"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "След това влез в backend-а и нулирай парола�
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Това действие не може да бъде отменено. Това ще изтрие всички записи за {name} от датабазата."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Това ще доведе до трайно изтриване на всички избрани записи от базата данни."
@@ -1892,6 +2089,10 @@ msgstr "Пропускателна способност на {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Пропускателна способност на ZFS пул {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "До имейл(ите)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Токен"
@@ -2093,8 +2295,13 @@ msgstr "Качване"
 msgid "Uptime"
 msgstr "Време на работа"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Използване на ZFS пул {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Използвани"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Искаш да помогнеш да направиш преводит�
 msgid "Wants"
 msgstr "Иска"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Предупреждение (%)"
@@ -2170,6 +2385,10 @@ msgstr "Предупреждение (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Прагове за предупреждение"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/cs/cs.po
+++ b/internal/site/src/locales/cs/cs.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} k dispozici"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} z {1} vybraných řádků."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dní"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Historie upozornění"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Všechny kontejnery"
 msgid "All Systems"
 msgstr "Všechny systémy"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Opravdu chcete odstranit {name}?"
@@ -196,6 +238,10 @@ msgstr "Opravdu chcete odstranit {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Jste si jistý?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Zálohy"
 msgid "Bandwidth"
 msgstr "Přenos"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Baterie"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Může zastavit"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsia (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Šířka grafu"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Zkontrolujte {email} pro odkaz na obnovení."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Zdraví kontejneru"
 msgid "Containers"
 msgstr "Kontejnery"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Vytvořeno"
 msgid "Critical (%)"
 msgstr "Kritické (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Kumulativní data přečtená od spuštění"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Denně"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Výchozí doba"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Odstranit"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Stažení"
 msgid "Duration"
 msgstr "Doba trvání"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Stávající systémy, které nejsou definovány v <0>config.yml</0>, bu
 msgid "Exited active"
 msgstr "Ukončeno aktivně"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Vyprší po jedné hodině nebo při restartu hubu."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Exportovat konfiguraci"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exportovat aktuální konfiguraci systémů."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exportovat aktuální konfiguraci systémů."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Hostitel / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Neaktivní"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Pokud jste ztratili heslo k vašemu účtu správce, můžete jej obnovit pomocí následujícího příkazu."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Neplatná e-mailová adresa."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Jazyk"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Využití paměti"
 msgid "Memory usage of containers"
 msgstr "Využití paměti kontejnery"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr ""
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Síťová jednotka"
 msgid "No"
 msgstr "Ne"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Pro tento fond nejsou k dispozici podrobné údaje."
@@ -1287,6 +1424,7 @@ msgstr "Pro toto zařízení nejsou k dispozici žádné atributy S.M.A.R.T."
 msgid "No systems found."
 msgstr "Nenalezeny žádné systémy."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Žádné"
@@ -1301,13 +1439,21 @@ msgstr "Upozornění"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Oznámení mohou obsahovat nedávné výňatky z protokolů kontejnerů."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Podpora OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Při každém restartu budou systémy v databázi aktualizovány tak, aby odpovídaly systémům definovaným v souboru."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Při každém restartu budou systémy v databázi aktualizovány tak, aby odpovídaly systémům definovaným v souboru."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Jiné"
 msgid "Overwrite existing alerts"
 msgstr "Přepsat existující upozornění"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Stránky / Nastavení"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Heslo"
 
@@ -1388,6 +1547,10 @@ msgstr "Minulé"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pozastavit"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Trvalý"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Trvalost"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Upřednostňovaný jazyk"
 msgid "Process started"
 msgstr "Proces spuštěn"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Chyby čtení"
 msgid "Received"
 msgstr "Přijato"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Vyžadováno službou"
 msgid "Requires"
 msgstr "Vyžaduje"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Obnovit heslo"
@@ -1592,6 +1775,14 @@ msgstr "Restarty"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Pokračovat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Stav"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Karty"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Poté se přihlaste do backendu a obnovte heslo k uživatelskému účtu
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Tuto akci nelze vzít zpět. Tím se z databáze trvale odstraní všechny aktuální záznamy pro {name}."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Tímto trvale odstraníte všechny vybrané záznamy z databáze."
@@ -1892,6 +2089,10 @@ msgstr "Propustnost {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Propustnost fondu ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Na email(y)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr ""
@@ -2093,8 +2295,13 @@ msgstr "Odeslání"
 msgid "Uptime"
 msgstr "Doba provozu"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Využití fondu ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Využito"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Chcete nám pomoci s našimi překlady ještě lépe? Podívejte se na <
 msgid "Wants"
 msgstr "Chce"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Varování (%)"
@@ -2170,6 +2385,10 @@ msgstr "Varování (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Prahové hodnoty pro varování"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/cs/cs.po
+++ b/internal/site/src/locales/cs/cs.po
@@ -126,6 +126,11 @@ msgstr "Aktivní stav"
 msgid "Add {foo}"
 msgstr "Přidat {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Přidat URL"
@@ -327,6 +332,7 @@ msgstr "Může spustit"
 msgid "Can stop"
 msgstr "Může zastavit"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Upozornění - možná ztráta dat"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsia (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Zkontrolujte svou monitorovací službu"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Zkontrolujte službu upozornění"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cykly"
 msgid "Daily"
 msgstr "Denně"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Výchozí"
 msgid "Default time period"
 msgstr "Výchozí doba"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Upravit"
 msgid "Edit {foo}"
 msgstr "Upravit {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Exportovat konfiguraci"
 msgid "Export your current systems configuration."
 msgstr "Exportovat aktuální konfiguraci systémů."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheita (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD příkaz"
 msgid "Full"
 msgstr "Plná"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew příkaz"
 msgid "Host / IP"
 msgstr "Hostitel / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP metoda"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O Využití"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Neaktivní"
 msgid "Interval"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Neplatná e-mailová adresa."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Využití paměti kontejnery"
 msgid "Model"
 msgstr ""
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Bod připojení"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Název"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Ne"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Pro tento fond nejsou k dispozici podrobné údaje."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Žádost o obnovu hesla byla přijata"
 msgid "Past"
 msgstr "Minulé"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pozastavit"
@@ -1391,6 +1467,14 @@ msgstr "Využití fondu"
 msgid "Port"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Chyby čtení"
 msgid "Received"
 msgstr "Přijato"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Obnovit heslo"
 msgid "Resolved"
 msgstr "Vyřešeno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Restarty"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Pokračovat"
@@ -1511,6 +1608,10 @@ msgstr "Změnit token"
 msgid "Rows per page"
 msgstr "Řádků na stránku"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metriky běhu"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. Detaily"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Vlastní test"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Vybrat {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Odešlete jeden heartbeat ping pro ověření funkčnosti vašeho koncového bodu."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Karty"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Úlohy"
@@ -1779,6 +1896,14 @@ msgstr "Propustnost fondu ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Formát času"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Spouští se, když se změní dostupnost"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Spustí se, když využití disku překročí prahovou hodnotu"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Neznámá"
 msgid "Unlimited"
 msgstr "Neomezeno"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Odeslání"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Doba provozu"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/da/da.po
+++ b/internal/site/src/locales/da/da.po
@@ -126,6 +126,11 @@ msgstr "Aktiv tilstand"
 msgid "Add {foo}"
 msgstr "Tilføj {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Tilføj URL"
@@ -327,6 +332,7 @@ msgstr "Kan starte"
 msgid "Can stop"
 msgstr "Kan stoppe"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Forsigtig - muligt tab af data"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Tjek din overvågningstjeneste"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Tjek din notifikationstjeneste"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cykler"
 msgid "Daily"
 msgstr "Dagligt"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standard"
 msgid "Default time period"
 msgstr "Standard tidsperiode"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Rediger"
 msgid "Edit {foo}"
 msgstr "Rediger {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Eksporter konfiguration"
 msgid "Export your current systems configuration."
 msgstr "Eksporter din nuværende systemkonfiguration."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD kommando"
 msgid "Full"
 msgstr "Fuldt opladt"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew-kommando"
 msgid "Host / IP"
 msgstr "Vært / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-metode"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O Udnyttelse"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inaktiv"
 msgid "Interval"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Ugyldig email adresse."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Containeres hukommelsesforbrug"
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Monteringspunkt"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Navn"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nej"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ingen detaljerede data for denne pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Anmodning om nulstilling af adgangskode modtaget"
 msgid "Past"
 msgstr "Tidligere"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
@@ -1391,6 +1467,14 @@ msgstr "Poolforbrug"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Læsefejl"
 msgid "Received"
 msgstr "Modtaget"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Nulstil adgangskode"
 msgid "Resolved"
 msgstr "Løst"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Genstarter"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Genoptag"
@@ -1511,6 +1608,10 @@ msgstr "Roter nøgle"
 msgid "Rows per page"
 msgstr "Rækker per side"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Køretidsmålinger"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.-detaljer"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. selvtest"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Vælg {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Send et enkelt heartbeat-ping for at bekræfte, at dit endpoint fungerer."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Faner"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Opgaver"
@@ -1779,6 +1896,14 @@ msgstr "Gennemløb for ZFS-pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Tidsformat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Udløser når status skifter mellem op og ned"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Udløser når brugen af en disk overstiger en tærskel"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Ukendt"
 msgid "Unlimited"
 msgstr "Ubegrænset"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Overfør"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Oppetid"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/da/da.po
+++ b/internal/site/src/locales/da/da.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} tilgængelig"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} af {1} række(r) valgt."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dage"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 minutter"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Advarselshistorik"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle systemer"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på, at du vil slette {name}?"
@@ -196,6 +238,10 @@ msgstr "Er du sikker på, at du vil slette {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Er du sikker?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Sikkerhedskopier"
 msgid "Bandwidth"
 msgstr "Båndbredde"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batteri"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Kan stoppe"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Grafbredde"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Tjek {email} for et nulstillingslink."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Container-sundhed"
 msgid "Containers"
 msgstr "Containere"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Oprettet"
 msgid "Critical (%)"
 msgstr "Kritisk (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Samlet mængde data læst siden opstart"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Dagligt"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standard tidsperiode"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Slet"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Hent ned"
 msgid "Duration"
 msgstr "Varighed"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Eksisterende systemer ikke defineret i <0>config.yml</0> vil blive slett
 msgid "Exited active"
 msgstr "Afsluttet aktiv"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Udløber efter en time eller ved hub-genstart."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Eksporter konfiguration"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Eksporter din nuværende systemkonfiguration."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Eksporter din nuværende systemkonfiguration."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Vært / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inaktiv"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Hvis du har mistet adgangskoden til din administratorkonto, kan du nulstille den ved hjælp af følgende kommando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Ugyldig email adresse."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Sprog"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Hukommelsesforbrug"
 msgid "Memory usage of containers"
 msgstr "Containeres hukommelsesforbrug"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Netværksenhed"
 msgid "No"
 msgstr "Nej"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ingen detaljerede data for denne pool."
@@ -1287,6 +1424,7 @@ msgstr "Ingen S.M.A.R.T.-attributter tilgængelige for denne enhed."
 msgid "No systems found."
 msgstr "Ingen systemer fundet."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Ingen"
@@ -1301,13 +1439,21 @@ msgstr "Notifikationer"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Notifikationer kan indeholde uddrag af nylige containerlogfiler."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC understøttelse"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Ved hver genstart vil systemer i databasen blive opdateret til at matche de systemer, der er defineret i filen."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Ved hver genstart vil systemer i databasen blive opdateret til at matche de systemer, der er defineret i filen."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Andre"
 msgid "Overwrite existing alerts"
 msgstr "Overskriv eksisterende alarmer"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Sider / Indstillinger"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Adgangskode"
 
@@ -1388,6 +1547,10 @@ msgstr "Tidligere"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr ""
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Vedholdenhed"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Foretrukket sprog"
 msgid "Process started"
 msgstr "Proces startet"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Læsefejl"
 msgid "Received"
 msgstr "Modtaget"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Kræves af"
 msgid "Requires"
 msgstr "Kræver"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Nulstil adgangskode"
@@ -1592,6 +1775,14 @@ msgstr "Genstarter"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Genoptag"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Tilstand"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Faner"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Log derefter ind på backend og nulstil adgangskoden til din brugerkonto
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Denne handling kan ikke fortrydes. Dette vil permanent slette alle aktuelle elementer for {name} fra databasen."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Dette vil permanent slette alle poster fra databasen."
@@ -1892,6 +2089,10 @@ msgstr "Gennemløb af {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Gennemløb for ZFS-pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Til email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Nøgle"
@@ -2093,8 +2295,13 @@ msgstr "Overfør"
 msgid "Uptime"
 msgstr "Oppetid"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Forbrug af ZFS-pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Brugt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Vil du hjælpe os med at gøre vores oversættelser endnu bedre? Tjek <0
 msgid "Wants"
 msgstr "Ønsker"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Advarsel (%)"
@@ -2170,6 +2385,10 @@ msgstr "Advarsel (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Advarselstærskler"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/de/de.po
+++ b/internal/site/src/locales/de/de.po
@@ -126,6 +126,11 @@ msgstr "Aktiver Zustand"
 msgid "Add {foo}"
 msgstr "{foo} hinzufügen"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URL hinzufügen"
@@ -327,6 +332,7 @@ msgstr "Kann starten"
 msgid "Can stop"
 msgstr "Kann stoppen"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Vorsicht - potenzieller Datenverlust"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Überprüfen Sie Ihren Überwachungsdienst"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Überprüfe deinen Benachrichtigungsdienst"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Zyklen"
 msgid "Daily"
 msgstr "Täglich"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standard"
 msgid "Default time period"
 msgstr "Standardzeitraum"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Bearbeiten"
 msgid "Edit {foo}"
 msgstr "{foo} bearbeiten"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Konfiguration exportieren"
 msgid "Export your current systems configuration."
 msgstr "Exportiere die aktuelle Systemkonfiguration."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD Befehl"
 msgid "Full"
 msgstr "Voll"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew-Befehl"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-Methode"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O-Auslastung"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inaktiv"
 msgid "Interval"
 msgstr "Intervall"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Ungültige E-Mail-Adresse."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Speichernutzung der Container"
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Einhängepunkt"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Name"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nein"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Für diesen Pool sind keine Detaildaten verfügbar."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Anfrage zum Zurücksetzen des Passworts erhalten"
 msgid "Past"
 msgstr "Vergangen"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
@@ -1391,6 +1467,14 @@ msgstr "Pool-Auslastung"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Lesefehler"
 msgid "Received"
 msgstr "Empfangen"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Passwort zurücksetzen"
 msgid "Resolved"
 msgstr "Gelöst"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Neustarts"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Fortsetzen"
@@ -1511,6 +1608,10 @@ msgstr "Token rotieren"
 msgid "Rows per page"
 msgstr "Zeilen pro Seite"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Laufzeitmetriken"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.-Details"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T.-Selbsttest"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Auswählen {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Senden Sie einen einzelnen Heartbeat-Ping, um zu überprüfen, ob Ihr Endpunkt funktioniert."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Tabs"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Aufgaben"
@@ -1779,6 +1896,14 @@ msgstr "Durchsatz des ZFS-Pools {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Zeitformat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Löst aus, wenn der Status zwischen online und offline wechselt"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Löst aus, wenn die Nutzung einer Festplatte einen Schwellenwert überschreitet"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Unbekannt"
 msgid "Unlimited"
 msgstr "Unbegrenzt"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Hochladen"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Betriebszeit"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/de/de.po
+++ b/internal/site/src/locales/de/de.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} verfügbar"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} von {1} Zeile(n) ausgewählt."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 Tage"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 Min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Warnungsverlauf"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Alle Container"
 msgid "All Systems"
 msgstr "Alle Systeme"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Möchtest du {name} wirklich löschen?"
@@ -196,6 +238,10 @@ msgstr "Möchtest du {name} wirklich löschen?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Bist du sicher?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Backups"
 msgid "Bandwidth"
 msgstr "Bandbreite"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Batt"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batterie"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Kann stoppen"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Diagrammbreite"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Überprüfe {email} auf einen Link zum Zurücksetzen."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Container-Gesundheit"
 msgid "Containers"
 msgstr "Container"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Erstellt"
 msgid "Critical (%)"
 msgstr "Kritisch (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Seit dem Start insgesamt gelesene Daten"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Täglich"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standardzeitraum"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Löschen"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Herunterladen"
 msgid "Duration"
 msgstr "Dauer"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Bestehende Systeme, die nicht in der <0>config.yml</0> definiert sind, w
 msgid "Exited active"
 msgstr "Beendet aktiv"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Läuft nach einer Stunde oder bei Hub-Neustart ab."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Konfiguration exportieren"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exportiere die aktuelle Systemkonfiguration."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exportiere die aktuelle Systemkonfiguration."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Untätig"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Wenn du das Passwort für dein Administratorkonto verloren hast, kannst du es mit dem folgenden Befehl zurücksetzen."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Ungültige E-Mail-Adresse."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Sprache"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Arbeitsspeichernutzung"
 msgid "Memory usage of containers"
 msgstr "Speichernutzung der Container"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Netzwerkeinheit"
 msgid "No"
 msgstr "Nein"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Für diesen Pool sind keine Detaildaten verfügbar."
@@ -1287,6 +1424,7 @@ msgstr "Für dieses Gerät sind keine S.M.A.R.T.-Attribute verfügbar."
 msgid "No systems found."
 msgstr "Keine Systeme gefunden."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Keine"
@@ -1301,13 +1439,21 @@ msgstr "Benachrichtigungen"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Benachrichtigungen können Auszüge aus aktuellen Container-Logs enthalten."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC-Unterstützung"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Bei jedem Neustart werden die Systeme in der Datenbank aktualisiert, um den in der Datei definierten Systemen zu entsprechen."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Bei jedem Neustart werden die Systeme in der Datenbank aktualisiert, um den in der Datei definierten Systemen zu entsprechen."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Andere"
 msgid "Overwrite existing alerts"
 msgstr "Bestehende Warnungen überschreiben"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Seiten / Einstellungen"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Passwort"
 
@@ -1388,6 +1547,10 @@ msgstr "Vergangen"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Dauerhaft"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistenz"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Bevorzugte Sprache"
 msgid "Process started"
 msgstr "Prozess gestartet"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Öffentlicher Schlüssel"
@@ -1535,6 +1706,10 @@ msgstr "Lesefehler"
 msgid "Received"
 msgstr "Empfangen"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Benötigt von"
 msgid "Requires"
 msgstr "Benötigt"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Passwort zurücksetzen"
@@ -1592,6 +1775,14 @@ msgstr "Neustarts"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Fortsetzen"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Status"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Tabs"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Melde dich dann im Backend an und setze dein Benutzerkontopasswort in de
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Diese Aktion kann nicht rückgängig gemacht werden. Dadurch werden alle aktuellen Datensätze für {name} dauerhaft aus der Datenbank gelöscht."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Dadurch werden alle ausgewählten Datensätze dauerhaft aus der Datenbank gelöscht."
@@ -1892,6 +2089,10 @@ msgstr "Durchsatz von {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Durchsatz des ZFS-Pools {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "An E-Mail(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Hochladen"
 msgid "Uptime"
 msgstr "Betriebszeit"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Auslastung des ZFS-Pools {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Verwendet"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Möchtest du uns helfen, unsere Übersetzungen noch besser zu machen? Sc
 msgid "Wants"
 msgstr "Möchte"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Warnung (%)"
@@ -2170,6 +2385,10 @@ msgstr "Warnung (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Warnschwellen"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/el/el.po
+++ b/internal/site/src/locales/el/el.po
@@ -126,6 +126,11 @@ msgstr "Ενεργή κατάσταση"
 msgid "Add {foo}"
 msgstr "Προσθήκη {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Προσθήκη URL"
@@ -327,6 +332,7 @@ msgstr "Δυνατότητα εκκίνησης"
 msgid "Can stop"
 msgstr "Δυνατότητα διακοπής"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Προσοχή - πιθανή απώλεια δεδομένων"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Κελσίου (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Ελέγξτε την υπηρεσία παρακολούθησής σα
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Ελέγξτε την υπηρεσία ειδοποιήσεών σας"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Κύκλοι"
 msgid "Daily"
 msgstr "Καθημερινά"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Προεπιλογή"
 msgid "Default time period"
 msgstr "Προεπιλεγμένη χρονική περίοδος"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Επεξεργασία"
 msgid "Edit {foo}"
 msgstr "Επεξεργασία {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Εξαγωγή διαμόρφωσης"
 msgid "Export your current systems configuration."
 msgstr "Εξαγάγετε την τρέχουσα διαμόρφωση των συστημάτων σας."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Φαρενάιτ (°F)"
@@ -916,6 +943,10 @@ msgstr "Εντολή FreeBSD"
 msgid "Full"
 msgstr "Πλήρες"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Εντολή Homebrew"
 msgid "Host / IP"
 msgstr "Κεντρικός υπολογιστής / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Μέθοδος HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Χρήση I/O"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Ανενεργό"
 msgid "Interval"
 msgstr "Διάστημα"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Μη έγκυρη διεύθυνση email."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Χρήση μνήμης των κοντέινερ"
 msgid "Model"
 msgstr "Μοντέλο"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Σημείο προσάρτησης"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Όνομα"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Όχι"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Δεν υπάρχουν λεπτομερή δεδομένα για αυτό το pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Το αίτημα επαναφοράς κωδικού πρόσβασης
 msgid "Past"
 msgstr "Παρελθόν"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Παύση"
@@ -1391,6 +1467,14 @@ msgstr "Χρήση pool"
 msgid "Port"
 msgstr "Θύρα"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Σφάλματα ανάγνωσης"
 msgid "Received"
 msgstr "Λήφθηκαν"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Επαναφορά κωδικού πρόσβασης"
 msgid "Resolved"
 msgstr "Επιλύθηκε"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Επανεκκινήσεις"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Συνέχιση"
@@ -1511,6 +1608,10 @@ msgstr "Ανανέωση token"
 msgid "Rows per page"
 msgstr "Γραμμές ανά σελίδα"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Μετρήσεις χρόνου εκτέλεσης"
@@ -1522,6 +1623,10 @@ msgstr "Λεπτομέρειες S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Αυτοέλεγχος S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Επιλογή {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Στείλτε ένα μεμονωμένο heartbeat για να επαληθεύσετε ότι το τελικό σημείο λειτουργεί."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Καρτέλες"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Εργασίες"
@@ -1779,6 +1896,14 @@ msgstr "Ρυθμός διαμεταγωγής του ZFS pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Μορφή ώρας"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Ενεργοποιείται όταν η κατάσταση εναλλά
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Ενεργοποιείται όταν η χρήση οποιουδήποτε δίσκου υπερβαίνει ένα όριο"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Άγνωστο"
 msgid "Unlimited"
 msgstr "Απεριόριστο"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Αποστολή"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Χρόνος λειτουργίας"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/el/el.po
+++ b/internal/site/src/locales/el/el.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "Διαθέσιμη έκδοση {0}"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} από {1} σειρά(ες) επιλέχθηκαν."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 ημέρες"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 λ"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Πράκτορας"
 msgid "Alert History"
 msgstr "Ιστορικό ειδοποιήσεων"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Όλα τα κοντέινερ"
 msgid "All Systems"
 msgstr "Όλα τα συστήματα"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Είστε βέβαιοι ότι θέλετε να διαγράψετε το {name};"
@@ -196,6 +238,10 @@ msgstr "Είστε βέβαιοι ότι θέλετε να διαγράψετε 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Είστε βέβαιοι;"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Αντίγραφα ασφαλείας"
 msgid "Bandwidth"
 msgstr "Εύρος ζώνης"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Μπατ."
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Μπαταρία"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Δυνατότητα διακοπής"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Κελσίου (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Πλάτος γραφήματος"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Ελέγξτε το {email} για έναν σύνδεσμο επαναφοράς."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr ""
 msgid "Containers"
 msgstr "Κοντέινερ"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Δημιουργήθηκε"
 msgid "Critical (%)"
 msgstr "Κρίσιμο (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Συνολικά δεδομένα που διαβάστηκαν από την εκκίνηση"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Καθημερινά"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Προεπιλεγμένη χρονική περίοδος"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Διαγραφή"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Λήψη"
 msgid "Duration"
 msgstr "Διάρκεια"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Τα υπάρχοντα συστήματα που δεν ορίζοντ�
 msgid "Exited active"
 msgstr "Ενεργό μετά την έξοδο"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Λήγει μετά από μία ώρα ή με επανεκκίνηση του κόμβου."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Εξαγωγή διαμόρφωσης"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Εξαγάγετε την τρέχουσα διαμόρφωση των συστημάτων σας."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Εξαγάγετε την τρέχουσα διαμόρφωση των συστημάτων σας."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Κεντρικός υπολογιστής / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Αδράνεια"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Αν έχετε χάσει τον κωδικό πρόσβασης του λογαριασμού διαχειριστή σας, μπορείτε να τον επαναφέρετε χρησιμοποιώντας την ακόλουθη εντολή."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Μη έγκυρη διεύθυνση email."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Γλώσσα"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Χρήση μνήμης"
 msgid "Memory usage of containers"
 msgstr "Χρήση μνήμης των κοντέινερ"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Μοντέλο"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Μονάδα δικτύου"
 msgid "No"
 msgstr "Όχι"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Δεν υπάρχουν λεπτομερή δεδομένα για αυτό το pool."
@@ -1287,6 +1424,7 @@ msgstr "Δεν υπάρχουν διαθέσιμα χαρακτηριστικά 
 msgid "No systems found."
 msgstr "Δεν βρέθηκαν συστήματα."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Κανένα"
@@ -1301,13 +1439,21 @@ msgstr "Ειδοποιήσεις"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Οι ειδοποιήσεις μπορεί να περιλαμβάνουν πρόσφατα αποσπάσματα από αρχεία καταγραφής κοντέινερ."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Υποστήριξη OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Σε κάθε επανεκκίνηση, τα συστήματα στη βάση δεδομένων θα ενημερώνονται ώστε να αντιστοιχούν στα συστήματα που ορίζονται στο αρχείο."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Σε κάθε επανεκκίνηση, τα συστήματα στη βάση δεδομένων θα ενημερώνονται ώστε να αντιστοιχούν στα συστήματα που ορίζονται στο αρχείο."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Άλλο"
 msgid "Overwrite existing alerts"
 msgstr "Αντικατάσταση υπαρχουσών ειδοποιήσεων"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Σελίδες / Ρυθμίσεις"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Κωδικός πρόσβασης"
 
@@ -1388,6 +1547,10 @@ msgstr "Παρελθόν"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Παύση"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Μόνιμο"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Διατήρηση"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Προτιμώμενη γλώσσα"
 msgid "Process started"
 msgstr "Η διεργασία ξεκίνησε"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Δημόσιο κλειδί"
@@ -1535,6 +1706,10 @@ msgstr "Σφάλματα ανάγνωσης"
 msgid "Received"
 msgstr "Λήφθηκαν"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Απαιτείται από"
 msgid "Requires"
 msgstr "Απαιτεί"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Επαναφορά κωδικού πρόσβασης"
@@ -1592,6 +1775,14 @@ msgstr "Επανεκκινήσεις"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Συνέχιση"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Κατάσταση"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Καρτέλες"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Στη συνέχεια, συνδεθείτε στο backend και επ
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Θα διαγράψει οριστικά όλες τις τρέχουσες εγγραφές για το {name} από τη βάση δεδομένων."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Αυτό θα διαγράψει οριστικά όλες τις επιλεγμένες εγγραφές από τη βάση δεδομένων."
@@ -1892,6 +2089,10 @@ msgstr "Ρυθμός μεταφοράς του {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Ρυθμός διαμεταγωγής του ZFS pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Προς email"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Διακριτικό"
@@ -2093,8 +2295,13 @@ msgstr "Αποστολή"
 msgid "Uptime"
 msgstr "Χρόνος λειτουργίας"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Χρήση του ZFS pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Χρησιμοποιείται"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Θέλετε να βοηθήσετε στη βελτίωση των με
 msgid "Wants"
 msgstr "Επιθυμεί"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Προειδοποίηση (%)"
@@ -2170,6 +2385,10 @@ msgstr "Προειδοποίηση (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Όρια προειδοποίησης"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/en/en.po
+++ b/internal/site/src/locales/en/en.po
@@ -13,17 +13,46 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr "(leave empty to keep)"
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} available"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr "{0} down"
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr "{0} ms"
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} of {1} row(s) selected."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr "{0} paused"
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr "{0} up"
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr "{0} warning"
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -87,6 +116,10 @@ msgstr "30 days"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr "Accepted codes"
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -162,6 +195,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Alert History"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr "Alert when keyword is missing"
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -184,6 +221,11 @@ msgstr "All Containers"
 msgid "All Systems"
 msgstr "All Systems"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr "Are you sure you want to delete {0}?"
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Are you sure you want to delete {name}?"
@@ -191,6 +233,10 @@ msgstr "Are you sure you want to delete {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Are you sure?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr "Auth"
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -255,6 +301,10 @@ msgstr "Backups"
 msgid "Bandwidth"
 msgstr "Bandwidth"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr "Basic"
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -265,6 +315,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Battery"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr "Bearer token"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -328,6 +382,7 @@ msgid "Can stop"
 msgstr "Can stop"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -352,8 +407,21 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
-msgstr "Cert"
+#~ msgid "Cert"
+#~ msgstr "Cert"
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr "Cert expires in {0} days"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr "Cert thresholds must be positive with critical below warning."
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
+msgstr "Certificate"
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -383,6 +451,14 @@ msgstr "Chart width"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Check {email} for a reset link."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr "Check completed"
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr "Check failed"
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -466,6 +542,7 @@ msgstr "Container Health"
 msgid "Containers"
 msgstr "Containers"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -589,6 +666,10 @@ msgstr "Created"
 msgid "Critical (%)"
 msgstr "Critical (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr "Critical below (days)"
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Cumulative data read since boot"
@@ -631,8 +712,8 @@ msgid "Daily"
 msgstr "Daily"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr "days"
+#~ msgid "days"
+#~ msgstr "days"
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -650,6 +731,10 @@ msgstr "Default time period"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Delete"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr "Delete failed"
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -732,6 +817,7 @@ msgstr "Download"
 msgid "Duration"
 msgstr "Duration"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -826,9 +912,18 @@ msgstr "Existing systems not defined in <0>config.yml</0> will be deleted. Pleas
 msgid "Exited active"
 msgstr "Exited active"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr "Expected answer (optional)"
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Expires after one hour or on hub restart."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr "Expires in {0} days"
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -839,8 +934,12 @@ msgid "Export configuration"
 msgstr "Export configuration"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Export your current systems configuration."
+msgid "Export your current systems and monitors configuration."
+msgstr "Export your current systems and monitors configuration."
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Export your current systems configuration."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1001,8 +1100,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
-msgstr "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
+msgstr "HTTP check that also looks for text in the first 2 MB of the response."
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr "HTTP check that also looks for text in the response."
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1040,6 +1143,10 @@ msgstr "Idle"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "If you've lost the password to your admin account, you may reset it using the following command."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr "Ignore TLS errors (insecure)"
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1066,6 +1173,10 @@ msgid "Invalid email address."
 msgstr "Invalid email address."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr "Invert status (upside down)"
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr "Keyword"
 
@@ -1076,6 +1187,18 @@ msgstr "Keyword is required for keyword monitors."
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Language"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr "Last latency"
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr "Latency"
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr "Latency (ms)"
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1191,13 +1314,23 @@ msgstr "Memory Usage"
 msgid "Memory usage of containers"
 msgstr "Memory usage of containers"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr "Message"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr "Method"
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1251,6 +1384,10 @@ msgstr "Network unit"
 msgid "No"
 msgstr "No"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr "No checks recorded yet."
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "No detail data for this pool."
@@ -1282,6 +1419,7 @@ msgstr "No S.M.A.R.T. attributes available for this device."
 msgid "No systems found."
 msgstr "No systems found."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "None"
@@ -1296,13 +1434,21 @@ msgstr "Notifications"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Notifications may include recent container log excerpts."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr "Notifications toggled"
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC support"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "On each restart, systems in the database will be updated to match the systems defined in the file."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1342,6 +1488,18 @@ msgstr "Other"
 msgid "Overwrite existing alerts"
 msgstr "Overwrite existing alerts"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr "Packet size"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr "Packet size must be between 0 and 65400."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr "Packets"
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1360,6 +1518,7 @@ msgstr "Pages / Settings"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Password"
 
@@ -1383,6 +1542,10 @@ msgstr "Past"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr "Pause toggled"
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1416,6 +1579,10 @@ msgstr "Permanent"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistence"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr "Ping count must be between 1 and 10."
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1493,6 +1660,10 @@ msgstr "Preferred Language"
 msgid "Process started"
 msgstr "Process started"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr "Protocol"
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Public key"
@@ -1530,6 +1701,10 @@ msgstr "Read errors"
 msgid "Received"
 msgstr "Received"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr "Recent checks"
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr "Record type"
@@ -1561,6 +1736,14 @@ msgstr "Required by"
 msgid "Requires"
 msgstr "Requires"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr "Resend delay must be between 0 and 1440 minutes."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr "Resend every (minutes, 0 = never)"
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Reset Password"
@@ -1587,6 +1770,14 @@ msgstr "Restarts"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Resume"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr "Retries before down"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr "Retries must be between 0 and 10."
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1753,6 +1944,7 @@ msgid "State"
 msgstr "State"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1822,6 +2014,7 @@ msgid "Tabs"
 msgstr "Tabs"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr "Target"
 
@@ -1876,6 +2069,10 @@ msgstr "Then log into the backend and reset your user account password in the us
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr "This action cannot be undone. This will permanently delete the monitor and its check history."
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "This will permanently delete all selected records from the database."
@@ -1887,6 +2084,10 @@ msgstr "Throughput of {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Throughput of ZFS pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr "Time"
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1905,6 +2106,7 @@ msgid "To email(s)"
 msgstr "To email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2088,9 +2290,14 @@ msgstr "Upload"
 msgid "Uptime"
 msgstr "Uptime"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
 msgstr "Uptime 24h"
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
+msgstr "Uptime 24h: {0}%"
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2113,6 +2320,10 @@ msgstr "Usage of ZFS pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Used"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr "Username"
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2158,6 +2369,10 @@ msgstr "Want to help improve our translations? Check <0>Crowdin</0> for details.
 msgid "Wants"
 msgstr "Wants"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr "Warn below (days)"
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Warning (%)"
@@ -2165,6 +2380,10 @@ msgstr "Warning (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Warning thresholds"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr "Watch certificate expiry"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/en/en.po
+++ b/internal/site/src/locales/en/en.po
@@ -121,6 +121,11 @@ msgstr "Active state"
 msgid "Add {foo}"
 msgstr "Add {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr "Add monitor"
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Add URL"
@@ -322,6 +327,7 @@ msgstr "Can start"
 msgid "Can stop"
 msgstr "Can stop"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -344,6 +350,10 @@ msgstr "Caution - potential data loss"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr "Cert"
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -385,6 +395,10 @@ msgstr "Check your monitoring service"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Check your notification service"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr "Checks certificate expiry without an HTTP request."
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -616,6 +630,10 @@ msgstr "Cycles"
 msgid "Daily"
 msgstr "Daily"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr "days"
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -625,6 +643,7 @@ msgstr "Default"
 msgid "Default time period"
 msgstr "Default time period"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -723,6 +742,10 @@ msgstr "Edit"
 msgid "Edit {foo}"
 msgstr "Edit {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr "Edit monitor"
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -819,6 +842,10 @@ msgstr "Export configuration"
 msgid "Export your current systems configuration."
 msgstr "Export your current systems configuration."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr "External uptime check executed from the hub."
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -911,6 +938,10 @@ msgstr "FreeBSD command"
 msgid "Full"
 msgstr "Full"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr "Full URL. Accepts 2xx by default."
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -969,6 +1000,10 @@ msgstr "Homebrew command"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr "HTTP check that also looks for text in the response."
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP Method"
@@ -992,6 +1027,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O Utilization"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr "ICMP echo. The hub may need NET_RAW capability in Docker."
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1014,9 +1053,25 @@ msgstr "Inactive"
 msgid "Interval"
 msgstr "Interval"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr "Interval (seconds)"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr "Interval must be at least 20 seconds."
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Invalid email address."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr "Keyword"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr "Keyword is required for keyword monitors."
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1141,17 +1196,33 @@ msgstr "Memory usage of containers"
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr "Monitors"
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Mountpoint"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr "Mute notifications"
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Name"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr "Name is required."
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1183,6 +1254,10 @@ msgstr "No"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "No detail data for this pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1304,6 +1379,7 @@ msgstr "Password reset request received"
 msgid "Past"
 msgstr "Past"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
@@ -1386,6 +1462,14 @@ msgstr "Pool Usage"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr "Port (default 443)"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr "Port must be between 1 and 65535."
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1446,6 +1530,10 @@ msgstr "Read errors"
 msgid "Received"
 msgstr "Received"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr "Record type"
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1483,10 +1571,19 @@ msgstr "Reset Password"
 msgid "Resolved"
 msgstr "Resolved"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr "Resolver (optional)"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr "Resolves a record type, optionally against a custom resolver."
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Restarts"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Resume"
@@ -1506,6 +1603,10 @@ msgstr "Rotate token"
 msgid "Rows per page"
 msgstr "Rows per page"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr "Run check now"
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Runtime Metrics"
@@ -1517,6 +1618,10 @@ msgstr "S.M.A.R.T. Details"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Self-Test"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr "Save"
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1570,6 +1675,10 @@ msgstr "Select {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Send a single heartbeat ping to verify your endpoint is working."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr "Send notifications"
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1712,6 +1821,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Tabs"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr "Target"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr "Target is required."
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tasks"
@@ -1774,6 +1891,14 @@ msgstr "Throughput of ZFS pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Time format"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr "Timeout (seconds)"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr "Timeout must be positive and less than the interval."
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1889,6 +2014,7 @@ msgstr "Triggers when status switches between up and down"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Triggers when usage of any disk exceeds a threshold"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1924,6 +2050,10 @@ msgstr "Unknown"
 msgid "Unlimited"
 msgstr "Unlimited"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr "Unmute notifications"
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1957,6 +2087,10 @@ msgstr "Upload"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Uptime"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr "Uptime 24h"
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/es/es.po
+++ b/internal/site/src/locales/es/es.po
@@ -126,6 +126,11 @@ msgstr "Estado activo"
 msgid "Add {foo}"
 msgstr "Agregar {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Agregar URL"
@@ -327,6 +332,7 @@ msgstr "Puede iniciarse"
 msgid "Can stop"
 msgstr "Puede detenerse"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Precaución - posible pérdida de datos"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Compruebe su servicio de monitorización"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Verifica tu servicio de notificaciones"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Ciclos"
 msgid "Daily"
 msgstr "Diariamente"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Predeterminado"
 msgid "Default time period"
 msgstr "Periodo de tiempo predeterminado"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Editar"
 msgid "Edit {foo}"
 msgstr "Editar {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Exportar configuración"
 msgid "Export your current systems configuration."
 msgstr "Exporta la configuración actual de sus sistemas."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "Comando FreeBSD"
 msgid "Full"
 msgstr "Llena"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Comando Homebrew"
 msgid "Host / IP"
 msgstr "Servidor / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Método HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Utilización de E/S"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inactivo"
 msgid "Interval"
 msgstr "Intervalo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Dirección de correo electrónico no válida."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Uso de memoria de los contenedores"
 msgid "Model"
 msgstr "Modelo"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Punto de montaje"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nombre"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "No"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "No hay datos detallados para este pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Solicitud de restablecimiento de contraseña recibida"
 msgid "Past"
 msgstr "Pasado"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausar"
@@ -1391,6 +1467,14 @@ msgstr "Uso del pool"
 msgid "Port"
 msgstr "Puerto"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Errores de lectura"
 msgid "Received"
 msgstr "Recibido"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Restablecer contraseña"
 msgid "Resolved"
 msgstr "Resuelto"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Reinicios"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Reanudar"
@@ -1511,6 +1608,10 @@ msgstr "Rotar token"
 msgid "Rows per page"
 msgstr "Filas por página"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Métricas de tiempo de ejecución"
@@ -1522,6 +1623,10 @@ msgstr "Detalles S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Autoprueba S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Seleccionar {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Envíe un único ping de latido para verificar que su punto de conexión funciona."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Pestañas"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tareas"
@@ -1779,6 +1896,14 @@ msgstr "Rendimiento del pool ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Formato de hora"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Se activa cuando el estado cambia entre activo e inactivo"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Se activa cuando el uso de cualquier disco supera un umbral"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Desconocida"
 msgid "Unlimited"
 msgstr "Ilimitado"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Cargar"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Tiempo de actividad"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/es/es.po
+++ b/internal/site/src/locales/es/es.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} disponible"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} de {1} fila(s) seleccionada(s)."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 días"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agente"
 msgid "Alert History"
 msgstr "Historial de alertas"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Todos los contenedores"
 msgid "All Systems"
 msgstr "Todos los sistemas"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "¿Estás seguro de que deseas eliminar {name}?"
@@ -196,6 +238,10 @@ msgstr "¿Estás seguro de que deseas eliminar {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "¿Estás seguro?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Copias de seguridad"
 msgid "Bandwidth"
 msgstr "Ancho de banda"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batería"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Puede detenerse"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Ancho del gráfico"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Revisa {email} para un enlace de restablecimiento."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Estado del contenedor"
 msgid "Containers"
 msgstr "Contenedores"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Creada"
 msgid "Critical (%)"
 msgstr "Crítico (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Datos leídos acumulados desde el arranque"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Diariamente"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Periodo de tiempo predeterminado"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Eliminar"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Descargar"
 msgid "Duration"
 msgstr "Duración"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Los sistemas existentes no definidos en <0>config.yml</0> serán elimina
 msgid "Exited active"
 msgstr "Salió activo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Expira después de una hora o al reiniciar el hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Exportar configuración"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exporta la configuración actual de sus sistemas."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exporta la configuración actual de sus sistemas."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Servidor / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inactiva"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Si has perdido la contraseña de tu cuenta de administrador, puedes restablecerla usando el siguiente comando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Dirección de correo electrónico no válida."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Idioma"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Uso de memoria"
 msgid "Memory usage of containers"
 msgstr "Uso de memoria de los contenedores"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modelo"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Unidad de red"
 msgid "No"
 msgstr "No"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "No hay datos detallados para este pool."
@@ -1287,6 +1424,7 @@ msgstr "No hay atributos S.M.A.R.T. disponibles para este dispositivo."
 msgid "No systems found."
 msgstr "No se encontraron sistemas."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Ninguno"
@@ -1301,13 +1439,21 @@ msgstr "Notificaciones"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Las notificaciones pueden incluir fragmentos recientes de los registros de los contenedores."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Soporte para OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "En cada reinicio, los sistemas en la base de datos se actualizarán para coincidir con los sistemas definidos en el archivo."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "En cada reinicio, los sistemas en la base de datos se actualizarán para coincidir con los sistemas definidos en el archivo."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Otro"
 msgid "Overwrite existing alerts"
 msgstr "Sobrescribir alertas existentes"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Páginas / Configuraciones"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Contraseña"
 
@@ -1388,6 +1547,10 @@ msgstr "Pasado"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausar"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Permanente"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistencia"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Idioma preferido"
 msgid "Process started"
 msgstr "Proceso iniciado"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Errores de lectura"
 msgid "Received"
 msgstr "Recibido"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Requerido por"
 msgid "Requires"
 msgstr "Requiere"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Restablecer contraseña"
@@ -1592,6 +1775,14 @@ msgstr "Reinicios"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Reanudar"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Estado"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Pestañas"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Luego inicia sesión en el backend y restablece la contraseña de tu cue
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Esta acción no se puede deshacer. Esto eliminará permanentemente todos los registros actuales de {name} de la base de datos."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Esto eliminará permanentemente todos los registros seleccionados de la base de datos."
@@ -1892,6 +2089,10 @@ msgstr "Rendimiento de {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Rendimiento del pool ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "A correo(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Cargar"
 msgid "Uptime"
 msgstr "Tiempo de actividad"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Uso del pool ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Usado"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "¿Quieres ayudar a mejorar nuestras traducciones? Consulta <0>Crowdin</0
 msgid "Wants"
 msgstr "Desea"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Advertencia (%)"
@@ -2170,6 +2385,10 @@ msgstr "Advertencia (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Umbrales de advertencia"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/fa/fa.po
+++ b/internal/site/src/locales/fa/fa.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} در دسترس است"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} از {1} ردیف انتخاب شده است."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "۳۰ روز"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "۵ دقیقه"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "عامل"
 msgid "Alert History"
 msgstr "تاریخچه هشدارها"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "همه کانتینرها"
 msgid "All Systems"
 msgstr "همه سیستم‌ها"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "آیا مطمئن هستید که می‌خواهید {name} را حذف کنید؟"
@@ -196,6 +238,10 @@ msgstr "آیا مطمئن هستید که می‌خواهید {name} را حذف
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "آیا مطمئن هستید؟"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "پشتیبان‌گیری‌ها"
 msgid "Bandwidth"
 msgstr "پهنای باند"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "باتری"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "باتری"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "می‌تواند متوقف شود"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "سلسیوس (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "عرض نمودار"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "ایمیل {email} خود را برای لینک بازنشانی بررسی کنید."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "سلامت کانتینر"
 msgid "Containers"
 msgstr "کانتینرها"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "ایجاد شده"
 msgid "Critical (%)"
 msgstr "بحرانی (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "مجموع داده‌های خوانده‌شده از زمان راه‌اندازی"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "روزانه"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "بازه زمانی پیش‌فرض"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "حذف"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "دانلود"
 msgid "Duration"
 msgstr "مدت زمان"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "سیستم‌های موجود که در <0>config.yml</0> تعریف ن
 msgid "Exited active"
 msgstr "خروج فعال"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "پس از یک ساعت یا راه‌اندازی مجدد هاب منقضی می‌شود."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "خارج کردن پیکربندی"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "پیکربندی سیستم‌های فعلی خود را خارج کنید."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "پیکربندی سیستم‌های فعلی خود را خارج کنید."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "میزبان / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "بیکار"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "اگر رمز عبور حساب مدیر خود را گم کرده‌اید، می‌توانید آن را با استفاده از دستور زیر بازنشانی کنید."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "آدرس ایمیل نامعتبر است."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "زبان"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "میزان استفاده از حافظه"
 msgid "Memory usage of containers"
 msgstr "میزان استفاده حافظه کانتینرها"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "مدل"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "واحد شبکه"
 msgid "No"
 msgstr "خیر"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "دادهٔ جزئی برای این استخر موجود نیست."
@@ -1287,6 +1424,7 @@ msgstr "هیچ ویژگی S.M.A.R.T برای این دستگاه موجود نی
 msgid "No systems found."
 msgstr "هیچ سیستمی یافت نشد."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "هیچ‌کدام"
@@ -1301,13 +1439,21 @@ msgstr "اعلان‌ها"
 msgid "Notifications may include recent container log excerpts."
 msgstr "اعلان‌ها ممکن است شامل بخش‌هایی از گزارش‌های اخیر کانتینر باشند."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "پشتیبانی از OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "در هر بار راه‌اندازی مجدد، سیستم‌های موجود در پایگاه داده با سیستم‌های تعریف شده در فایل مطابقت داده می‌شوند."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "در هر بار راه‌اندازی مجدد، سیستم‌های موجود در پایگاه داده با سیستم‌های تعریف شده در فایل مطابقت داده می‌شوند."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "سایر"
 msgid "Overwrite existing alerts"
 msgstr "بازنویسی هشدارهای موجود"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "صفحات / تنظیمات"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "رمز عبور"
 
@@ -1388,6 +1547,10 @@ msgstr "گذشته"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "توقف"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "دائمی"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "ماندگاری"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "زبان ترجیحی"
 msgid "Process started"
 msgstr "فرآیند شروع شد"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "خطاهای خواندن"
 msgid "Received"
 msgstr "دریافت شد"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "مورد نیاز توسط"
 msgid "Requires"
 msgstr "نیازمند"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "بازنشانی رمز عبور"
@@ -1592,6 +1775,14 @@ msgstr "راه‌اندازی مجدد"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "ادامه"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "وضعیت"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "تب‌ها"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "سپس وارد بخش پشتیبان شوید و رمز عبور حسا
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "این عمل قابل برگشت نیست. این کار تمام رکوردهای فعلی {name} را برای همیشه از پایگاه داده حذف خواهد کرد."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "این کار تمام رکوردهای انتخاب شده را برای همیشه از پایگاه داده حذف خواهد کرد."
@@ -1892,6 +2089,10 @@ msgstr "توان عملیاتی {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "توان عملیاتی استخر ZFS ‏{poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "به ایمیل(ها)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "توکن"
@@ -2093,8 +2295,13 @@ msgstr "آپلود"
 msgid "Uptime"
 msgstr "آپتایم"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "استفاده از استخر ZFS ‏{poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "استفاده شده"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "می‌خواهید به ما کمک کنید تا ترجمه‌های �
 msgid "Wants"
 msgstr "می‌خواهد"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "هشدار (%)"
@@ -2170,6 +2385,10 @@ msgstr "هشدار (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "آستانه های هشدار"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/fa/fa.po
+++ b/internal/site/src/locales/fa/fa.po
@@ -126,6 +126,11 @@ msgstr "وضعیت فعال"
 msgid "Add {foo}"
 msgstr "افزودن {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "افزودن آدرس اینترنتی"
@@ -327,6 +332,7 @@ msgstr "می‌تواند شروع شود"
 msgid "Can stop"
 msgstr "می‌تواند متوقف شود"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "احتیاط - احتمال از دست رفتن داده‌ها"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "سلسیوس (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "سرویس نظارتی خود را بررسی کنید"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "سرویس اطلاع‌رسانی خود را بررسی کنید"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "چرخه‌ها"
 msgid "Daily"
 msgstr "روزانه"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "پیش‌فرض"
 msgid "Default time period"
 msgstr "بازه زمانی پیش‌فرض"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "ویرایش"
 msgid "Edit {foo}"
 msgstr "ویرایش {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "خارج کردن پیکربندی"
 msgid "Export your current systems configuration."
 msgstr "پیکربندی سیستم‌های فعلی خود را خارج کنید."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "فارنهایت (°F)"
@@ -916,6 +943,10 @@ msgstr "دستور FreeBSD"
 msgid "Full"
 msgstr "پر"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "دستور Homebrew"
 msgid "Host / IP"
 msgstr "میزبان / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "متد HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "استفاده از ورودی/خروجی"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "غیرفعال"
 msgid "Interval"
 msgstr "بازه زمانی"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "آدرس ایمیل نامعتبر است."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "میزان استفاده حافظه کانتینرها"
 msgid "Model"
 msgstr "مدل"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "نقطه اتصال"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "نام"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "خیر"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "دادهٔ جزئی برای این استخر موجود نیست."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "درخواست بازنشانی رمز عبور دریافت شد"
 msgid "Past"
 msgstr "گذشته"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "توقف"
@@ -1391,6 +1467,14 @@ msgstr "استفاده از استخر"
 msgid "Port"
 msgstr "پورت"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "خطاهای خواندن"
 msgid "Received"
 msgstr "دریافت شد"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "بازنشانی رمز عبور"
 msgid "Resolved"
 msgstr "حل شده"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "راه‌اندازی مجدد"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "ادامه"
@@ -1511,6 +1608,10 @@ msgstr "چرخش توکن"
 msgid "Rows per page"
 msgstr "ردیف در هر صفحه"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "معیارهای زمان اجرا"
@@ -1522,6 +1623,10 @@ msgstr "جزئیات S.M.A.R.T"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "تست خود S.M.A.R.T"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "انتخاب {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "یک پینگ ضربان قلب تکی ارسال کنید تا از کارکرد نقطه پایانی خود اطمینان حاصل کنید."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "تب‌ها"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "وظایف"
@@ -1779,6 +1896,14 @@ msgstr "توان عملیاتی استخر ZFS ‏{poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "فرمت زمان"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "هنگامی که وضعیت بین بالا و پایین تغییر م
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "هنگامی که استفاده از هر دیسکی از یک آستانه فراتر رود، فعال می‌شود"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "ناشناخته"
 msgid "Unlimited"
 msgstr "نامحدود"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "آپلود"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "آپتایم"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -939,8 +939,12 @@ msgid "Export configuration"
 msgstr "Exporter la configuration"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exportez la configuration actuelle de vos systèmes."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exportez la configuration actuelle de vos systèmes."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1444,8 +1448,12 @@ msgid "OAuth 2 / OIDC support"
 msgstr "Support OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "À chaque redémarrage, les systèmes dans la base de données seront mis à jour pour correspondre aux systèmes définis dans le fichier."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "À chaque redémarrage, les systèmes dans la base de données seront mis à jour pour correspondre aux systèmes définis dans le fichier."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -126,6 +126,11 @@ msgstr "État actif"
 msgid "Add {foo}"
 msgstr "Ajouter {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Ajouter l’URL"
@@ -327,6 +332,7 @@ msgstr "Peut démarrer"
 msgid "Can stop"
 msgstr "Peut arrêter"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Attention - perte de données potentielle"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Vérifiez votre service de surveillance"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Vérifiez votre service de notification"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cycles"
 msgid "Daily"
 msgstr "Quotidien"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Par défaut"
 msgid "Default time period"
 msgstr "Période par défaut"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Éditer"
 msgid "Edit {foo}"
 msgstr "Modifier {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Exporter la configuration"
 msgid "Export your current systems configuration."
 msgstr "Exportez la configuration actuelle de vos systèmes."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "Commande FreeBSD"
 msgid "Full"
 msgstr "Pleine"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Commande Homebrew"
 msgid "Host / IP"
 msgstr "Hôte / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Méthode HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Utilisation E/S"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inactif"
 msgid "Interval"
 msgstr "Intervalle"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Adresse email invalide."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Utilisation de la mémoire des conteneurs"
 msgid "Model"
 msgstr "Modèle"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Point de montage"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nom"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Non"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Aucune donnée détaillée disponible pour ce pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Demande de réinitialisation du mot de passe reçue"
 msgid "Past"
 msgstr "Passé"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
@@ -1391,6 +1467,14 @@ msgstr "Utilisation du pool"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Erreurs de lecture"
 msgid "Received"
 msgstr "Reçu"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Réinitialiser le mot de passe"
 msgid "Resolved"
 msgstr "Résolu"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Redémarrages"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Reprendre"
@@ -1511,6 +1608,10 @@ msgstr "Faire tourner le token"
 msgid "Rows per page"
 msgstr "Lignes par page"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Métriques d'exécution"
@@ -1522,6 +1623,10 @@ msgstr "Détails S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Auto-test S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Sélectionner {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Envoyez un seul ping heartbeat pour vérifier que votre point de terminaison fonctionne."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Onglets"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tâches"
@@ -1779,6 +1896,14 @@ msgstr "Débit du pool ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Format d'heure"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Se déclenche lorsque le statut passe de \"Joignable\" à \"Injoignable\
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Déclenchement lorsque l'utilisation de tout disque dépasse un seuil"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Inconnue"
 msgid "Unlimited"
 msgstr "Illimité"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Téléverser"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Temps de fonctionnement"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/fr/fr.po
+++ b/internal/site/src/locales/fr/fr.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr "(laisser vide pour conserver)"
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} disponible"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} sur  {1} ligne(s) sectionner."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -93,6 +122,10 @@ msgstr "30 jours"
 msgid "5 min"
 msgstr "5 min"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr "Codes acceptés"
+
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
@@ -129,7 +162,7 @@ msgstr "Ajouter {foo}"
 #: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/monitors.tsx
 msgid "Add monitor"
-msgstr ""
+msgstr "Ajouter un moniteur"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Historique des alertes"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr "Alerter quand le mot-clé est absent"
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Tous les conteneurs"
 msgid "All Systems"
 msgstr "Tous les systèmes"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Êtes-vous sûr de vouloir supprimer {name} ?"
@@ -196,6 +238,10 @@ msgstr "Êtes-vous sûr de vouloir supprimer {name} ?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Êtes-vous sûr ?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr "Authentification"
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Sauvegardes"
 msgid "Bandwidth"
 msgstr "Bande passante"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr "Basique"
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batterie"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr "Jeton Bearer"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Peut arrêter"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,8 +412,21 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr "Les seuils doivent être positifs, critique sous avertissement."
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
+msgstr "Certificat"
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -389,6 +457,14 @@ msgstr "Largeur du graphique"
 msgid "Check {email} for a reset link."
 msgstr "Vérifiez {email} pour un lien de réinitialisation."
 
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr "Vérification terminée"
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr "Échec de la vérification"
+
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
 msgstr "Vérifiez les journaux pour plus de détails."
@@ -403,7 +479,7 @@ msgstr "Vérifiez votre service de notification"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Checks certificate expiry without an HTTP request."
-msgstr ""
+msgstr "Vérifie l'expiration du certificat sans requête HTTP."
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -471,6 +547,7 @@ msgstr "Santé du conteneur"
 msgid "Containers"
 msgstr "Conteneurs"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Date de création"
 msgid "Critical (%)"
 msgstr "Critique (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr "Critique sous (jours)"
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Données lues depuis le démarrage"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Quotidien"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Période par défaut"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Supprimer"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr "Échec de la suppression"
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Télécharger"
 msgid "Duration"
 msgstr "Durée"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -749,7 +835,7 @@ msgstr "Modifier {foo}"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Edit monitor"
-msgstr ""
+msgstr "Modifier le moniteur"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
@@ -831,9 +917,18 @@ msgstr "Les systèmes existants non définis dans <0>config.yml</0> seront suppr
 msgid "Exited active"
 msgstr "Sorti actif"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr "Réponse attendue (optionnelle)"
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Expire après une heure ou au redémarrage du hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -849,7 +944,7 @@ msgstr "Exportez la configuration actuelle de vos systèmes."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
-msgstr ""
+msgstr "Vérification externe exécutée depuis le hub."
 
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
@@ -945,7 +1040,7 @@ msgstr "Pleine"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Full URL. Accepts 2xx by default."
-msgstr ""
+msgstr "URL complète. Accepte les 2xx par défaut."
 
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
@@ -1006,8 +1101,12 @@ msgid "Host / IP"
 msgstr "Hôte / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
-msgstr ""
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
+msgstr "Vérification HTTP qui cherche aussi un texte dans les 2 premiers Mo de la réponse."
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1034,7 +1133,7 @@ msgstr "Utilisation E/S"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
-msgstr ""
+msgstr "Écho ICMP. Le hub peut nécessiter la capacité NET_RAW sous Docker."
 
 #. Context: Battery state
 #: src/lib/i18n.ts
@@ -1044,6 +1143,10 @@ msgstr "Inactive"
 #: src/components/login/forgot-pass-form.tsx
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Si vous avez perdu le mot de passe de votre compte administrateur, vous pouvez le réinitialiser en utilisant la commande suivante."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr "Ignorer les erreurs TLS (non sécurisé)"
 
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
@@ -1060,27 +1163,43 @@ msgstr "Intervalle"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Interval (seconds)"
-msgstr ""
+msgstr "Intervalle (secondes)"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Interval must be at least 20 seconds."
-msgstr ""
+msgstr "L'intervalle doit être d'au moins 20 secondes."
 
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Adresse email invalide."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr "Inverser le statut"
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
-msgstr ""
+msgstr "Mot-clé"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Keyword is required for keyword monitors."
-msgstr ""
+msgstr "Le mot-clé est requis pour ce type."
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Langue"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr "Dernière latence"
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr "Latence"
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr "Latence (ms)"
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,17 +1315,27 @@ msgstr "Utilisation de la mémoire"
 msgid "Memory usage of containers"
 msgstr "Utilisation de la mémoire des conteneurs"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr "Message"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr "Méthode"
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modèle"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
-msgstr ""
+msgstr "Moniteurs"
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
@@ -1214,7 +1343,7 @@ msgstr "Point de montage"
 
 #: src/components/routes/monitors.tsx
 msgid "Mute notifications"
-msgstr ""
+msgstr "Couper les notifications"
 
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
@@ -1227,7 +1356,7 @@ msgstr "Nom"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Name is required."
-msgstr ""
+msgstr "Le nom est requis."
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1256,13 +1385,17 @@ msgstr "Unité réseau"
 msgid "No"
 msgstr "Non"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr "Aucune vérification enregistrée."
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Aucune donnée détaillée disponible pour ce pool."
 
 #: src/components/routes/monitors.tsx
 msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
-msgstr ""
+msgstr "Aucun moniteur. Ajoutez votre première vérification HTTP, DNS, ping ou TLS."
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1287,6 +1420,7 @@ msgstr "Aucun attribut S.M.A.R.T. disponible pour cet appareil."
 msgid "No systems found."
 msgstr "Aucun système trouvé."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Aucun"
@@ -1300,6 +1434,10 @@ msgstr "Notifications"
 #: src/lib/alerts.ts
 msgid "Notifications may include recent container log excerpts."
 msgstr "Les notifications peuvent inclure des extraits récents des journaux des conteneurs."
+
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr "Notifications modifiées"
 
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
@@ -1347,6 +1485,18 @@ msgstr "Autre"
 msgid "Overwrite existing alerts"
 msgstr "Écraser les alertes existantes"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr "Taille des paquets"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr "La taille doit être entre 0 et 65400."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr "Paquets"
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1515,7 @@ msgstr "Pages / Paramètres"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -1388,6 +1539,10 @@ msgstr "Passé"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr "Suspension modifiée"
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1576,10 @@ msgstr "Permanent"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistance"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr "Le nombre de paquets doit être entre 1 et 10."
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1469,11 +1628,11 @@ msgstr "Port"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Port (default 443)"
-msgstr ""
+msgstr "Port (443 par défaut)"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Port must be between 1 and 65535."
-msgstr ""
+msgstr "Le port doit être entre 1 et 65535."
 
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
@@ -1497,6 +1656,10 @@ msgstr "Langue préférée"
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Process started"
 msgstr "Processus démarré"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr "Protocole"
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
@@ -1535,9 +1698,13 @@ msgstr "Erreurs de lecture"
 msgid "Received"
 msgstr "Reçu"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr "Vérifications récentes"
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
-msgstr ""
+msgstr "Type d'enregistrement"
 
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
@@ -1566,6 +1733,14 @@ msgstr "Requis par"
 msgid "Requires"
 msgstr "Requiert"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr "Le délai doit être entre 0 et 1440 minutes."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr "Renvoyer toutes les (minutes, 0 = jamais)"
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Réinitialiser le mot de passe"
@@ -1578,11 +1753,11 @@ msgstr "Résolu"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Resolver (optional)"
-msgstr ""
+msgstr "Résolveur (optionnel)"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Resolves a record type, optionally against a custom resolver."
-msgstr ""
+msgstr "Résout un type d'enregistrement, éventuellement via un résolveur personnalisé."
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
@@ -1592,6 +1767,14 @@ msgstr "Redémarrages"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Reprendre"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr "Tentatives avant panne"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr "Les tentatives doivent être entre 0 et 10."
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1610,7 +1793,7 @@ msgstr "Lignes par page"
 
 #: src/components/routes/monitors.tsx
 msgid "Run check now"
-msgstr ""
+msgstr "Lancer la vérification"
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
@@ -1626,7 +1809,7 @@ msgstr "Auto-test S.M.A.R.T."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1683,7 +1866,7 @@ msgstr "Envoyez un seul ping heartbeat pour vérifier que votre point de termina
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Send notifications"
-msgstr ""
+msgstr "Envoyer des notifications"
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1758,6 +1941,7 @@ msgid "State"
 msgstr "État"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,12 +2011,13 @@ msgid "Tabs"
 msgstr "Onglets"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
-msgstr ""
+msgstr "Cible"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Target is required."
-msgstr ""
+msgstr "La cible est requise."
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
@@ -1881,6 +2066,10 @@ msgstr "Ensuite, connectez-vous au backend et réinitialisez le mot de passe de 
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Cette action ne peut pas être annulée. Cela supprimera définitivement tous les enregistrements actuels pour {name} de la base de données."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Ceci supprimera définitivement tous les enregistrements sélectionnés de la base de données."
@@ -1893,23 +2082,28 @@ msgstr "Débit de {extraFsName}"
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Débit du pool ZFS {poolName}"
 
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr "Heure"
+
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Format d'heure"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Timeout (seconds)"
-msgstr ""
+msgstr "Délai maximal (secondes)"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "Timeout must be positive and less than the interval."
-msgstr ""
+msgstr "Le délai doit être positif et inférieur à l'intervalle."
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
 msgstr "Aux email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2057,7 +2251,7 @@ msgstr "Illimité"
 
 #: src/components/routes/monitors.tsx
 msgid "Unmute notifications"
-msgstr ""
+msgstr "Réactiver les notifications"
 
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
@@ -2093,8 +2287,13 @@ msgstr "Téléverser"
 msgid "Uptime"
 msgstr "Temps de fonctionnement"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr "Disponibilité 24 h"
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2317,10 @@ msgstr "Utilisation du pool ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Utilisé"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr "Identifiant"
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2366,10 @@ msgstr "Vous voulez nous aider à améliorer nos traductions ? Consultez <0>Crow
 msgid "Wants"
 msgstr "Souhaite"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr "Alerter sous (jours)"
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Avertissement (%)"
@@ -2170,6 +2377,10 @@ msgstr "Avertissement (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Seuils d'avertissement"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr "Surveiller l'expiration du certificat"
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/he/he.po
+++ b/internal/site/src/locales/he/he.po
@@ -126,6 +126,11 @@ msgstr "מצב פעיל"
 msgid "Add {foo}"
 msgstr "הוסף {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "הוסף URL"
@@ -327,6 +332,7 @@ msgstr "יכול להתחיל"
 msgid "Can stop"
 msgstr "יכול לעצור"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "זהירות - אפשרות לאובדן נתונים"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "צלזיוס (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "בדוק את שירות הניטור שלך"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "בדוק את שירות ההתראות שלך"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "מחזורים"
 msgid "Daily"
 msgstr "יומי"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "ברירת מחדל"
 msgid "Default time period"
 msgstr "תקופת זמן ברירת מחדל"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "ערוך"
 msgid "Edit {foo}"
 msgstr "ערוך {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "ייצא תצורה"
 msgid "Export your current systems configuration."
 msgstr "ייצא את תצורת המערכות הנוכחית שלך."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "פרנהייט (°F)"
@@ -916,6 +943,10 @@ msgstr "פקודת FreeBSD"
 msgid "Full"
 msgstr "מלא"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "פקודת Homebrew"
 msgid "Host / IP"
 msgstr "מארח / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "שיטת HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "ניצול קלט/פלט"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "לא פעיל"
 msgid "Interval"
 msgstr "מרווח"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "כתובת אימייל לא תקינה."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "שימוש בזיכרון של קונטיינרים"
 msgid "Model"
 msgstr "דגם"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "נקודת עגינה"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "שם"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "לא"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "אין נתונים מפורטים עבור מאגר זה."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "בקשת איפוס סיסמה התקבלה"
 msgid "Past"
 msgstr "עבר"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "השהה"
@@ -1391,6 +1467,14 @@ msgstr "שימוש במאגר"
 msgid "Port"
 msgstr "פורט"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "שגיאות קריאה"
 msgid "Received"
 msgstr "התקבל"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "איפוס סיסמה"
 msgid "Resolved"
 msgstr "נפתר"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "הפעלות מחדש"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "המשך"
@@ -1511,6 +1608,10 @@ msgstr "סובב token"
 msgid "Rows per page"
 msgstr "שורות לעמוד"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "מדדי זמן ריצה"
@@ -1522,6 +1623,10 @@ msgstr "פרטי S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "בדיקה עצמית S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "בחר {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "שלח פינג פעימת לב בודד כדי לוודא שנקודת הקצה שלך עובדת."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "לשוניות"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "משימות"
@@ -1779,6 +1896,14 @@ msgstr "תפוקת מאגר ZFS ‏{poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "פורמט זמן"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "מופעל כאשר הסטטוס מתחלף בין למעלה ולמטה
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "מופעל כאשר שימוש בכל דיסק עולה על סף"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "לא ידוע"
 msgid "Unlimited"
 msgstr "ללא הגבלה"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "העלאה"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "זמן פעילות"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/he/he.po
+++ b/internal/site/src/locales/he/he.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} זמין"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} מתוך {1} שורה(ות) נבחרו."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 ימים"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 דק'"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "סוכן"
 msgid "Alert History"
 msgstr "היסטוריית התראות"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "כל הקונטיינרים"
 msgid "All Systems"
 msgstr "כל המערכות"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "האם אתה בטוח שברצונך למחוק את {name}?"
@@ -196,6 +238,10 @@ msgstr "האם אתה בטוח שברצונך למחוק את {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "האם אתה בטוח?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "גיבויים"
 msgid "Bandwidth"
 msgstr "רוחב פס"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "סוללה"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "סוללה"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "יכול לעצור"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "צלזיוס (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "רוחב תרשים"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "בדוק את {email} לקישור איפוס."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "בריאות הקונטיינר"
 msgid "Containers"
 msgstr "קונטיינרים"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "נוצר"
 msgid "Critical (%)"
 msgstr "קריטי (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "סך הנתונים שנקראו מאז האתחול"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "יומי"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "תקופת זמן ברירת מחדל"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "מחק"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "הורדה"
 msgid "Duration"
 msgstr "משך זמן"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "מערכות קיימות שלא מוגדרות ב-<0>config.yml</0> י�
 msgid "Exited active"
 msgstr "יצא פעיל"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "התוקף פג לאחר שעה או לאחר הפעלת ה־hub מחדש."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "ייצא תצורה"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "ייצא את תצורת המערכות הנוכחית שלך."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "ייצא את תצורת המערכות הנוכחית שלך."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "מארח / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "לא פעיל"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "אם איבדת את הסיסמה לחשבון המנהל שלך, תוכל לאפס אותה באמצעות הפקודה הבאה."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "כתובת אימייל לא תקינה."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "שפה"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "שימוש בזיכרון"
 msgid "Memory usage of containers"
 msgstr "שימוש בזיכרון של קונטיינרים"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "דגם"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "יחידת רשת"
 msgid "No"
 msgstr "לא"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "אין נתונים מפורטים עבור מאגר זה."
@@ -1287,6 +1424,7 @@ msgstr "אין מאפייני S.M.A.R.T. זמינים עבור התקן זה."
 msgid "No systems found."
 msgstr "לא נמצאו מערכות."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "ללא"
@@ -1301,13 +1439,21 @@ msgstr "התראות"
 msgid "Notifications may include recent container log excerpts."
 msgstr "ההתראות עשויות לכלול קטעים מיומני קונטיינרים אחרונים."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "תמיכה ב-OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "בכל הפעלה מחדש, המערכות במסד הנתונים יעודכנו כדי להתאים למערכות המוגדרות בקובץ."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "בכל הפעלה מחדש, המערכות במסד הנתונים יעודכנו כדי להתאים למערכות המוגדרות בקובץ."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "אחר"
 msgid "Overwrite existing alerts"
 msgstr "דרוס התראות קיימות"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "עמודים / הגדרות"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "סיסמה"
 
@@ -1388,6 +1547,10 @@ msgstr "עבר"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "השהה"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "קבוע"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "עקביות"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "שפה מועדפת"
 msgid "Process started"
 msgstr "תהליך התחיל"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "שגיאות קריאה"
 msgid "Received"
 msgstr "התקבל"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "נדרש על ידי"
 msgid "Requires"
 msgstr "דורש"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "איפוס סיסמה"
@@ -1592,6 +1775,14 @@ msgstr "הפעלות מחדש"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "המשך"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "מצב"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "לשוניות"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "לאחר מכן התחבר ל-backend ואפס את סיסמת חשבו�
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "פעולה זו לא ניתנת לביטול. פעולה זו תמחק לצמיתות את כל הרשומות הנוכחיות עבור {name} ממסד הנתונים."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "פעולה זו תמחק לצמיתות את כל הרשומות שנבחרו ממסד הנתונים."
@@ -1892,6 +2089,10 @@ msgstr "תפוקה של {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "תפוקת מאגר ZFS ‏{poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "לאימייל(ים)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "העלאה"
 msgid "Uptime"
 msgstr "זמן פעילות"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "שימוש במאגר ZFS ‏{poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "בשימוש"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "רוצה לעזור לשפר את התרגומים שלנו? בדוק <0
 msgid "Wants"
 msgstr "רוצה"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "אזהרה (%)"
@@ -2170,6 +2385,10 @@ msgstr "אזהרה (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "ספי אזהרה"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/hr/hr.po
+++ b/internal/site/src/locales/hr/hr.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} dostupno"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} od {1} redaka izabrano."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dana"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 minuta"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Povijest Upozorenja"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Svi spremnici"
 msgid "All Systems"
 msgstr "Svi Sustavi"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Jeste li sigurni da želite izbrisati {name}?"
@@ -196,6 +238,10 @@ msgstr "Jeste li sigurni da želite izbrisati {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Jeste li sigurni?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Sigurnosne kopije"
 msgid "Bandwidth"
 msgstr "Mrežna Propusnost"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Baterija"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Može se zaustaviti"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Širina grafikona"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Provjerite {email} za pristup poveznici za resetiranje."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Zdravlje kontejnera"
 msgid "Containers"
 msgstr "Kontejneri"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Kreiran"
 msgid "Critical (%)"
 msgstr "Kritično (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Ukupno pročitani podaci od pokretanja"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Dnevno"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Zadano vremensko razdoblje"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Izbriši"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Preuzmi"
 msgid "Duration"
 msgstr "Trajanje"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Postojeći sustavi koji nisu definirani u <0>config.yml</0> datoteci bit
 msgid "Exited active"
 msgstr "Izašlo aktivno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Istječe nakon jednog sata ili ponovnog pokretanja huba."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Izvoz konfiguracije"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Izvoz trenutne sistemske konfiguracije."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Izvoz trenutne sistemske konfiguracije."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Neaktivno"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Ako ste izgubili lozinku za svoj administratorski račun, možete ju resetirati pomoću sljedeće naredbe."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Nevažeća email adresa."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Jezik"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Iskorištenost memorije"
 msgid "Memory usage of containers"
 msgstr "Upotreba memorije spremnika"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr ""
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Mjerna jedinica za mrežu"
 msgid "No"
 msgstr "Ne"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Nema detaljnih podataka za ovo spremište."
@@ -1287,6 +1424,7 @@ msgstr "Nema dostupnih S.M.A.R.T. atributa za ovaj uređaj."
 msgid "No systems found."
 msgstr "Nije pronađen nijedan sustav."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Nema"
@@ -1301,13 +1439,21 @@ msgstr "Obavijesti"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Obavijesti mogu sadržavati nedavne isječke iz zapisnika spremnika."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Podrška za OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Prilikom svakog ponovnog pokretanja, sustavi u bazi podataka bit će ažurirani kako bi odgovarali sustavima definiranim u datoteci."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Prilikom svakog ponovnog pokretanja, sustavi u bazi podataka bit će ažurirani kako bi odgovarali sustavima definiranim u datoteci."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Ostalo"
 msgid "Overwrite existing alerts"
 msgstr "Prebriši postojeća upozorenja"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Stranice / Postavke"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Lozinka"
 
@@ -1388,6 +1547,10 @@ msgstr "Prošlost"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Trajan"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Postojanost"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Preferirani jezik"
 msgid "Process started"
 msgstr "Proces pokrenut"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Pogreške čitanja"
 msgid "Received"
 msgstr "Primljeno"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Zahtijeva"
 msgid "Requires"
 msgstr "Zahtijeva"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Resetiraj Lozinku"
@@ -1592,6 +1775,14 @@ msgstr "Ponovna pokretanja"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Nastavi"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Stanje"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Kartice"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Zatim se prijavite u backend i resetirajte lozinku korisničkog računa 
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Ova radnja ne može se poništiti. Svi trenutni zapisi za {name} bit će trajno izbrisani iz baze podataka."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Ovom radnjom će se trajno izbrisati svi odabrani zapisi iz baze podataka."
@@ -1892,6 +2089,10 @@ msgstr "Protok {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Propusnost ZFS spremišta {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Primaoci emaila"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Otpremi"
 msgid "Uptime"
 msgstr "Vrijeme rada"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Iskorištenost ZFS spremišta {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Iskorišteno"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Želite li nam pomoći poboljšati prijevode? Posjetite <0>Crowdin</0> z
 msgid "Wants"
 msgstr "Želi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Upozorenje (%)"
@@ -2170,6 +2385,10 @@ msgstr "Upozorenje (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Pragovi upozorenja"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/hr/hr.po
+++ b/internal/site/src/locales/hr/hr.po
@@ -126,6 +126,11 @@ msgstr "Aktivno stanje"
 msgid "Add {foo}"
 msgstr "Dodaj {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Dodaj URL"
@@ -327,6 +332,7 @@ msgstr "Može se pokrenuti"
 msgid "Can stop"
 msgstr "Može se zaustaviti"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Oprez - mogući gubitak podataka"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Provjerite svoju uslugu nadzora"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Provjerite svoju obavještajnu uslugu"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Ciklusi"
 msgid "Daily"
 msgstr "Dnevno"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Zadano"
 msgid "Default time period"
 msgstr "Zadano vremensko razdoblje"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Uredi"
 msgid "Edit {foo}"
 msgstr "Uredi {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Izvoz konfiguracije"
 msgid "Export your current systems configuration."
 msgstr "Izvoz trenutne sistemske konfiguracije."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Farenhajt (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD naredba"
 msgid "Full"
 msgstr "Puno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew naredba"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP metoda"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O iskorištenost"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Neaktivno"
 msgid "Interval"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Nevažeća email adresa."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Upotreba memorije spremnika"
 msgid "Model"
 msgstr ""
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Točka montiranja"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Ime"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Ne"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Nema detaljnih podataka za ovo spremište."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Zahtjev za ponovno postavljanje lozinke zaprimljen"
 msgid "Past"
 msgstr "Prošlost"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
@@ -1391,6 +1467,14 @@ msgstr "Iskorištenost spremišta"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Pogreške čitanja"
 msgid "Received"
 msgstr "Primljeno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Resetiraj Lozinku"
 msgid "Resolved"
 msgstr "Razrješeno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Ponovna pokretanja"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Nastavi"
@@ -1511,6 +1608,10 @@ msgstr "Promijeni token"
 msgid "Rows per page"
 msgstr "Redovi po stranici"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metrike izvršavanja"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. Detalji"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Samotestiranje"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Odaberi {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Pošaljite jedan heartbeat ping kako biste provjerili radi li vaša krajnja točka."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Kartice"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Zadaci"
@@ -1779,6 +1896,14 @@ msgstr "Propusnost ZFS spremišta {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Format vremena"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Pokreće se kada se status sustava promijeni"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Pokreće se kada iskorištenost bilo kojeg diska premaši prag"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Nepoznato"
 msgid "Unlimited"
 msgstr "Neograničeno"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Otpremi"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Vrijeme rada"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/hu/hu.po
+++ b/internal/site/src/locales/hu/hu.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} elérhető"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} a(z) {1} sorból kiválasztva."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 nap"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 perc"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Ügynök"
 msgid "Alert History"
 msgstr "Riasztási előzmények"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Minden konténer"
 msgid "All Systems"
 msgstr "Minden rendszer"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Biztosan törölni szeretnéd {name}-t?"
@@ -196,6 +238,10 @@ msgstr "Biztosan törölni szeretnéd {name}-t?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Biztos vagy benne?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Biztonsági mentések"
 msgid "Bandwidth"
 msgstr "Sávszélesség"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Akku"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Akkumulátor"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Leállítható"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Grafikon szélessége"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Ellenőrizd a {email} címet a visszaállító linkért."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Konténer állapota"
 msgid "Containers"
 msgstr "Konténerek"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Létrehozva"
 msgid "Critical (%)"
 msgstr "Kritikus (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "A rendszerindítás óta összesen olvasott adat"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Napi"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Alapértelmezett időszak"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Törlés"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Letöltés"
 msgid "Duration"
 msgstr "Időtartam"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "A <0>config.yml</0> fájlban nem definiált meglévő rendszerek törlé
 msgid "Exited active"
 msgstr "Aktívként kilépett"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Lejár egy óra után vagy a hub újraindításakor."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Konfiguráció exportálása"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exportálja a jelenlegi rendszerkonfigurációt."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exportálja a jelenlegi rendszerkonfigurációt."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Állomás / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Tétlen"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Ha elvesztette az admin fiók jelszavát, a következő paranccsal állíthatja vissza."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Érvénytelen e-mail cím."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Nyelv"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Memóriahasználat"
 msgid "Memory usage of containers"
 msgstr "Konténerek memóriahasználata"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Sávszélesség mértékegysége"
 msgid "No"
 msgstr "Nem"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ehhez a tárkészlethez nem érhetők el részletes adatok."
@@ -1287,6 +1424,7 @@ msgstr "Ehhez az eszközhöz nem állnak rendelkezésre S.M.A.R.T. attribútumok
 msgid "No systems found."
 msgstr "Nem található rendszer."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Nincs"
@@ -1301,13 +1439,21 @@ msgstr "Értesítések"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Az értesítések tartalmazhatnak részleteket a konténerek legutóbbi naplóiból."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC támogatás"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Minden újraindításkor az adatbázisban lévő rendszerek frissítésre kerülnek, hogy megfeleljenek a fájlban meghatározott rendszereknek."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Minden újraindításkor az adatbázisban lévő rendszerek frissítésre kerülnek, hogy megfeleljenek a fájlban meghatározott rendszereknek."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Egyéb"
 msgid "Overwrite existing alerts"
 msgstr "Felülírja a meglévő riasztásokat"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Oldalak / Beállítások"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Jelszó"
 
@@ -1388,6 +1547,10 @@ msgstr "Múlt"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Szüneteltetés"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Állandó"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Tartósság"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Preferált nyelv"
 msgid "Process started"
 msgstr "Folyamat elindítva"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Olvasási hibák"
 msgid "Received"
 msgstr "Fogadott"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Szükséges"
 msgid "Requires"
 msgstr "Igényel"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Jelszó visszaállítása"
@@ -1592,6 +1775,14 @@ msgstr "Újraindítások"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Folytatás"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Állapot"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Lapok"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Ezután jelentkezzen be a backendbe, és állítsa vissza a felhasznál�
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Ezt a műveletet nem lehet visszavonni! Véglegesen törli a {name} összes jelenlegi rekordját az adatbázisból!"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Ez véglegesen törli az összes kijelölt bejegyzést az adatbázisból."
@@ -1892,6 +2089,10 @@ msgstr "A {extraFsName} átviteli teljesítménye"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "{poolName} ZFS-tárkészlet átviteli sebessége"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "E-mailben"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Feltöltés"
 msgid "Uptime"
 msgstr "Üzemidő"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "{poolName} ZFS-tárkészlet kihasználtsága"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Felhasznált"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Szeretne segíteni nekünk abban, hogy fordításaink még jobbak legyen
 msgid "Wants"
 msgstr "Igényel"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Figyelmeztetés (%)"
@@ -2170,6 +2385,10 @@ msgstr "Figyelmeztetés (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Figyelmeztetési küszöbértékek"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/hu/hu.po
+++ b/internal/site/src/locales/hu/hu.po
@@ -126,6 +126,11 @@ msgstr "Aktív állapot"
 msgid "Add {foo}"
 msgstr "Hozzáadás {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URL hozzáadása"
@@ -327,6 +332,7 @@ msgstr "Indítható"
 msgid "Can stop"
 msgstr "Leállítható"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Figyelem - potenciális adatvesztés"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Ellenőrizze a megfigyelő szolgáltatást"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Ellenőrizd az értesítési szolgáltatásodat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Ciklusok"
 msgid "Daily"
 msgstr "Napi"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Alapértelmezett"
 msgid "Default time period"
 msgstr "Alapértelmezett időszak"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Szerkesztés"
 msgid "Edit {foo}"
 msgstr "Szerkesztés {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Konfiguráció exportálása"
 msgid "Export your current systems configuration."
 msgstr "Exportálja a jelenlegi rendszerkonfigurációt."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD parancs"
 msgid "Full"
 msgstr "Tele"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew parancs"
 msgid "Host / IP"
 msgstr "Állomás / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP metódus"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O kihasználtság"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inaktív"
 msgid "Interval"
 msgstr "Intervallum"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Érvénytelen e-mail cím."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Konténerek memóriahasználata"
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Csatolási pont"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Név"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nem"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ehhez a tárkészlethez nem érhetők el részletes adatok."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Jelszó-visszaállítási kérelmet kaptunk"
 msgid "Past"
 msgstr "Múlt"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Szüneteltetés"
@@ -1391,6 +1467,14 @@ msgstr "Tárkészlet kihasználtsága"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Olvasási hibák"
 msgid "Received"
 msgstr "Fogadott"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Jelszó visszaállítása"
 msgid "Resolved"
 msgstr "Megoldva"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Újraindítások"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Folytatás"
@@ -1511,6 +1608,10 @@ msgstr "Tokenváltás"
 msgid "Rows per page"
 msgstr "Sorok száma oldalanként"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Futásidejű metrikák"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. Részletek"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Önteszt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "{foo} kiválasztása"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Küldjön egyetlen heartbeat pinget a végpont működésének ellenőrzéséhez."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Lapok"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Feladatok"
@@ -1779,6 +1896,14 @@ msgstr "{poolName} ZFS-tárkészlet átviteli sebessége"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Időformátum"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Riaszt, amikor a rendszer online állapota változik"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Riaszt, ha a lemezhasználat túllép egy küszöbértéket"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Ismeretlen"
 msgid "Unlimited"
 msgstr "Korlátlan"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Feltöltés"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Üzemidő"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/id/id.po
+++ b/internal/site/src/locales/id/id.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} tersedia"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} dari {1} baris terpilih."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 hari"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 mnt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agen"
 msgid "Alert History"
 msgstr "Riwayat Peringatan"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Semua Container"
 msgid "All Systems"
 msgstr "Semua Sistem"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Apakah anda yakin ingin menghapus {name}?"
@@ -196,6 +238,10 @@ msgstr "Apakah anda yakin ingin menghapus {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Apakah anda yakin?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Cadangan"
 msgid "Bandwidth"
 msgstr "Bandwith"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Baterai"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Baterai"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Dapat diberhentikan"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Lebar grafik"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Periksa {email} untuk tautan atur ulang password."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Kesehatan Kontainer"
 msgid "Containers"
 msgstr "Kontainer"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Dibuat"
 msgid "Critical (%)"
 msgstr "Kritis (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Total data yang dibaca sejak boot"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Harian"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standar waktu"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Hapus"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Unduh"
 msgid "Duration"
 msgstr "Durasi"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Sistem yang ada yang tidak didefinisikan dalam <0>config.yml</0> akan di
 msgid "Exited active"
 msgstr "Keluar aktif"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Kedaluwarsa setelah satu jam atau saat restart hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Export konfigurasi"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Export konfigurasi sistem anda saat ini."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Export konfigurasi sistem anda saat ini."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr ""
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr ""
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Jika anda kehilangan kata sandi untuk akun admin anda, anda dapat meresetnya menggunakan perintah berikut."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Alamat email tidak valid."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Bahasa"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Penggunaan Memori"
 msgid "Memory usage of containers"
 msgstr "Penggunaan memori container"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr ""
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Unit jaringan"
 msgid "No"
 msgstr "Tidak"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Tidak ada data terperinci yang tersedia untuk pool ini."
@@ -1287,6 +1424,7 @@ msgstr "Tidak ada atribut S.M.A.R.T. yang tersedia untuk perangkat ini."
 msgid "No systems found."
 msgstr "Sistem tidak ditemukan."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Tidak ada"
@@ -1301,13 +1439,21 @@ msgstr "Notifikasi"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Notifikasi dapat menyertakan cuplikan terbaru dari log kontainer."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Dukungan OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Pada setiap restart, sistem dalam database akan diperbarui untuk mencocokkan sistem yang didefinisikan dalam file."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Pada setiap restart, sistem dalam database akan diperbarui untuk mencocokkan sistem yang didefinisikan dalam file."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Lainnya"
 msgid "Overwrite existing alerts"
 msgstr "Timpa peringatan yang ada"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Halaman / Pengaturan"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Kata sandi"
 
@@ -1388,6 +1547,10 @@ msgstr "Lalu"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Jeda"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Permanen"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Tetap berlaku"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Pilihan Bahasa"
 msgid "Process started"
 msgstr "Proses dimulai"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Kesalahan baca"
 msgid "Received"
 msgstr "Diterima"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Diperlukan oleh"
 msgid "Requires"
 msgstr "Memerlukan"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Reset Kata Sandi"
@@ -1592,6 +1775,14 @@ msgstr "Restart"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Lanjutkan"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Status"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Tab"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Kemudian masuk ke backend dan reset kata sandi akun pengguna anda di tab
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Aksi ini tidak dapat di kembalikan. ini akan menghapus permanen semua record {name} dari database"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Ini akan menghapus secara permanen semua record yang dipilih dari database."
@@ -1892,6 +2089,10 @@ msgstr "Throughput dari {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Throughput pool ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Ke email"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr ""
@@ -2093,8 +2295,13 @@ msgstr "Unggah"
 msgid "Uptime"
 msgstr "Waktu aktif"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Penggunaan pool ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Digunakan"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Ingin membantu meningkatkan terjemahan kami? Periksa <0>Crowdin</0> untu
 msgid "Wants"
 msgstr "Menginginkan"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Peringatan (%)"
@@ -2170,6 +2385,10 @@ msgstr "Peringatan (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Ambang peringatan"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/id/id.po
+++ b/internal/site/src/locales/id/id.po
@@ -126,6 +126,11 @@ msgstr "Status aktif"
 msgid "Add {foo}"
 msgstr "Tambah {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Tambah URL"
@@ -327,6 +332,7 @@ msgstr "Dapat dimulai"
 msgid "Can stop"
 msgstr "Dapat diberhentikan"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Perhatian - potensi kehilangan data"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Periksa layanan pemantauan Anda"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Periksa jasa penyedia notifikasi anda"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Siklus"
 msgid "Daily"
 msgstr "Harian"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr ""
 msgid "Default time period"
 msgstr "Standar waktu"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Ubah"
 msgid "Edit {foo}"
 msgstr "Ubah {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Export konfigurasi"
 msgid "Export your current systems configuration."
 msgstr "Export konfigurasi sistem anda saat ini."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr ""
@@ -916,6 +943,10 @@ msgstr "Perintah FreeBSD"
 msgid "Full"
 msgstr "Penuh"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Perintah Homebrew"
 msgid "Host / IP"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Metode HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Utilisasi I/O"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Tidak aktif"
 msgid "Interval"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Alamat email tidak valid."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Penggunaan memori container"
 msgid "Model"
 msgstr ""
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Titik kait"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nama"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Tidak"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Tidak ada data terperinci yang tersedia untuk pool ini."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Permintaan reset kata sandi diterima"
 msgid "Past"
 msgstr "Lalu"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Jeda"
@@ -1391,6 +1467,14 @@ msgstr "Penggunaan pool"
 msgid "Port"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Kesalahan baca"
 msgid "Received"
 msgstr "Diterima"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Reset Kata Sandi"
 msgid "Resolved"
 msgstr "Diselesaikan"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Restart"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Lanjutkan"
@@ -1511,6 +1608,10 @@ msgstr "Ganti ulang token"
 msgid "Rows per page"
 msgstr "Baris per halaman"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metrik Runtime"
@@ -1522,6 +1623,10 @@ msgstr "Detail S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Self-Test S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Pilih {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Kirim satu ping heartbeat untuk memverifikasi titik akhir Anda berfungsi."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Tab"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tugas"
@@ -1779,6 +1896,14 @@ msgstr "Throughput pool ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Format waktu"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Dipicu ketika status beralih antara up dan down"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Dipicu ketika penggunaan disk apa pun melebihi ambang batas"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Tidak diketahui"
 msgid "Unlimited"
 msgstr "Tidak terbatas"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Unggah"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Waktu aktif"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/it/it.po
+++ b/internal/site/src/locales/it/it.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} disponibile"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} di {1} righe selezionate."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 giorni"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agente"
 msgid "Alert History"
 msgstr "Cronologia Avvisi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Tutti i contenitori"
 msgid "All Systems"
 msgstr "Tutti i Sistemi"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Sei sicuro di voler eliminare {name}?"
@@ -196,6 +238,10 @@ msgstr "Sei sicuro di voler eliminare {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Sei sicuro?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Backup"
 msgid "Bandwidth"
 msgstr "Larghezza di banda"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Batt"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batteria"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Può fermare"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Larghezza grafico"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Controlla {email} per un link di reset."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Stato del container"
 msgid "Containers"
 msgstr "Container"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Creato"
 msgid "Critical (%)"
 msgstr "Critico (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Dati totali letti dall'avvio"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Giornaliero"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Periodo di tempo predefinito"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Elimina"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Scarica"
 msgid "Duration"
 msgstr "Durata"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "I sistemi esistenti non definiti in <0>config.yml</0> verranno eliminati
 msgid "Exited active"
 msgstr "Uscito attivo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Scade dopo un'ora o al riavvio dell'hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Esporta configurazione"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Esporta la configurazione attuale dei tuoi sistemi."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Esporta la configurazione attuale dei tuoi sistemi."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inattiva"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Se hai perso la password del tuo account amministratore, puoi reimpostarla utilizzando il seguente comando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Indirizzo email non valido."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Lingua"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Utilizzo Memoria"
 msgid "Memory usage of containers"
 msgstr "Utilizzo della memoria dei container"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modello"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Unità rete"
 msgid "No"
 msgstr "No"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Nessun dato dettagliato disponibile per questo pool."
@@ -1287,6 +1424,7 @@ msgstr "Nessun attributo S.M.A.R.T. disponibile per questo dispositivo."
 msgid "No systems found."
 msgstr "Nessun sistema trovato."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Nessuno"
@@ -1301,13 +1439,21 @@ msgstr "Notifiche"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Le notifiche possono includere estratti recenti dai log dei container."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Supporto OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Ad ogni riavvio, i sistemi nel database verranno aggiornati per corrispondere ai sistemi definiti nel file."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Ad ogni riavvio, i sistemi nel database verranno aggiornati per corrispondere ai sistemi definiti nel file."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Altro"
 msgid "Overwrite existing alerts"
 msgstr "Sovrascrivi avvisi esistenti"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Pagine / Impostazioni"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Password"
 
@@ -1388,6 +1547,10 @@ msgstr "Passato"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausa"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Permanente"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistenza"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Lingua Preferita"
 msgid "Process started"
 msgstr "Processo avviato"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Errori di lettura"
 msgid "Received"
 msgstr "Ricevuto"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Richiesto da"
 msgid "Requires"
 msgstr "Richiede"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Reimposta Password"
@@ -1592,6 +1775,14 @@ msgstr "Riavvii"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Riprendi"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Stato"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Schede"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Quindi accedi al backend e reimposta la password del tuo account utente 
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Questa azione non può essere annullata. Questo eliminerà permanentemente tutti i record attuali per {name} dal database."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Questo eliminerà permanentemente tutti i record selezionati dal database."
@@ -1892,6 +2089,10 @@ msgstr "Throughput di {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Throughput del pool ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "A email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Carica"
 msgid "Uptime"
 msgstr "Tempo di attività"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Utilizzo del pool ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Utilizzato"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Vuoi aiutarci a migliorare ulteriormente le nostre traduzioni? Dai un'oc
 msgid "Wants"
 msgstr "Desidera"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Avviso (%)"
@@ -2170,6 +2385,10 @@ msgstr "Avviso (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Soglie di avviso"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/it/it.po
+++ b/internal/site/src/locales/it/it.po
@@ -126,6 +126,11 @@ msgstr "Stato attivo"
 msgid "Add {foo}"
 msgstr "Aggiungi {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Aggiungi URL"
@@ -327,6 +332,7 @@ msgstr "Può avviare"
 msgid "Can stop"
 msgstr "Può fermare"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Attenzione - possibile perdita di dati"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Controlla il tuo servizio di monitoraggio"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Controlla il tuo servizio di notifica"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cicli"
 msgid "Daily"
 msgstr "Giornaliero"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Predefinito"
 msgid "Default time period"
 msgstr "Periodo di tempo predefinito"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Modifica"
 msgid "Edit {foo}"
 msgstr "Modifica {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Esporta configurazione"
 msgid "Export your current systems configuration."
 msgstr "Esporta la configurazione attuale dei tuoi sistemi."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "Comando FreeBSD"
 msgid "Full"
 msgstr "Piena"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Comando Homebrew"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Metodo HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Utilizzo I/O"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inattivo"
 msgid "Interval"
 msgstr "Intervallo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Indirizzo email non valido."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Utilizzo della memoria dei container"
 msgid "Model"
 msgstr "Modello"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Punto di montaggio"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nome"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "No"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Nessun dato dettagliato disponibile per questo pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Richiesta di reimpostazione password ricevuta"
 msgid "Past"
 msgstr "Passato"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausa"
@@ -1391,6 +1467,14 @@ msgstr "Utilizzo del pool"
 msgid "Port"
 msgstr "Porta"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Errori di lettura"
 msgid "Received"
 msgstr "Ricevuto"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Reimposta Password"
 msgid "Resolved"
 msgstr "Risolto"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Riavvii"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Riprendi"
@@ -1511,6 +1608,10 @@ msgstr "Ruota token"
 msgid "Rows per page"
 msgstr "Righe per pagina"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metriche di runtime"
@@ -1522,6 +1623,10 @@ msgstr "Dettagli S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Autotest S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Seleziona {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Invia un singolo ping di heartbeat per verificare che l'endpoint funzioni."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Schede"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Attività"
@@ -1779,6 +1896,14 @@ msgstr "Throughput del pool ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Formato orario"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Attiva quando lo stato passa tra up e down"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Attiva quando l'utilizzo di un disco supera una soglia"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Sconosciuta"
 msgid "Unlimited"
 msgstr "Illimitato"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Carica"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Tempo di attività"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ja/ja.po
+++ b/internal/site/src/locales/ja/ja.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} が利用可能"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{1}行のうち{0}行が選択されました。"
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30日間"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5分"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "エージェント"
 msgid "Alert History"
 msgstr "アラート履歴"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "すべてのコンテナ"
 msgid "All Systems"
 msgstr "すべてのシステム"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}を削除してもよろしいですか？"
@@ -196,6 +238,10 @@ msgstr "{name}を削除してもよろしいですか？"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "よろしいですか？"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "バックアップ"
 msgid "Bandwidth"
 msgstr "帯域幅"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "バッテリー"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "バッテリー"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "停止可能"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "摂氏 (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "チャートの幅"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "{email}を確認してリセットリンクを探してください。"
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "コンテナのヘルス"
 msgid "Containers"
 msgstr "コンテナ"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "作成日"
 msgid "Critical (%)"
 msgstr "致命的 (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "起動後の累積読み取りデータ"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "毎日"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "デフォルトの期間"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "削除"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "ダウンロード"
 msgid "Duration"
 msgstr "期間"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "<0>config.yml</0>に定義されていない既存のシステムは削�
 msgid "Exited active"
 msgstr "アクティブ状態で終了"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "1時間後、またはハブの再起動時に有効期限が切れます。"
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "設定をエクスポート"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "現在のシステム設定をエクスポートします。"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "現在のシステム設定をエクスポートします。"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "ホスト / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "アイドル"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "管理者アカウントのパスワードを忘れた場合は、次のコマンドを使用してリセットできます。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "無効なメールアドレスです。"
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "言語"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "メモリ使用率"
 msgid "Memory usage of containers"
 msgstr "コンテナのメモリ使用量"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "モデル"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "ネットワーク単位"
 msgid "No"
 msgstr "いいえ"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "このプールの詳細データはありません。"
@@ -1287,6 +1424,7 @@ msgstr "このデバイスのS.M.A.R.T.属性は利用できません。"
 msgid "No systems found."
 msgstr "システムが見つかりませんでした。"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "なし"
@@ -1301,13 +1439,21 @@ msgstr "通知"
 msgid "Notifications may include recent container log excerpts."
 msgstr "通知には、最近のコンテナログの抜粋が含まれる場合があります。"
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDCサポート"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "再起動のたびに、データベース内のシステムはファイルに定義されたシステムに一致するように更新されます。"
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "再起動のたびに、データベース内のシステムはファイルに定義されたシステムに一致するように更新されます。"
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "その他"
 msgid "Overwrite existing alerts"
 msgstr "既存のアラートを上書き"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "ページ / 設定"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "パスワード"
 
@@ -1388,6 +1547,10 @@ msgstr "過去"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "一時停止"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "永久"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "永続性"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "優先言語"
 msgid "Process started"
 msgstr "プロセス開始"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "読み取りエラー"
 msgid "Received"
 msgstr "受信"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "必要とされる"
 msgid "Requires"
 msgstr "必要とする"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "パスワードをリセット"
@@ -1592,6 +1775,14 @@ msgstr "再起動"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "再開"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "状態"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "タブ"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "その後、バックエンドにログインして、ユーザーテー
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "この操作は元に戻せません。これにより、データベースから{name}のすべての現在のレコードが永久に削除されます。"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "これにより、選択したすべてのレコードがデータベースから完全に削除されます。"
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName}のスループット"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS プール {poolName} のスループット"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "宛先メールアドレス"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "トークン"
@@ -2093,8 +2295,13 @@ msgstr "アップロード"
 msgid "Uptime"
 msgstr "稼働時間"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS プール {poolName} の使用量"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "使用中"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "翻訳をさらに良くするためにご協力をお願いします。
 msgid "Wants"
 msgstr "要求"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "警告 (%)"
@@ -2170,6 +2385,10 @@ msgstr "警告 (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "警告のしきい値"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/ja/ja.po
+++ b/internal/site/src/locales/ja/ja.po
@@ -126,6 +126,11 @@ msgstr "アクティブ状態"
 msgid "Add {foo}"
 msgstr "{foo}を追加"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URLを追加"
@@ -327,6 +332,7 @@ msgstr "開始可能"
 msgid "Can stop"
 msgstr "停止可能"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "注意 - データ損失の可能性"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "摂氏 (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "監視サービスを確認する"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "通知サービスを確認してください"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "サイクル"
 msgid "Daily"
 msgstr "毎日"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "デフォルト"
 msgid "Default time period"
 msgstr "デフォルトの期間"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "編集"
 msgid "Edit {foo}"
 msgstr "{foo}を編集"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "設定をエクスポート"
 msgid "Export your current systems configuration."
 msgstr "現在のシステム設定をエクスポートします。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "華氏 (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD コマンド"
 msgid "Full"
 msgstr "満充電"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew コマンド"
 msgid "Host / IP"
 msgstr "ホスト / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP メソッド"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O 利用率"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "非アクティブ"
 msgid "Interval"
 msgstr "間隔"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "無効なメールアドレスです。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "コンテナのメモリ使用量"
 msgid "Model"
 msgstr "モデル"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "マウントポイント"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "名前"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "いいえ"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "このプールの詳細データはありません。"
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "パスワードリセットのリクエストを受け取りました"
 msgid "Past"
 msgstr "過去"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "一時停止"
@@ -1391,6 +1467,14 @@ msgstr "プール使用量"
 msgid "Port"
 msgstr "ポート"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "読み取りエラー"
 msgid "Received"
 msgstr "受信"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "パスワードをリセット"
 msgid "Resolved"
 msgstr "解決済み"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "再起動"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "再開"
@@ -1511,6 +1608,10 @@ msgstr "トークンをローテート"
 msgid "Rows per page"
 msgstr "ページあたりの行数"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "ランタイムメトリクス"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.詳細"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T.セルフテスト"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "{foo}を選択"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "エンドポイントが機能していることを確認するために、単一のハートビート ping を送信します。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "タブ"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "タスク"
@@ -1779,6 +1896,14 @@ msgstr "ZFS プール {poolName} のスループット"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "時間形式"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "ステータスが上から下に切り替わるときにトリガーさ
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "ディスクの使用量がしきい値を超えたときにトリガーされます"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "不明"
 msgid "Unlimited"
 msgstr "無制限"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "アップロード"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "稼働時間"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ko/ko.po
+++ b/internal/site/src/locales/ko/ko.po
@@ -126,6 +126,11 @@ msgstr "활성 상태"
 msgid "Add {foo}"
 msgstr "{foo} 추가"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URL 추가"
@@ -327,6 +332,7 @@ msgstr "시작 가능"
 msgid "Can stop"
 msgstr "중지 가능"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "주의 - 데이터 손실 가능성"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "섭씨 (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "모니터링 서비스 확인"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "알림 서비스를 확인하세요."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "사이클"
 msgid "Daily"
 msgstr "매일"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "기본값"
 msgid "Default time period"
 msgstr "기본 기간"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "수정"
 msgid "Edit {foo}"
 msgstr "{foo} 수정"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "구성 내보내기"
 msgid "Export your current systems configuration."
 msgstr "현재 시스템 구성 내보내기"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "화씨 (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD 명령어"
 msgid "Full"
 msgstr "가득"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew 명령어"
 msgid "Host / IP"
 msgstr "호스트 / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP 메서드"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O 사용률"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "비활성"
 msgid "Interval"
 msgstr "간격"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "잘못된 이메일 주소입니다."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "컨테이너 메모리 사용량"
 msgid "Model"
 msgstr "모델"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "마운트 지점"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "이름"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "아니오"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "이 풀에 대한 상세 데이터가 없습니다."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "비밀번호 재설정 요청이 접수되었습니다"
 msgid "Past"
 msgstr "과거"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "일시 중지"
@@ -1391,6 +1467,14 @@ msgstr "풀 사용량"
 msgid "Port"
 msgstr "포트"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "읽기 오류"
 msgid "Received"
 msgstr "수신됨"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "비밀번호 재설정"
 msgid "Resolved"
 msgstr "해결됨"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "재시작 횟수"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "재개"
@@ -1511,6 +1608,10 @@ msgstr "토큰 회전"
 msgid "Rows per page"
 msgstr "페이지당 행 수"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "런타임 메트릭"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. 세부 정보"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. 자체 테스트"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "{foo} 선택"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "엔드포인트가 작동하는지 확인하기 위해 단일 하트비트 핑을 보냅니다."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "탭"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "작업"
@@ -1779,6 +1896,14 @@ msgstr "ZFS 풀 {poolName} 처리량"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "시간 형식"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "시스템의 전원이 켜지거나 꺼질때 트리거됩니다."
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "디스크 사용량이 임계값을 초과할 때 트리거됩니다."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "알 수 없음"
 msgid "Unlimited"
 msgstr "무제한"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "업로드"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "가동시간"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ko/ko.po
+++ b/internal/site/src/locales/ko/ko.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} 사용 가능"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{1}개의 행 중 {0}개가 선택되었습니다."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30일"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5분"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "에이전트"
 msgid "Alert History"
 msgstr "알림 기록"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "모든 컨테이너"
 msgid "All Systems"
 msgstr "모든 시스템"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name}을(를) 삭제하시겠습니까?"
@@ -196,6 +238,10 @@ msgstr "{name}을(를) 삭제하시겠습니까?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "확실합니까?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "백업"
 msgid "Bandwidth"
 msgstr "대역폭"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "배터리"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "배터리"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "중지 가능"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "섭씨 (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "차트 너비"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "{email}에서 재설정 링크를 확인하세요."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "컨테이너 상태"
 msgid "Containers"
 msgstr "컨테이너"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "생성됨"
 msgid "Critical (%)"
 msgstr "위험 (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "부팅 이후 누적 읽기 데이터"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "매일"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "기본 기간"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "삭제"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "다운로드"
 msgid "Duration"
 msgstr "기간"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "<0>config.yml</0>에 정의되지 않은 기존 시스템은 삭제됩�
 msgid "Exited active"
 msgstr "활성 종료됨"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "한 시간 후 또는 허브 재시작 시 만료됩니다."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "구성 내보내기"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "현재 시스템 구성 내보내기"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "현재 시스템 구성 내보내기"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "호스트 / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "대기"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "관리자 계정의 비밀번호를 잃어버린 경우, 다음 명령어를 사용하여 재설정할 수 있습니다."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "잘못된 이메일 주소입니다."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "언어"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "메모리 사용량"
 msgid "Memory usage of containers"
 msgstr "컨테이너 메모리 사용량"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "모델"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "네트워크 단위"
 msgid "No"
 msgstr "아니오"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "이 풀에 대한 상세 데이터가 없습니다."
@@ -1287,6 +1424,7 @@ msgstr "이 장치에 사용할 수 있는 S.M.A.R.T. 속성이 없습니다."
 msgid "No systems found."
 msgstr "시스템을 찾을 수 없습니다."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "없음"
@@ -1301,13 +1439,21 @@ msgstr "알림"
 msgid "Notifications may include recent container log excerpts."
 msgstr "알림에는 최근 컨테이너 로그의 일부가 포함될 수 있습니다."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC 지원"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "매 시작 시, 데이터베이스가 파일에 정의된 시스템과 일치하도록 업데이트됩니다."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "매 시작 시, 데이터베이스가 파일에 정의된 시스템과 일치하도록 업데이트됩니다."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "기타"
 msgid "Overwrite existing alerts"
 msgstr "기존 알림 덮어쓰기"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "페이지 / 설정"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "비밀번호"
 
@@ -1388,6 +1547,10 @@ msgstr "과거"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "일시 중지"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "영구적"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "지속성"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "선호 언어"
 msgid "Process started"
 msgstr "프로세스 시작됨"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "읽기 오류"
 msgid "Received"
 msgstr "수신됨"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "필요한 대상"
 msgid "Requires"
 msgstr "필요 항목"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "비밀번호 재설정"
@@ -1592,6 +1775,14 @@ msgstr "재시작 횟수"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "재개"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "상태"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "탭"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "그런 다음 백엔드에 로그인하여 사용자 테이블에서 사
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "이 작업은 되돌릴 수 없습니다. 데이터베이스에서 {name}에 대한 모든 현재 기록이 영구적으로 삭제됩니다."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "선택한 모든 레코드를 데이터베이스에서 영구적으로 삭제합니다."
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName}의 처리량"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS 풀 {poolName} 처리량"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "받는사람(들)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "토큰"
@@ -2093,8 +2295,13 @@ msgstr "업로드"
 msgid "Uptime"
 msgstr "가동시간"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS 풀 {poolName} 사용량"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "사용됨"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "번역을 개선하는데 도움을 주시겠습니까? 자세한 내용
 msgid "Wants"
 msgstr "요구 항목"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "경고 (%)"
@@ -2170,6 +2385,10 @@ msgstr "경고 (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "경고 임계값"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/nl/nl.po
+++ b/internal/site/src/locales/nl/nl.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} beschikbaar"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} van de {1} rij(en) geselecteerd."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dagen"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 minuten"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Melding geschiedenis"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Alle containers"
 msgid "All Systems"
 msgstr "Alle systemen"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Weet je zeker dat je {name} wilt verwijderen?"
@@ -196,6 +238,10 @@ msgstr "Weet je zeker dat je {name} wilt verwijderen?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Weet je het zeker?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Back-ups"
 msgid "Bandwidth"
 msgstr "Bandbreedte"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batterij"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Kan stoppen"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Grafiekbreedte"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Controleer {email} op een reset link."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Containergezondheid"
 msgid "Containers"
 msgstr "Containers"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Aangemaakt"
 msgid "Critical (%)"
 msgstr "Kritiek (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Cumulatief gelezen gegevens sinds het opstarten"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Dagelijks"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standaard tijdsduur"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Verwijderen"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Downloaden"
 msgid "Duration"
 msgstr "Duur"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Bestaande systemen die niet gedefinieerd zijn in <0>config.yml</0> zulle
 msgid "Exited active"
 msgstr "Beëindigd actief"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Verloopt na één uur of bij hub-herstart."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Configuratie exporteren"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exporteer je huidige systeemconfiguratie."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exporteer je huidige systeemconfiguratie."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP-adres"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inactief"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Als je het wachtwoord voor je beheerdersaccount bent kwijtgeraakt, kan je het opnieuw instellen met behulp van de volgende opdracht."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Ongeldig e-mailadres."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Taal"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Geheugengebruik"
 msgid "Memory usage of containers"
 msgstr "Geheugengebruik van containers"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Netwerk eenheid"
 msgid "No"
 msgstr "Nee"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Geen gedetailleerde gegevens beschikbaar voor deze pool."
@@ -1287,6 +1424,7 @@ msgstr "Geen S.M.A.R.T. kenmerken beschikbaar voor dit apparaat."
 msgid "No systems found."
 msgstr "Geen systemen gevonden."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Geen"
@@ -1301,13 +1439,21 @@ msgstr "Meldingen"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Meldingen kunnen recente fragmenten uit containerlogboeken bevatten."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC ondersteuning"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Bij elke herstart zullen systemen in de database worden bijgewerkt om overeen te komen met de systemen die in het bestand zijn gedefinieerd."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Bij elke herstart zullen systemen in de database worden bijgewerkt om overeen te komen met de systemen die in het bestand zijn gedefinieerd."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Overig"
 msgid "Overwrite existing alerts"
 msgstr "Overschrijf bestaande waarschuwingen"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Pagina's / Instellingen"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Wachtwoord"
 
@@ -1388,6 +1547,10 @@ msgstr "Verleden"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauze"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Blijvend"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistentie"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Voorkeurstaal"
 msgid "Process started"
 msgstr "Proces gestart"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Publieke sleutel"
@@ -1535,6 +1706,10 @@ msgstr "Leesfouten"
 msgid "Received"
 msgstr "Ontvangen"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Vereist door"
 msgid "Requires"
 msgstr "Vereist"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Wachtwoord resetten"
@@ -1592,6 +1775,14 @@ msgstr "Herstarten"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Hervatten"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Status"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Tabbladen"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Log vervolgens in op de backend en reset het wachtwoord van je gebruiker
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Deze actie kan niet ongedaan worden gemaakt. Dit zal alle huidige records voor {name} permanent verwijderen uit de database."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Dit zal alle geselecteerde records verwijderen uit de database."
@@ -1892,6 +2089,10 @@ msgstr "Doorvoer van {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Doorvoer van ZFS-pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Naar e-mail(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Uploaden"
 msgid "Uptime"
 msgstr "Actief"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Gebruik van ZFS-pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Gebruikt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Wil je ons helpen onze vertalingen nog beter te maken? Bekijk <0>Crowdin
 msgid "Wants"
 msgstr "Wil"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Waarschuwing (%)"
@@ -2170,6 +2385,10 @@ msgstr "Waarschuwing (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Waarschuwingsdrempels"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/nl/nl.po
+++ b/internal/site/src/locales/nl/nl.po
@@ -126,6 +126,11 @@ msgstr "Actieve status"
 msgid "Add {foo}"
 msgstr "Voeg {foo} toe"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Voeg URL toe"
@@ -327,6 +332,7 @@ msgstr "Kan starten"
 msgid "Can stop"
 msgstr "Kan stoppen"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Opgelet - potentieel gegevensverlies"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Controleer je monitoringservice"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Controleer je meldingsservice"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cycli"
 msgid "Daily"
 msgstr "Dagelijks"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standaard"
 msgid "Default time period"
 msgstr "Standaard tijdsduur"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Bewerken"
 msgid "Edit {foo}"
 msgstr "Bewerk {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Configuratie exporteren"
 msgid "Export your current systems configuration."
 msgstr "Exporteer je huidige systeemconfiguratie."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD commando"
 msgid "Full"
 msgstr "Vol"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew-commando"
 msgid "Host / IP"
 msgstr "Host / IP-adres"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-methode"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O Gebruik"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inactief"
 msgid "Interval"
 msgstr "Interval"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Ongeldig e-mailadres."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Geheugengebruik van containers"
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Koppelpunt"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Naam"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nee"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Geen gedetailleerde gegevens beschikbaar voor deze pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Wachtwoord reset aanvraag ontvangen"
 msgid "Past"
 msgstr "Verleden"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauze"
@@ -1391,6 +1467,14 @@ msgstr "Poolgebruik"
 msgid "Port"
 msgstr "Poort"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Leesfouten"
 msgid "Received"
 msgstr "Ontvangen"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Wachtwoord resetten"
 msgid "Resolved"
 msgstr "Opgelost"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Herstarten"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Hervatten"
@@ -1511,6 +1608,10 @@ msgstr "Roteer Token"
 msgid "Rows per page"
 msgstr "Rijen per pagina"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Runtime-metrieken"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.-details"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Zelf-test"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Selecteer {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Stuur een enkele heartbeat-ping om te controleren of je endpoint werkt."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Tabbladen"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Taken"
@@ -1779,6 +1896,14 @@ msgstr "Doorvoer van ZFS-pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Tijdnotatie"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Triggert wanneer de status schakelt tussen up en down"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Triggert wanneer het gebruik van een schijf een drempelwaarde overschrijdt"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Onbekend"
 msgid "Unlimited"
 msgstr "Onbeperkt"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Uploaden"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Actief"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/no/no.po
+++ b/internal/site/src/locales/no/no.po
@@ -126,6 +126,11 @@ msgstr "Aktiv tilstand"
 msgid "Add {foo}"
 msgstr "Legg til {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Legg Til URL"
@@ -327,6 +332,7 @@ msgstr "Kan starte"
 msgid "Can stop"
 msgstr "Kan stoppe"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Advarsel - potensielt tap av data"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Sjekk overvåkingstjenesten din"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Sjekk din meldingstjeneste"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Sykluser"
 msgid "Daily"
 msgstr "Daglig"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standard"
 msgid "Default time period"
 msgstr "Standard tidsperiode"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Rediger"
 msgid "Edit {foo}"
 msgstr "Rediger {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Eksporter konfigurasjon"
 msgid "Export your current systems configuration."
 msgstr "Eksporter din nåværende systemkonfigurasjon"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD kommando"
 msgid "Full"
 msgstr "Fullt"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew-kommando"
 msgid "Host / IP"
 msgstr "Vert / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-metode"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O-utnyttelse"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inaktiv"
 msgid "Interval"
 msgstr "Intervall"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Ugyldig e-postadresse."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Minnebruk for containere"
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Monteringspunkt"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Navn"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nei"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ingen detaljerte data er tilgjengelige for denne poolen."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Mottatt forespørsel om å nullstille passord"
 msgid "Past"
 msgstr "Fortid"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
@@ -1391,6 +1467,14 @@ msgstr "Poolbruk"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Lesefeil"
 msgid "Received"
 msgstr "Mottatt"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Nullstill Passord"
 msgid "Resolved"
 msgstr "Løst"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Omstarter"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Gjenoppta"
@@ -1511,6 +1608,10 @@ msgstr "Forny token"
 msgid "Rows per page"
 msgstr "Rader per side"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Kjøretidsmålinger"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.-detaljer"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. selvtest"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Velg {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Send en enkelt hjerteslag-ping for å verifisere at endepunktet ditt fungerer."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Faner"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Oppgaver"
@@ -1779,6 +1896,14 @@ msgstr "Gjennomstrømning for ZFS-pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Tidsformat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Slår inn når statusen veksler mellom oppe og nede"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Slår inn når forbruk av hvilken som helst disk overstiger en grenseverdi"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Ukjent"
 msgid "Unlimited"
 msgstr "Ubegrenset"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Last opp"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Oppetid"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/no/no.po
+++ b/internal/site/src/locales/no/no.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} tilgjengelig"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} av {1} rad(er) valgt."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dager"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Varselhistorikk"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Alle containere"
 msgid "All Systems"
 msgstr "Alle Systemer"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Er du sikker på at du vil slette {name}?"
@@ -196,6 +238,10 @@ msgstr "Er du sikker på at du vil slette {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Er du sikker?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Sikkerhetskopier"
 msgid "Bandwidth"
 msgstr "Båndbredde"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Batteri"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batteri"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Kan stoppe"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Diagrambredde"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Sjekk {email} for en nullstillings-link."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Containerhelse"
 msgid "Containers"
 msgstr "Containere"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Opprettet"
 msgid "Critical (%)"
 msgstr "Kritisk (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Kumulative data lest siden oppstart"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Daglig"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standard tidsperiode"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Slett"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Last ned"
 msgid "Duration"
 msgstr "Varighet"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Eksisterende systemer som ikke er er definert i <0>config.yml</0> vil bl
 msgid "Exited active"
 msgstr "Avsluttet aktiv"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Utløper etter en time eller ved hub-omstart."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Eksporter konfigurasjon"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Eksporter din nåværende systemkonfigurasjon"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Eksporter din nåværende systemkonfigurasjon"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Vert / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inaktiv"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Dersom du har mistet passordet til admin-kontoen kan du nullstille det med følgende kommando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Ugyldig e-postadresse."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Språk"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Minnebruk"
 msgid "Memory usage of containers"
 msgstr "Minnebruk for containere"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Nettverksenhet"
 msgid "No"
 msgstr "Nei"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Ingen detaljerte data er tilgjengelige for denne poolen."
@@ -1287,6 +1424,7 @@ msgstr "Ingen S.M.A.R.T.-attributter tilgjengelig for denne enheten."
 msgid "No systems found."
 msgstr "Ingen systemer funnet."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Ingen"
@@ -1301,13 +1439,21 @@ msgstr "Varslinger"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Varsler kan inneholde nylige utdrag fra containerlogger."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC-støtte"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Ved hver omstart vil systemer i databasen bli oppdatert til å matche systemene definert i fila."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Ved hver omstart vil systemer i databasen bli oppdatert til å matche systemene definert i fila."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Andre"
 msgid "Overwrite existing alerts"
 msgstr "Overskriv eksisterende alarmer"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Sider / Innstillinger"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Passord"
 
@@ -1388,6 +1547,10 @@ msgstr "Fortid"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Permanent"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Vedvarenhet"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Foretrukket Språk"
 msgid "Process started"
 msgstr "Prosess startet"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Lesefeil"
 msgid "Received"
 msgstr "Mottatt"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Påkrevd av"
 msgid "Requires"
 msgstr "Påkrevd"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Nullstill Passord"
@@ -1592,6 +1775,14 @@ msgstr "Omstarter"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Gjenoppta"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Tilstand"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Faner"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Logg deretter inn i backend og nullstill passordet på din konto i users
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Denne handlingen kan ikke omgjøres. Dette vil slette alle poster for {name} permanent fra databasen."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Dette vil permanent slette alle valgte oppføringer fra databasen."
@@ -1892,6 +2089,10 @@ msgstr "Gjennomstrømning av {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Gjennomstrømning for ZFS-pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Til e-postadresse(r)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Last opp"
 msgid "Uptime"
 msgstr "Oppetid"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Bruk av ZFS-pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Brukt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Vil du hjelpe oss med å gjøre oversettelsene enda bedre? Ta en titt p�
 msgid "Wants"
 msgstr "Ønsker"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Advarsel (%)"
@@ -2170,6 +2385,10 @@ msgstr "Advarsel (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Advarselsterskler"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/pl/pl.po
+++ b/internal/site/src/locales/pl/pl.po
@@ -126,6 +126,11 @@ msgstr "Status aktywny"
 msgid "Add {foo}"
 msgstr "Dodaj {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Dodaj URL"
@@ -327,6 +332,7 @@ msgstr "Może uruchomić"
 msgid "Can stop"
 msgstr "Może zatrzymać"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Uwaga - ryzyko utraty danych"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsjusza (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Sprawdź usługę monitorowania"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Sprawdź swój serwis powiadomień"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cykle"
 msgid "Daily"
 msgstr "Codziennie"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Domyślne"
 msgid "Default time period"
 msgstr "Domyślny przedział czasu"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Edytuj"
 msgid "Edit {foo}"
 msgstr "Edytuj {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Eksportuj konfigurację"
 msgid "Export your current systems configuration."
 msgstr "Eksportuj aktualną konfigurację systemów."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "Polecenie FreeBSD"
 msgid "Full"
 msgstr "Pełna"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Polecenie Homebrew"
 msgid "Host / IP"
 msgstr "Host / adres IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Metoda HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Użycie I/O"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Nieaktywny"
 msgid "Interval"
 msgstr "Interwał"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Nieprawidłowy adres e-mail."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Zużycie pamięci przez kontenery"
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Punkt montowania"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nazwa"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nie"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Brak szczegółowych danych dla tej puli."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Otrzymano żądanie resetowania hasła"
 msgid "Past"
 msgstr "Poprzednie"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
@@ -1391,6 +1467,14 @@ msgstr "Użycie puli"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Błędy odczytu"
 msgid "Received"
 msgstr "Otrzymane"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Resetuj hasło"
 msgid "Resolved"
 msgstr "Rozwiązany"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Uruchamia ponownie"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Wznów"
@@ -1511,6 +1608,10 @@ msgstr "Zmień token"
 msgid "Rows per page"
 msgstr "Wiersze na stronę"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metryki czasu wykonania"
@@ -1522,6 +1623,10 @@ msgstr "Szczegóły S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Samodiagnostyka S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Wybierz {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Wyślij pojedynczy ping heartbeat, aby sprawdzić, czy punkt końcowy działa."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Karty"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Zadania"
@@ -1779,6 +1896,14 @@ msgstr "Przepustowość puli ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Format czasu"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Wyzwalane, gdy status przełącza się między stanem aktywnym a nieakty
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Wyzwalane, gdy wykorzystanie któregokolwiek dysku przekroczy ustalony próg"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Nieznana"
 msgid "Unlimited"
 msgstr "Bez limitu"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Wysyłanie"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Czas pracy"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/pl/pl.po
+++ b/internal/site/src/locales/pl/pl.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} jest dostępna"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} z {1} wybranych wierszy."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dni"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Historia alertów"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Wszystkie kontenery"
 msgid "All Systems"
 msgstr "Wszystkie systemy"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Czy na pewno chcesz usunąć {name}?"
@@ -196,6 +238,10 @@ msgstr "Czy na pewno chcesz usunąć {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Czy jesteś pewien?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Kopie zapasowe"
 msgid "Bandwidth"
 msgstr "Przepustowość"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bateria"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Bateria"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Może zatrzymać"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsjusza (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Szerokość wykresu"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Sprawdź {email}, aby uzyskać link do resetowania."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Kondycja kontenera"
 msgid "Containers"
 msgstr "Kontenery"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Utworzono"
 msgid "Critical (%)"
 msgstr "Krytyczny (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Łączna ilość danych odczytanych od uruchomienia"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Codziennie"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Domyślny przedział czasu"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Usuń"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Pobieranie"
 msgid "Duration"
 msgstr "Czas trwania"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Istniejące systemy, które nie są zdefiniowane w <0>config.yml</0>, zo
 msgid "Exited active"
 msgstr "Zakończono aktywnie"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Wygasa po godzinie lub przy ponownym uruchomieniu huba."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Eksportuj konfigurację"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Eksportuj aktualną konfigurację systemów."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Eksportuj aktualną konfigurację systemów."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / adres IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Bezczynna"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Jeśli utraciłeś hasło do swojego konta administratora, możesz je zresetować, używając następującego polecenia."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Nieprawidłowy adres e-mail."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Język"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Użycie pamięci"
 msgid "Memory usage of containers"
 msgstr "Zużycie pamięci przez kontenery"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Jednostka sieciowa"
 msgid "No"
 msgstr "Nie"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Brak szczegółowych danych dla tej puli."
@@ -1287,6 +1424,7 @@ msgstr "Brak dostępnych atrybutów S.M.A.R.T. dla tego urządzenia."
 msgid "No systems found."
 msgstr "Nie znaleziono systemów."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Brak"
@@ -1301,13 +1439,21 @@ msgstr "Powiadomienia"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Powiadomienia mogą zawierać fragmenty ostatnich logów kontenera."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Wsparcie OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Przy każdym ponownym uruchomieniu systemy w bazie danych będą aktualizowane, aby odpowiadały systemom zdefiniowanym w pliku."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Przy każdym ponownym uruchomieniu systemy w bazie danych będą aktualizowane, aby odpowiadały systemom zdefiniowanym w pliku."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Inne"
 msgid "Overwrite existing alerts"
 msgstr "Nadpisz istniejące alerty"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Strony / Ustawienia"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Hasło"
 
@@ -1388,6 +1547,10 @@ msgstr "Poprzednie"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Stały"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Trwałość"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Preferowany język"
 msgid "Process started"
 msgstr "Proces uruchomiony"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Błędy odczytu"
 msgid "Received"
 msgstr "Otrzymane"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Wymagane przez"
 msgid "Requires"
 msgstr "Wymaga"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Resetuj hasło"
@@ -1592,6 +1775,14 @@ msgstr "Uruchamia ponownie"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Wznów"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Stan"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Karty"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Następnie zaloguj się do panelu administracyjnego i  zresetuj hasło d
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Tej akcji nie można cofnąć. Spowoduje to trwałe usunięcie wszystkich bieżących rekordów dla {name} z bazy danych."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Spowoduje to trwałe usunięcie wszystkich zaznaczonych rekordów z bazy danych."
@@ -1892,6 +2089,10 @@ msgstr "Przepustowość {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Przepustowość puli ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Do e-mail(ów)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Wysyłanie"
 msgid "Uptime"
 msgstr "Czas pracy"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Użycie puli ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Używane"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Chcesz pomóc ulepszyć nasze tłumaczenie? Sprawdź <0>Crowdin</0> po s
 msgid "Wants"
 msgstr "Wymaga"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Ostrzeżenie (%)"
@@ -2170,6 +2385,10 @@ msgstr "Ostrzeżenie (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Progi ostrzegawcze"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/pt/pt.po
+++ b/internal/site/src/locales/pt/pt.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} disponível"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} de {1} linha(s) selecionada(s)."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dias"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agente"
 msgid "Alert History"
 msgstr "Histórico de alertas"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Todos os Contêineres"
 msgid "All Systems"
 msgstr "Todos os Sistemas"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Tem certeza de que deseja excluir {name}?"
@@ -196,6 +238,10 @@ msgstr "Tem certeza de que deseja excluir {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Tem certeza?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Cópias de segurança"
 msgid "Bandwidth"
 msgstr "Largura de Banda"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Bateria"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Pode parar"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Largura do gráfico"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Verifique {email} para um link de redefinição."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Saúde do contentor"
 msgid "Containers"
 msgstr "Contentores"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Criado"
 msgid "Critical (%)"
 msgstr "Crítico (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Dados lidos acumulados desde o arranque"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Diariamente"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Período de tempo padrão"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Excluir"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Transferir"
 msgid "Duration"
 msgstr "Duração"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Sistemas existentes não definidos em <0>config.yml</0> serão excluído
 msgid "Exited active"
 msgstr "Saiu ativo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Expira após uma hora ou no reinício do hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Exportar configuração"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exporte a configuração atual dos seus sistemas."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exporte a configuração atual dos seus sistemas."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Inativa"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Se você perdeu a senha da sua conta de administrador, pode redefini-la usando o seguinte comando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Endereço de email inválido."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Idioma"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Uso de Memória"
 msgid "Memory usage of containers"
 msgstr "Utilização de memória dos contentores"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modelo"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Unidade de rede"
 msgid "No"
 msgstr "Não"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Não existem dados detalhados para este pool."
@@ -1287,6 +1424,7 @@ msgstr "Nenhum atributo S.M.A.R.T. disponível para este dispositivo."
 msgid "No systems found."
 msgstr "Nenhum sistema encontrado."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Nenhum"
@@ -1301,13 +1439,21 @@ msgstr "Notificações"
 msgid "Notifications may include recent container log excerpts."
 msgstr "As notificações podem incluir excertos recentes dos registos dos contentores."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Suporte a OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "A cada reinício, os sistemas no banco de dados serão atualizados para corresponder aos sistemas definidos no arquivo."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "A cada reinício, os sistemas no banco de dados serão atualizados para corresponder aos sistemas definidos no arquivo."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Outro"
 msgid "Overwrite existing alerts"
 msgstr "Sobrescrever alertas existentes"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Páginas / Configurações"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Senha"
 
@@ -1388,6 +1547,10 @@ msgstr "Passado"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausar"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Permanente"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Persistência"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Idioma Preferido"
 msgid "Process started"
 msgstr "Processo iniciado"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Erros de leitura"
 msgid "Received"
 msgstr "Recebido"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Requerido por"
 msgid "Requires"
 msgstr "Requer"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Redefinir Senha"
@@ -1592,6 +1775,14 @@ msgstr "Reinícios"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Retomar"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Estado"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Separadores"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Em seguida, faça login no backend e redefina a senha da sua conta de us
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Esta ação não pode ser desfeita. Isso excluirá permanentemente todos os registros atuais de {name} do banco de dados."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Isso excluirá permanentemente todos os registros selecionados do banco de dados."
@@ -1892,6 +2089,10 @@ msgstr "Taxa de transferência de {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Débito do pool ZFS {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Para email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Carregar"
 msgid "Uptime"
 msgstr "Tempo de Atividade"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Utilização do pool ZFS {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Usado"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Quer nos ajudar a melhorar ainda mais nossas traduções? Confira <0>Cro
 msgid "Wants"
 msgstr "Deseja"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Aviso (%)"
@@ -2170,6 +2385,10 @@ msgstr "Aviso (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Limites de aviso"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/pt/pt.po
+++ b/internal/site/src/locales/pt/pt.po
@@ -126,6 +126,11 @@ msgstr "Estado ativo"
 msgid "Add {foo}"
 msgstr "Adicionar {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Adicionar URL"
@@ -327,6 +332,7 @@ msgstr "Pode iniciar"
 msgid "Can stop"
 msgstr "Pode parar"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Cuidado - possível perda de dados"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Verifique o seu serviço de monitorização"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Verifique seu serviço de notificação"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Ciclos"
 msgid "Daily"
 msgstr "Diariamente"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Predefinido"
 msgid "Default time period"
 msgstr "Período de tempo padrão"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Editar"
 msgid "Edit {foo}"
 msgstr "Editar {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Exportar configuração"
 msgid "Export your current systems configuration."
 msgstr "Exporte a configuração atual dos seus sistemas."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "Comando FreeBSD"
 msgid "Full"
 msgstr "Cheia"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Comando Homebrew"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Método HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Utilização de E/S"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inativo"
 msgid "Interval"
 msgstr "Intervalo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Endereço de email inválido."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Utilização de memória dos contentores"
 msgid "Model"
 msgstr "Modelo"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Ponto de montagem"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nome"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Não"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Não existem dados detalhados para este pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Solicitação de redefinição de senha recebida"
 msgid "Past"
 msgstr "Passado"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pausar"
@@ -1391,6 +1467,14 @@ msgstr "Utilização do pool"
 msgid "Port"
 msgstr "Porta"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Erros de leitura"
 msgid "Received"
 msgstr "Recebido"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Redefinir Senha"
 msgid "Resolved"
 msgstr "Resolvido"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Reinícios"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Retomar"
@@ -1511,6 +1608,10 @@ msgstr "Rotacionar token"
 msgid "Rows per page"
 msgstr "Linhas por página"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Métricas de tempo de execução"
@@ -1522,6 +1623,10 @@ msgstr "Detalhes S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Auto-teste S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Selecionar {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Envie um único ping de heartbeat para verificar se o seu endpoint está a funcionar."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Separadores"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tarefas"
@@ -1779,6 +1896,14 @@ msgstr "Débito do pool ZFS {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Formato de hora"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Dispara quando o status alterna entre ativo e inativo"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Dispara quando o uso de qualquer disco excede um limite"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Desconhecida"
 msgid "Unlimited"
 msgstr "Ilimitado"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Carregar"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Tempo de Atividade"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ru/ru.po
+++ b/internal/site/src/locales/ru/ru.po
@@ -126,6 +126,11 @@ msgstr "Активное состояние"
 msgid "Add {foo}"
 msgstr "Добавить {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Добавить URL"
@@ -327,6 +332,7 @@ msgstr "Может запустить"
 msgid "Can stop"
 msgstr "Может остановить"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Внимание - возможная потеря данных"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Цельсий (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Проверьте ваш сервис мониторинга"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Проверьте ваш сервис уведомлений"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Циклы"
 msgid "Daily"
 msgstr "Ежедневно"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "По умолчанию"
 msgid "Default time period"
 msgstr "Период по умолчанию"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Редактировать"
 msgid "Edit {foo}"
 msgstr "Редактировать {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Экспорт конфигурации"
 msgid "Export your current systems configuration."
 msgstr "Экспортируйте текущую конфигурацию систем."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Фаренгейт (°F)"
@@ -916,6 +943,10 @@ msgstr "Команда FreeBSD"
 msgid "Full"
 msgstr "Полная"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Команда Homebrew"
 msgid "Host / IP"
 msgstr "Хост / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-метод"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Использование ввода/вывода"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Неактивно"
 msgid "Interval"
 msgstr "Интервал"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Неверный адрес электронной почты."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Использование памяти контейнерами"
 msgid "Model"
 msgstr "Модель"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Точка монтирования"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Имя"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Нет"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Подробные данные для этого пула отсутствуют."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Запрос на сброс пароля получен"
 msgid "Past"
 msgstr "Прошлое"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Пауза"
@@ -1391,6 +1467,14 @@ msgstr "Использование пула"
 msgid "Port"
 msgstr "Порт"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Ошибки чтения"
 msgid "Received"
 msgstr "Получено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Сбросить пароль"
 msgid "Resolved"
 msgstr "Завершено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Перезапуски"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Возобновить"
@@ -1511,6 +1608,10 @@ msgstr "Сменить токен"
 msgid "Rows per page"
 msgstr "Строк на странице"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Метрики времени выполнения"
@@ -1522,6 +1623,10 @@ msgstr "Детали S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Запуск теста S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Выбрать {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Отправьте одиночный пинг heartbeat, чтобы проверить работоспособность конечной точки."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Вкладки"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Задачи"
@@ -1779,6 +1896,14 @@ msgstr "Пропускная способность ZFS-пула {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Формат времени"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Срабатывает, когда статус переключаетс
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Срабатывает, когда нагрузка на любой из дисков превышает порог"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Неизвестно"
 msgid "Unlimited"
 msgstr "Неограниченно"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Отдача"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Время работы"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/ru/ru.po
+++ b/internal/site/src/locales/ru/ru.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} доступно"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "Выбрано {0} из {1} строк."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 дней"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 мин"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Агент"
 msgid "Alert History"
 msgstr "История оповещений"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Все контейнеры"
 msgid "All Systems"
 msgstr "Все системы"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Вы уверены, что хотите удалить {name}?"
@@ -196,6 +238,10 @@ msgstr "Вы уверены, что хотите удалить {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Вы уверены?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Резервные копии"
 msgid "Bandwidth"
 msgstr "Пропускная способность"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Бтр"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Батарея"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Может остановить"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Цельсий (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Ширина графика"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Проверьте {email} для получения ссылки сброса."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Здоровье контейнера"
 msgid "Containers"
 msgstr "Контейнеры"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Создано"
 msgid "Critical (%)"
 msgstr "Критический (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Суммарно прочитано данных с момента загрузки"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Ежедневно"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Период по умолчанию"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Удалить"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Загрузка"
 msgid "Duration"
 msgstr "Длительность"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Существующие системы, не определенные �
 msgid "Exited active"
 msgstr "Завершился активным"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Истекает через час или при перезапуске хаба."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Экспорт конфигурации"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Экспортируйте текущую конфигурацию систем."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Экспортируйте текущую конфигурацию систем."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Хост / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Неактивная"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Если вы потеряли пароль от учетной записи администратора, вы можете сбросить его, используя следующую команду."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Неверный адрес электронной почты."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Язык"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Использование памяти"
 msgid "Memory usage of containers"
 msgstr "Использование памяти контейнерами"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Модель"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Единицы измерения скорости сети"
 msgid "No"
 msgstr "Нет"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Подробные данные для этого пула отсутствуют."
@@ -1287,6 +1424,7 @@ msgstr "Для этого устройства нет доступных атр�
 msgid "No systems found."
 msgstr "Системы не найдены."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Нет"
@@ -1301,13 +1439,21 @@ msgstr "Уведомления"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Уведомления могут содержать недавние фрагменты журналов контейнеров."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Поддержка OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "При каждом перезапуске системы в базе данных будут обновлены в соответствии с системами, определенными в файле."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "При каждом перезапуске системы в базе данных будут обновлены в соответствии с системами, определенными в файле."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Другое"
 msgid "Overwrite existing alerts"
 msgstr "Перезаписать существующие оповещения"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Страницы / Настройки"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Пароль"
 
@@ -1388,6 +1547,10 @@ msgstr "Прошлое"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Пауза"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Постоянный"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Устойчивость"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Предпочтительный язык"
 msgid "Process started"
 msgstr "Процесс запущен"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Открытый ключ"
@@ -1535,6 +1706,10 @@ msgstr "Ошибки чтения"
 msgid "Received"
 msgstr "Получено"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Требуется для"
 msgid "Requires"
 msgstr "Требует"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Сбросить пароль"
@@ -1592,6 +1775,14 @@ msgstr "Перезапуски"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Возобновить"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Состояние"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Вкладки"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Затем войдите в бэкенд и сбросьте парол
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Это действие не может быть отменено. Оно навсегда удалит все текущие записи для {name} из базы данных."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Это навсегда удалит все выбранные записи из базы данных."
@@ -1892,6 +2089,10 @@ msgstr "Пропускная способность {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Пропускная способность ZFS-пула {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "На электронную почту"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Токен"
@@ -2093,8 +2295,13 @@ msgstr "Отдача"
 msgid "Uptime"
 msgstr "Время работы"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Использование ZFS-пула {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Использовано"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Хотите помочь нам улучшить наши перево�
 msgid "Wants"
 msgstr "Требует"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Предупреждений (%)"
@@ -2170,6 +2385,10 @@ msgstr "Предупреждений (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Пороги предупреждений"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/sl/sl.po
+++ b/internal/site/src/locales/sl/sl.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} na voljo"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} od {1} vrstic izbranih."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dni"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr ""
 msgid "Alert History"
 msgstr "Zgodovina opozoril"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Vsi kontejnerji"
 msgid "All Systems"
 msgstr "Vsi sistemi"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ali ste prepričani, da želite izbrisati {name}?"
@@ -196,6 +238,10 @@ msgstr "Ali ste prepričani, da želite izbrisati {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Ali ste prepričani?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Varnostne kopije"
 msgid "Bandwidth"
 msgstr "Pasovna širina"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Baterija"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Baterija"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Lahko ustavi"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celzija (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Širina grafikona"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Preverite {email} za povezavo za ponastavitev."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Zdravje vsebnika"
 msgid "Containers"
 msgstr "Vsebniki"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Ustvarjeno"
 msgid "Critical (%)"
 msgstr "Kritično (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Skupno prebrani podatki od zagona"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Dnevno"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Privzeto časovno obdobje"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Izbriši"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Prenesi"
 msgid "Duration"
 msgstr "Trajanje"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Obstoječi sistemi, ki niso definirani v <0>config.yml</0>, bodo izbrisa
 msgid "Exited active"
 msgstr "Izhod aktivno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Poteče po eni uri ali ob ponovnem zagonu huba."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Izvozi nastavitve"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Izvozi trenutne nastavitve sistema."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Izvozi trenutne nastavitve sistema."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Gostitelj / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Neaktivna"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Če ste izgubili geslo za svoj skrbniški račun, ga lahko ponastavite z naslednjim ukazom."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Napačen e-poštni naslov."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Jezik"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Poraba pomnilnika"
 msgid "Memory usage of containers"
 msgstr "Poraba pomnilnika vsebnikov"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr ""
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Enota omrežja"
 msgid "No"
 msgstr "Ne"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Za ta pool ni podrobnih podatkov."
@@ -1287,6 +1424,7 @@ msgstr "Za to napravo ni na voljo atributov S.M.A.R.T."
 msgid "No systems found."
 msgstr "Ne najdem sistema."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Brez"
@@ -1301,13 +1439,21 @@ msgstr "Obvestila"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Obvestila lahko vključujejo nedavne izseke dnevnikov vsebnikov."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Podpora za OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Ob vsakem ponovnem zagonu bodo sistemi v zbirki podatkov posodobljeni, da se bodo ujemali s sistemi, definiranimi v datoteki."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Ob vsakem ponovnem zagonu bodo sistemi v zbirki podatkov posodobljeni, da se bodo ujemali s sistemi, definiranimi v datoteki."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Drugo"
 msgid "Overwrite existing alerts"
 msgstr "Prepiši obstoječe alarme"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Strani / Nastavitve"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Geslo"
 
@@ -1388,6 +1547,10 @@ msgstr "Preteklo"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Premor"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Trajen"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Vztrajnost"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Prednostni jezik"
 msgid "Process started"
 msgstr "Proces začet"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Napake pri branju"
 msgid "Received"
 msgstr "Prejeto"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Zahtevano od"
 msgid "Requires"
 msgstr "Zahteva"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Ponastavi geslo"
@@ -1592,6 +1775,14 @@ msgstr "Ponovni zagoni"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Nadaljuj"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Stanje"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Zavihki"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Nato se prijavite v zaledni sistem in ponastavite geslo svojega uporabni
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Tega dejanja ni mogoče razveljaviti. To bo trajno izbrisalo vse trenutne zapise za {name} iz zbirke podatkov."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "To bo trajno izbrisalo vse izbrane zapise iz zbirke podatkov."
@@ -1892,6 +2089,10 @@ msgstr "Prepustnost {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Prepustnost ZFS poola {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "E-pošta za"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Žeton"
@@ -2093,8 +2295,13 @@ msgstr "Naloži"
 msgid "Uptime"
 msgstr "Čas delovanja"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Uporaba ZFS poola {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Uporabljeno"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Ali nam želite pomagati, da bomo naše prevode še izboljšali? Za več
 msgid "Wants"
 msgstr "Zahteva"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Opozorilo (%)"
@@ -2170,6 +2385,10 @@ msgstr "Opozorilo (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Pragovi za opozorila"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/sl/sl.po
+++ b/internal/site/src/locales/sl/sl.po
@@ -126,6 +126,11 @@ msgstr "Aktivno stanje"
 msgid "Add {foo}"
 msgstr "Dodaj {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Dodaj URL"
@@ -327,6 +332,7 @@ msgstr "Lahko zažene"
 msgid "Can stop"
 msgstr "Lahko ustavi"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Pozor - možna izguba podatkov"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celzija (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Preverite svojo storitev za spremljanje"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Preverite storitev obveščanja"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cikli"
 msgid "Daily"
 msgstr "Dnevno"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Privzeto"
 msgid "Default time period"
 msgstr "Privzeto časovno obdobje"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Uredi"
 msgid "Edit {foo}"
 msgstr "Uredi {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Izvozi nastavitve"
 msgid "Export your current systems configuration."
 msgstr "Izvozi trenutne nastavitve sistema."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr ""
@@ -916,6 +943,10 @@ msgstr "Ukaz FreeBSD"
 msgid "Full"
 msgstr "Polna"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Ukaz Homebrew"
 msgid "Host / IP"
 msgstr "Gostitelj / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Metoda HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O izkoriščenost"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Neaktivno"
 msgid "Interval"
 msgstr ""
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Napačen e-poštni naslov."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Poraba pomnilnika vsebnikov"
 msgid "Model"
 msgstr ""
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Točka priklopa"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Naziv"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Ne"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Za ta pool ni podrobnih podatkov."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Prejeta zahteva za ponastavitev gesla"
 msgid "Past"
 msgstr "Preteklo"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Premor"
@@ -1391,6 +1467,14 @@ msgstr "Uporaba poola"
 msgid "Port"
 msgstr "Vrata"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Napake pri branju"
 msgid "Received"
 msgstr "Prejeto"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Ponastavi geslo"
 msgid "Resolved"
 msgstr "Rešeno"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Ponovni zagoni"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Nadaljuj"
@@ -1511,6 +1608,10 @@ msgstr "Zavrti žeton"
 msgid "Rows per page"
 msgstr "Vrstic na stran"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Metrike izvajanja"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. podrobnosti"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. samotestiranje"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Izberi {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Pošljite en srčni utrip (ping), da preverite, ali vaša končna točka deluje."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Zavihki"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Naloge"
@@ -1779,6 +1896,14 @@ msgstr "Prepustnost ZFS poola {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Oblika časa"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Sproži se, ko se stanje preklaplja med gor in dol"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Sproži se, ko uporaba katerega koli diska preseže prag"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Neznana"
 msgid "Unlimited"
 msgstr "Neomejeno"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Naloži"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Čas delovanja"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/sr/sr.po
+++ b/internal/site/src/locales/sr/sr.po
@@ -126,6 +126,11 @@ msgstr "Активно стање"
 msgid "Add {foo}"
 msgstr "Додај {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Додај URL"
@@ -327,6 +332,7 @@ msgstr "Може се покренути"
 msgid "Can stop"
 msgstr "Може се зауставити"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Пажња - потенцијални губитак података"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Целзијус (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Proverite svoju uslugu monitoringa"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Проверите ваш сервис за обавештавања"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Циклуси"
 msgid "Daily"
 msgstr "Дневно"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Подразумевано"
 msgid "Default time period"
 msgstr "Подразумевани временски период"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Измени"
 msgid "Edit {foo}"
 msgstr "Измени {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Извези конфигурацију"
 msgid "Export your current systems configuration."
 msgstr "Извезите тренутну конфигурацију система."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Фаренхајт (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD команда"
 msgid "Full"
 msgstr "Пуно"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew команда"
 msgid "Host / IP"
 msgstr "Хост / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP metod"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O искоришћеност"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Неактивно"
 msgid "Interval"
 msgstr "Интервал"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Неважећа имејл адреса."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Коришћење меморије контејнера"
 msgid "Model"
 msgstr "Модел"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Тачка монтирања"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Име"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Не"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Нема детаљних података за овај pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Захтев за ресетовање лозинке примљен"
 msgid "Past"
 msgstr "Прошлост"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Паузирај"
@@ -1391,6 +1467,14 @@ msgstr "Коришћење pool-а"
 msgid "Port"
 msgstr "Порт"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Грешке при читању"
 msgid "Received"
 msgstr "Примљено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Ресетуј лозинку"
 msgid "Resolved"
 msgstr "Решено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Поновна покретања"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Настави"
@@ -1511,6 +1608,10 @@ msgstr "Ротирај токен"
 msgid "Rows per page"
 msgstr "Редова по страници"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Метрике у време извршавања"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. детаљи"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. самопровера"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Изаберите {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Pošaljite jedan heartbeat ping da biste proverili da li krajnja tačka radi."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Картице"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Задаци"
@@ -1779,6 +1896,14 @@ msgstr "Пропусност ZFS pool-а {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Формат времена"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Окида се када статус прелази између укљ
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Окида се када употреба било ког диска премаши праг"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Непознато"
 msgid "Unlimited"
 msgstr "Неограничено"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Отпреми"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Време рада"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/sr/sr.po
+++ b/internal/site/src/locales/sr/sr.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} доступно"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} од {1} редова изабрано."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 дана"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 мин"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Агент"
 msgid "Alert History"
 msgstr "Историја упозорења"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Сви контејнери"
 msgid "All Systems"
 msgstr "Сви системи"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Да ли сте сигурни да желите да избришете {name}?"
@@ -196,6 +238,10 @@ msgstr "Да ли сте сигурни да желите да избришет�
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Да ли сте сигурни?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Резервне копије"
 msgid "Bandwidth"
 msgstr "Пропусни опсег"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Бат"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Батерија"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Може се зауставити"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Целзијус (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Ширина графикона"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Проверите {email} за линк за ресетовање."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Здравље контејнера"
 msgid "Containers"
 msgstr "Контејнери"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Креирано"
 msgid "Critical (%)"
 msgstr "Критично (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Укупно прочитани подаци од покретања"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Дневно"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Подразумевани временски период"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Избриши"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Преузимање"
 msgid "Duration"
 msgstr "Трајање"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Системи који нису дефинисани у <0>config.yml</
 msgid "Exited active"
 msgstr "Излазак активан"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Истиче након једног сата или при поновном покретању хаба."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Извези конфигурацију"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Извезите тренутну конфигурацију система."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Извезите тренутну конфигурацију система."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Хост / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Неактивно"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Ако сте изгубили лозинку за ваш администраторски налог, можете је ресетовати користећи следећу команду."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Неважећа имејл адреса."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Језик"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Употреба меморије"
 msgid "Memory usage of containers"
 msgstr "Коришћење меморије контејнера"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Модел"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Мрежна јединица"
 msgid "No"
 msgstr "Не"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Нема детаљних података за овај pool."
@@ -1287,6 +1424,7 @@ msgstr "Нема доступних S.M.A.R.T. атрибута за овај у
 msgid "No systems found."
 msgstr "Нису пронађени системи."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Нема"
@@ -1301,13 +1439,21 @@ msgstr "Обавештења"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Обавештења могу да садрже недавне исечке из дневника контејнера."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC подршка"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "При сваком поновном покретању, системи у бази података ће се ажурирати да одговарају системима дефинисаним у датотеци."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "При сваком поновном покретању, системи у бази података ће се ажурирати да одговарају системима дефинисаним у датотеци."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Остало"
 msgid "Overwrite existing alerts"
 msgstr "Препиши постојећа упозорења"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Странице / Подешавања"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Лозинка"
 
@@ -1388,6 +1547,10 @@ msgstr "Прошлост"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Паузирај"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Трајан"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Упорност"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Жељени језик"
 msgid "Process started"
 msgstr "Процес покренут"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Јавни кључ"
@@ -1535,6 +1706,10 @@ msgstr "Грешке при читању"
 msgid "Received"
 msgstr "Примљено"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Захтевано од"
 msgid "Requires"
 msgstr "Захтева"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Ресетуј лозинку"
@@ -1592,6 +1775,14 @@ msgstr "Поновна покретања"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Настави"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Стање"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Картице"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Затим се пријавите на backend и ресетујте л
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Ова акција се не може опозвати. Ово ће трајно избрисати све тренутне записе за {name} из базе података."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Ово ће трајно избрисати све изабране записе из базе података."
@@ -1892,6 +2089,10 @@ msgstr "Проток {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Пропусност ZFS pool-а {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "На е-пошту(е)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Токен"
@@ -2093,8 +2295,13 @@ msgstr "Отпреми"
 msgid "Uptime"
 msgstr "Време рада"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Коришћење ZFS pool-а {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Коришћено"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Желите да помогнете у побољшању наших п
 msgid "Wants"
 msgstr "Жели"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Упозорење (%)"
@@ -2170,6 +2385,10 @@ msgstr "Упозорење (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Прагове упозорења"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/sv/sv.po
+++ b/internal/site/src/locales/sv/sv.po
@@ -126,6 +126,11 @@ msgstr "Aktivt tillstånd"
 msgid "Add {foo}"
 msgstr "Lägg till {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Lägg till URL"
@@ -327,6 +332,7 @@ msgstr "Kan starta"
 msgid "Can stop"
 msgstr "Kan stoppa"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Varning - potentiell dataförlust"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Kontrollera din övervakningstjänst"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Kontrollera din aviseringstjänst"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Cykler"
 msgid "Daily"
 msgstr "Dagligen"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standard"
 msgid "Default time period"
 msgstr "Standardtidsperiod"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Redigera"
 msgid "Edit {foo}"
 msgstr "Redigera {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Exportera konfiguration"
 msgid "Export your current systems configuration."
 msgstr "Exportera din nuvarande systemkonfiguration."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenheit (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD kommando"
 msgid "Full"
 msgstr "Full"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew-kommando"
 msgid "Host / IP"
 msgstr "Värd / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-metod"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O Användning"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Inaktiv"
 msgid "Interval"
 msgstr "Intervall"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Ogiltig e-postadress."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Minnesanvändning för containrar"
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Monteringspunkt"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Namn"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Nej"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Det finns inga detaljerade data för denna pool."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Begäran om återställning av lösenord mottagen"
 msgid "Past"
 msgstr "Förbi"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Paus"
@@ -1391,6 +1467,14 @@ msgstr "Poolanvändning"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Läsfel"
 msgid "Received"
 msgstr "Mottaget"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Återställ lösenord"
 msgid "Resolved"
 msgstr "Löst"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Omstarter"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Återuppta"
@@ -1511,6 +1608,10 @@ msgstr "Rotera token"
 msgid "Rows per page"
 msgstr "Rader per sida"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Körningsmätvärden"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T.-detaljer"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. själftest"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Välj {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Skicka en enstaka heartbeat-ping för att verifiera att din slutpunkt fungerar."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Flikar"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Uppgifter"
@@ -1779,6 +1896,14 @@ msgstr "Genomströmning för ZFS-pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Tidsformat"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Utlöses när status växlar mellan upp och ner"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Utlöses när användningen av någon disk överskrider ett tröskelvärde"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Okänd"
 msgid "Unlimited"
 msgstr "Obegränsad"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Ladda upp"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Drifttid"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/sv/sv.po
+++ b/internal/site/src/locales/sv/sv.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} tillgänglig"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{0} av {1} rad(er) valda."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 dagar"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 min"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Larmhistorik"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Alla behållare"
 msgid "All Systems"
 msgstr "Alla system"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Är du säker på att du vill ta bort {name}?"
@@ -196,6 +238,10 @@ msgstr "Är du säker på att du vill ta bort {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Är du säker?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Säkerhetskopior"
 msgid "Bandwidth"
 msgstr "Bandbredd"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr ""
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batteri"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Kan stoppa"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Celsius (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Diagrambredd"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Kontrollera {email} för en återställningslänk."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Containerhälsa"
 msgid "Containers"
 msgstr "Containrar"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Skapad"
 msgid "Critical (%)"
 msgstr "Kritisk (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Kumulativt lästa data sedan start"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Dagligen"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standardtidsperiod"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Ta bort"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Ladda ner"
 msgid "Duration"
 msgstr "Varaktighet"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Befintliga system som inte definieras i <0>config.yml</0> kommer att tas
 msgid "Exited active"
 msgstr "Avslutades aktivt"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Upphör efter en timme eller vid hub-omstart."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Exportera konfiguration"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Exportera din nuvarande systemkonfiguration."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Exportera din nuvarande systemkonfiguration."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Värd / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Vilande"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Om du har glömt lösenordet till ditt administratörskonto kan du återställa det med följande kommando."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Ogiltig e-postadress."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Språk"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Minnesanvändning"
 msgid "Memory usage of containers"
 msgstr "Minnesanvändning för containrar"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Modell"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Nätverksenhet"
 msgid "No"
 msgstr "Nej"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Det finns inga detaljerade data för denna pool."
@@ -1287,6 +1424,7 @@ msgstr "Inga S.M.A.R.T.-attribut tillgängliga för den här enheten."
 msgid "No systems found."
 msgstr "Inga system hittades."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Ingen"
@@ -1301,13 +1439,21 @@ msgstr "Aviseringar"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Aviseringar kan innehålla utdrag från de senaste containerloggarna."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Stöd för OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Vid varje omstart kommer systemen i databasen att uppdateras för att matcha systemen som definieras i filen."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Vid varje omstart kommer systemen i databasen att uppdateras för att matcha systemen som definieras i filen."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Annat"
 msgid "Overwrite existing alerts"
 msgstr "Skriv över befintliga larm"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Sidor / Inställningar"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Lösenord"
 
@@ -1388,6 +1547,10 @@ msgstr "Förbi"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Paus"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr ""
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Beständighet"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Föredraget språk"
 msgid "Process started"
 msgstr "Process startad"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Läsfel"
 msgid "Received"
 msgstr "Mottaget"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Krävs av"
 msgid "Requires"
 msgstr "Kräver"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Återställ lösenord"
@@ -1592,6 +1775,14 @@ msgstr "Omstarter"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Återuppta"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Tillstånd"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Flikar"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Logga sedan in på backend och återställ ditt användarkontos lösenor
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Den här åtgärden kan inte ångras. Detta kommer permanent att ta bort alla aktuella poster för {name} från databasen."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Detta kommer permanent att ta bort alla valda poster från databasen."
@@ -1892,6 +2089,10 @@ msgstr "Genomströmning av {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Genomströmning för ZFS-pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Till e-postadress(er)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Nyckel"
@@ -2093,8 +2295,13 @@ msgstr "Ladda upp"
 msgid "Uptime"
 msgstr "Drifttid"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Användning av ZFS-pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Använt"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Vill du hjälpa oss att göra våra översättningar ännu bättre? Koll
 msgid "Wants"
 msgstr "Vill ha"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Varning (%)"
@@ -2170,6 +2385,10 @@ msgstr "Varning (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Varningströsklar"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/tr/tr.po
+++ b/internal/site/src/locales/tr/tr.po
@@ -126,6 +126,11 @@ msgstr "Aktif durum"
 msgid "Add {foo}"
 msgstr "{foo} ekle"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URL Ekle"
@@ -327,6 +332,7 @@ msgstr "Başlatılabilir"
 msgid "Can stop"
 msgstr "Durdurulabilir"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Dikkat - potansiyel veri kaybı"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Santigrat (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "İzleme servisinizi kontrol edin"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Bildirim hizmetinizi kontrol edin"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Döngüler"
 msgid "Daily"
 msgstr "Günlük"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Varsayılan"
 msgid "Default time period"
 msgstr "Varsayılan zaman dilimi"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Düzenle"
 msgid "Edit {foo}"
 msgstr "{foo} düzenle"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Yapılandırmayı dışa aktar"
 msgid "Export your current systems configuration."
 msgstr "Mevcut sistem yapılandırmanızı dışa aktarın."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Fahrenhayt (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD komutu"
 msgid "Full"
 msgstr "Dolu"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew komutu"
 msgid "Host / IP"
 msgstr "Ana Bilgisayar / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP Yöntemi"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "G/Ç Kullanımı"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Pasif"
 msgid "Interval"
 msgstr "Aralık"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Geçersiz e-posta adresi."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Konteynerlerin bellek kullanımı"
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Bağlama noktası"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Ad"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Hayır"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Bu pool için ayrıntılı veri mevcut değil."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Şifre sıfırlama isteği alındı"
 msgid "Past"
 msgstr "Geçmiş"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Duraklat"
@@ -1391,6 +1467,14 @@ msgstr "Pool kullanımı"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Okuma hataları"
 msgid "Received"
 msgstr "Alındı"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Şifreyi Sıfırla"
 msgid "Resolved"
 msgstr "Çözüldü"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Yeniden başlatmalar"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Devam et"
@@ -1511,6 +1608,10 @@ msgstr "Token'ı döndür"
 msgid "Rows per page"
 msgstr "Sayfa başına satır"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Çalışma Zamanı Metrikleri"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. Ayrıntıları"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. Kendiliğinden Test"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Seç {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Uç noktanızın çalıştığını doğrulamak için tek bir heartbeat ping'i gönderin."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Sekmeler"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Görevler"
@@ -1779,6 +1896,14 @@ msgstr "ZFS pool {poolName} aktarım hızı"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Zaman formatı"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Durum yukarı ve aşağı arasında değiştiğinde tetiklenir"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Herhangi bir diskin kullanımı bir eşiği aştığında tetiklenir"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Bilinmiyor"
 msgid "Unlimited"
 msgstr "Sınırsız"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Yükle"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Çalışma Süresi"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/tr/tr.po
+++ b/internal/site/src/locales/tr/tr.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} mevcut"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{1} satırdan {0} tanesi seçildi."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 gün"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 dk"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Aracı"
 msgid "Alert History"
 msgstr "Uyarı Geçmişi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Tüm Konteynerler"
 msgid "All Systems"
 msgstr "Tüm Sistemler"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name} silmek istediğinizden emin misiniz?"
@@ -196,6 +238,10 @@ msgstr "{name} silmek istediğinizden emin misiniz?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Emin misiniz?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Yedekler"
 msgid "Bandwidth"
 msgstr "Bant Genişliği"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Pil"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Pil"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Durdurulabilir"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Santigrat (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Grafik genişliği"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Sıfırlama bağlantısı için {email} kontrol edin."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Konteyner Sağlığı"
 msgid "Containers"
 msgstr "Konteynerler"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Oluşturuldu"
 msgid "Critical (%)"
 msgstr "Kritik (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Önyüklemeden beri okunan toplam veri"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Günlük"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Varsayılan zaman dilimi"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Sil"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "İndir"
 msgid "Duration"
 msgstr "Süre"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "<0>config.yml</0> içinde tanımlanmayan mevcut sistemler silinecektir. 
 msgid "Exited active"
 msgstr "Aktif olarak çıktı"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Bir saat sonra veya hub yeniden başlatıldığında sona erer."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Yapılandırmayı dışa aktar"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Mevcut sistem yapılandırmanızı dışa aktarın."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Mevcut sistem yapılandırmanızı dışa aktarın."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Ana Bilgisayar / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Boşta"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Yönetici hesabınızın şifresini kaybettiyseniz, aşağıdaki komutu kullanarak sıfırlayabilirsiniz."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Geçersiz e-posta adresi."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Dil"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Bellek Kullanımı"
 msgid "Memory usage of containers"
 msgstr "Konteynerlerin bellek kullanımı"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Ağ birimi"
 msgid "No"
 msgstr "Hayır"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Bu pool için ayrıntılı veri mevcut değil."
@@ -1287,6 +1424,7 @@ msgstr "Bu cihaz için kullanılabilir S.M.A.R.T. özelliği yok."
 msgid "No systems found."
 msgstr "Sistem bulunamadı."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Yok"
@@ -1301,13 +1439,21 @@ msgstr "Bildirimler"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Bildirimler, son konteyner günlüklerinden alıntılar içerebilir."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC desteği"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Her yeniden başlatmada, veritabanındaki sistemler dosyada tanımlanan sistemlerle eşleşecek şekilde güncellenecektir."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Her yeniden başlatmada, veritabanındaki sistemler dosyada tanımlanan sistemlerle eşleşecek şekilde güncellenecektir."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Diğer"
 msgid "Overwrite existing alerts"
 msgstr "Mevcut uyarıların üzerine yaz"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Sayfalar / Ayarlar"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Şifre"
 
@@ -1388,6 +1547,10 @@ msgstr "Geçmiş"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Duraklat"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Kalıcı"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Kalıcılık"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Tercih Edilen Dil"
 msgid "Process started"
 msgstr "Süreç başlatıldı"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Okuma hataları"
 msgid "Received"
 msgstr "Alındı"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Gerektiren"
 msgid "Requires"
 msgstr "Gerektirir"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Şifreyi Sıfırla"
@@ -1592,6 +1775,14 @@ msgstr "Yeniden başlatmalar"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Devam et"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Durum"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Sekmeler"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Ardından arka uca giriş yapın ve kullanıcılar tablosunda kullanıc�
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Bu işlem geri alınamaz. Bu, veritabanından {name} için tüm mevcut kayıtları kalıcı olarak silecektir."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Bu, seçilen tüm kayıtları veritabanından kalıcı olarak silecektir."
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName} verimliliği"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS pool {poolName} aktarım hızı"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "E-posta(lar)a"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Erişim Anahtarı"
@@ -2093,8 +2295,13 @@ msgstr "Yükle"
 msgid "Uptime"
 msgstr "Çalışma Süresi"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS pool {poolName} kullanımı"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Kullanıldı"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Çevirilerimizi daha iyi hale getirmemize yardımcı olmak ister misiniz
 msgid "Wants"
 msgstr "İstekler"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Uyarı (%)"
@@ -2170,6 +2385,10 @@ msgstr "Uyarı (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Uyarı eşikleri"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/uk/uk.po
+++ b/internal/site/src/locales/uk/uk.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} Доступно"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "Вибрано {0} з {1} рядків."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 днів"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 хв"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Агент"
 msgid "Alert History"
 msgstr "Історія сповіщень"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Всі контейнери"
 msgid "All Systems"
 msgstr "Всі системи"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Ви впевнені, що хочете видалити {name}?"
@@ -196,6 +238,10 @@ msgstr "Ви впевнені, що хочете видалити {name}?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Ви впевнені?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Резервні копії"
 msgid "Bandwidth"
 msgstr "Пропускна здатність"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Батарея"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Батарея"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Може зупинити"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Цельсій (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Ширина графіка"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Перевірте {email} для отримання посилання на скидання."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Здоров'я контейнера"
 msgid "Containers"
 msgstr "Контейнери"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Створено"
 msgid "Critical (%)"
 msgstr "Критично (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Загалом даних прочитано з моменту завантаження"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Щодня"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Стандартний період часу"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Видалити"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Завантажити"
 msgid "Duration"
 msgstr "Тривалість"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Існуючі системи, не визначені в <0>config.yml<
 msgid "Exited active"
 msgstr "Завершилося активно"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Закінчується через годину або при перезапуску Hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Експорт конфігурації"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Експортуйте поточну конфігурацію систем."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Експортуйте поточну конфігурацію систем."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Хост / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Неактивна"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Якщо ви втратили пароль до свого адміністративного облікового запису, ви можете скинути його за допомогою наступної команди."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Неправильна адреса електронної пошти."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Мова"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Використання пам’яті"
 msgid "Memory usage of containers"
 msgstr "Використання пам’яті контейнерами"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Модель"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Одиниця виміру мережі"
 msgid "No"
 msgstr "Ні"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Докладні дані для цього pool недоступні."
@@ -1287,6 +1424,7 @@ msgstr "Для цього пристрою немає доступних атр�
 msgid "No systems found."
 msgstr "Систем не знайдено."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Немає"
@@ -1301,13 +1439,21 @@ msgstr "Сповіщення"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Сповіщення можуть містити фрагменти останніх журналів контейнерів."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Підтримка OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "При кожному перезапуску системи в базі даних оновлюватимуться відповідно до систем, визначених у файлі."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "При кожному перезапуску системи в базі даних оновлюватимуться відповідно до систем, визначених у файлі."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Інше"
 msgid "Overwrite existing alerts"
 msgstr "Перезаписати існуючі сповіщення"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Сторінки / Налаштування"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Пароль"
 
@@ -1388,6 +1547,10 @@ msgstr "Минуле"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Призупинити"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Постійний"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Стійкість"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Бажана мова"
 msgid "Process started"
 msgstr "Процес запущено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "Відкритий ключ"
@@ -1535,6 +1706,10 @@ msgstr "Помилки читання"
 msgid "Received"
 msgstr "Отримано"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Потрібно для"
 msgid "Requires"
 msgstr "Потребує"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Скинути пароль"
@@ -1592,6 +1775,14 @@ msgstr "Перезапуски"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Відновити"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Стан"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Вкладки"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Потім увійдіть у бекенд і скиньте парол
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Цю дію не можна скасувати. Це назавжди видалить всі поточні записи для {name} з бази даних."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Це назавжди видалить усі вибрані записи з бази даних."
@@ -1892,6 +2089,10 @@ msgstr "Пропускна здатність {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Пропускна здатність ZFS pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "На електронну пошту"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Токен"
@@ -2093,8 +2295,13 @@ msgstr "Відвантажити"
 msgid "Uptime"
 msgstr "Час роботи"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Використання ZFS pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Використано"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Хочете допомогти покращити наші перекл
 msgid "Wants"
 msgstr "Потребує"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Попередження (%)"
@@ -2170,6 +2385,10 @@ msgstr "Попередження (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Пороги попередження"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/uk/uk.po
+++ b/internal/site/src/locales/uk/uk.po
@@ -126,6 +126,11 @@ msgstr "Активний стан"
 msgid "Add {foo}"
 msgstr "Додати {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Додати URL"
@@ -327,6 +332,7 @@ msgstr "Може запустити"
 msgid "Can stop"
 msgstr "Може зупинити"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Увага — можлива втрата даних"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Цельсій (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Перевірте ваш сервіс моніторингу"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Перевірте ваш сервіс сповіщень"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Цикли"
 msgid "Daily"
 msgstr "Щодня"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "За замовчуванням"
 msgid "Default time period"
 msgstr "Стандартний період часу"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Редагувати"
 msgid "Edit {foo}"
 msgstr "Редагувати {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Експорт конфігурації"
 msgid "Export your current systems configuration."
 msgstr "Експортуйте поточну конфігурацію систем."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Фаренгейт (°F)"
@@ -916,6 +943,10 @@ msgstr "Команда FreeBSD"
 msgid "Full"
 msgstr "Повна"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Команда Homebrew"
 msgid "Host / IP"
 msgstr "Хост / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP-метод"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Використання вводу-виводу"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Неактивне"
 msgid "Interval"
 msgstr "Інтервал"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Неправильна адреса електронної пошти."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Використання пам’яті контейнерами"
 msgid "Model"
 msgstr "Модель"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Точка монтування"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Ім’я"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Ні"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Докладні дані для цього pool недоступні."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Запит на скидання пароля отримано"
 msgid "Past"
 msgstr "Минуле"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Призупинити"
@@ -1391,6 +1467,14 @@ msgstr "Використання pool"
 msgid "Port"
 msgstr "Порт"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Помилки читання"
 msgid "Received"
 msgstr "Отримано"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Скинути пароль"
 msgid "Resolved"
 msgstr "Вирішено"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Перезапуски"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Відновити"
@@ -1511,6 +1608,10 @@ msgstr "Оновити токен"
 msgid "Rows per page"
 msgstr "Рядків на сторінку"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Метрики виконання"
@@ -1522,6 +1623,10 @@ msgstr "Деталі S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Самодіагностика S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Вибрати {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Надішліть одиночний пінг heartbeat, щоб перевірити працездатність кінцевої точки."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Вкладки"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Завдання"
@@ -1779,6 +1896,14 @@ msgstr "Пропускна здатність ZFS pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Формат часу"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Спрацьовує, коли статус перемикається �
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Спрацьовує, коли використання будь-якого диска перевищує поріг"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Невідомо"
 msgid "Unlimited"
 msgstr "Необмежено"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Відвантажити"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Час роботи"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/uz/uz.po
+++ b/internal/site/src/locales/uz/uz.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} mavjud"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "{1} dan {0} qator tanlandi."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 kun"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 daq"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "Ogohlantirish tarixi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Barcha konteynerlar"
 msgid "All Systems"
 msgstr "Barcha tizimlar"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "{name} ni o'chirishni xohlaysizmi?"
@@ -196,6 +238,10 @@ msgstr "{name} ni o'chirishni xohlaysizmi?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Ishonchingiz komilmi?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Zaxira nusxalar"
 msgid "Bandwidth"
 msgstr "O'tkazish qobiliyati"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Bat"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Batareya"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "To'xtata oladi"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Selsiy (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Grafik kengligi"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Tiklash havolasi uchun {email} ni tekshiring."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr ""
 msgid "Containers"
 msgstr "Konteynerlar"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Yaratilgan"
 msgid "Critical (%)"
 msgstr "Kritik (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Yuklangandan beri jami o‘qilgan ma’lumotlar"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Kunlik"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Standart vaqt oralig'i"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "O'chirish"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Yuklab olish"
 msgid "Duration"
 msgstr "Davomiylik"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "<0>config.yml</0> da aniqlanmagan mavjud tizimlar o'chiriladi. Iltimos, 
 msgid "Exited active"
 msgstr "Faollikdan chiqdi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Bir soatdan keyin yoki hub qayta ishga tushganda muddati tugaydi."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Konfiguratsiyani eksport qilish"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Joriy tizimlar konfiguratsiyasini eksport qiling."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Joriy tizimlar konfiguratsiyasini eksport qiling."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Xost / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Faolsiz"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Agar admin hisobingiz parolini yo'qotgan bo'lsangiz, quyidagi buyruq yordamida uni tiklashingiz mumkin."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Noto'g'ri elektron pochta manzili."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Til"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Xotira ishlatilishi"
 msgid "Memory usage of containers"
 msgstr ""
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Model"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Tarmoq birligi"
 msgid "No"
 msgstr "Yo'q"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Bu pool uchun batafsil ma’lumot mavjud emas."
@@ -1287,6 +1424,7 @@ msgstr "Ushbu qurilma uchun S.M.A.R.T. atributlari mavjud emas."
 msgid "No systems found."
 msgstr "Tizimlar topilmadi."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Yo‘q"
@@ -1301,13 +1439,21 @@ msgstr "Bildirishnomalar"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Bildirishnomalarda konteyner jurnallarining so‘nggi parchalari bo‘lishi mumkin."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "OAuth 2 / OIDC qo'llab-quvvatlash"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Har qayta ishga tushirilganda, ma'lumotlar bazasidagi tizimlar fayldagi tizimlarga mos yangilanadi."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Har qayta ishga tushirilganda, ma'lumotlar bazasidagi tizimlar fayldagi tizimlarga mos yangilanadi."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Boshqa"
 msgid "Overwrite existing alerts"
 msgstr "Mavjud ogohlantirishlarni qayta yozish"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Sahifalar / Sozlamalar"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Parol"
 
@@ -1388,6 +1547,10 @@ msgstr "O'tgan"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Doimiy"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Saqlash"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Afzal til"
 msgid "Process started"
 msgstr "Jarayon boshlandi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "O‘qish xatolari"
 msgid "Received"
 msgstr "Qabul qilindi"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Talab qilinadi"
 msgid "Requires"
 msgstr "Talab qiladi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Parolni tiklash"
@@ -1592,6 +1775,14 @@ msgstr "Qayta ishga tushirishlar"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Davom ettirish"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Holat"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Yorliqlar"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Keyin backend'ga kiring va foydalanuvchilar jadvalidagi foydalanuvchi hi
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Bu amalni bekor qilib bo'lmaydi. Bu {name} uchun barcha joriy yozuvlarni ma'lumotlar bazasidan butunlay o'chiradi."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Bu barcha tanlangan yozuvlarni ma'lumotlar bazasidan butunlay o'chiradi."
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName} ning o'tkazish qobiliyati"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS pool {poolName} o‘tkazuvchanligi"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Kimga (elektron pochta)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "Yuklash"
 msgid "Uptime"
 msgstr "Ishlash vaqti"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS pool {poolName} ishlatilishi"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Ishlatilgan"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Tarjimalarimizni yaxshilashga yordam bermoqchimisiz? Batafsil ma'lumot u
 msgid "Wants"
 msgstr "Kerak qiladi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Ogohlantirish (%)"
@@ -2170,6 +2385,10 @@ msgstr "Ogohlantirish (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Ogohlantirish chegaralari"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/uz/uz.po
+++ b/internal/site/src/locales/uz/uz.po
@@ -126,6 +126,11 @@ msgstr "Faol holat"
 msgid "Add {foo}"
 msgstr "{foo} qo'shish"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "URL qo'shish"
@@ -327,6 +332,7 @@ msgstr "Ishga tushira oladi"
 msgid "Can stop"
 msgstr "To'xtata oladi"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Ehtiyot bo'ling - ma'lumotlar yo'qolishi mumkin"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Selsiy (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Monitoring xizmatingizni tekshiring"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Bildirishnoma xizmatingizni tekshiring"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Sikllar"
 msgid "Daily"
 msgstr "Kunlik"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Standart"
 msgid "Default time period"
 msgstr "Standart vaqt oralig'i"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Tahrirlash"
 msgid "Edit {foo}"
 msgstr "{foo} tahrirlash"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Konfiguratsiyani eksport qilish"
 msgid "Export your current systems configuration."
 msgstr "Joriy tizimlar konfiguratsiyasini eksport qiling."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Farengeyt (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD buyrug'i"
 msgid "Full"
 msgstr "To'liq"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew buyrug'i"
 msgid "Host / IP"
 msgstr "Xost / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP usul"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O yuklanishi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Nofaol"
 msgid "Interval"
 msgstr "Interval"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Noto'g'ri elektron pochta manzili."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr ""
 msgid "Model"
 msgstr "Model"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Ulash nuqtasi"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Nom"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Yo'q"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Bu pool uchun batafsil ma’lumot mavjud emas."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Parolni tiklash so'rovi qabul qilindi"
 msgid "Past"
 msgstr "O'tgan"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Pauza"
@@ -1391,6 +1467,14 @@ msgstr "Pool ishlatilishi"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "O‘qish xatolari"
 msgid "Received"
 msgstr "Qabul qilindi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Parolni tiklash"
 msgid "Resolved"
 msgstr "Hal qilindi"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Qayta ishga tushirishlar"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Davom ettirish"
@@ -1511,6 +1608,10 @@ msgstr "Tokenni yangilash"
 msgid "Rows per page"
 msgstr "Sahifadagi qatorlar"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Ishlash vaqti metrikasi"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. tafsilotlar"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. o'z-o'zini test"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "{foo} tanlash"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Endpoint'ingiz ishlayotganligini tekshirish uchun bitta heartbeat ping yuboring."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Yorliqlar"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Vazifalar"
@@ -1779,6 +1896,14 @@ msgstr "ZFS pool {poolName} o‘tkazuvchanligi"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Vaqt formati"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Holat ishlayapti/ishlamayapti o'rtasida o'zgarganda ishga tushadi"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Biron-bir disk ishlatilishi chegaradan oshganda ishga tushadi"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Noma'lum"
 msgid "Unlimited"
 msgstr "Cheksiz"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Yuklash"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Ishlash vaqti"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/vi/vi.po
+++ b/internal/site/src/locales/vi/vi.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} có sẵn"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "Đã chọn {0} trên {1} hàng."
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 ngày"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 phút"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Tác nhân"
 msgid "Alert History"
 msgstr "Lịch sử Cảnh báo"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "Tất cả container"
 msgid "All Systems"
 msgstr "Tất cả Hệ thống"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "Bạn có chắc chắn muốn xóa {name} không?"
@@ -196,6 +238,10 @@ msgstr "Bạn có chắc chắn muốn xóa {name} không?"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "Bạn có chắc không?"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "Sao lưu"
 msgid "Bandwidth"
 msgstr "Băng thông"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "Pin"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "Pin"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "Có thể dừng"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "Độ C (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "Chiều rộng biểu đồ"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "Kiểm tra {email} để lấy liên kết đặt lại."
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "Tình trạng sức khỏe container"
 msgid "Containers"
 msgstr "Container"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "Đã tạo"
 msgid "Critical (%)"
 msgstr "Độ nghiêm trọng (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "Tổng dữ liệu đã đọc kể từ khi khởi động"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "Hàng ngày"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "Thời gian mặc định"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "Xóa"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "Tải xuống"
 msgid "Duration"
 msgstr "Thời lượng"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "Các hệ thống hiện có không được định nghĩa trong <0>con
 msgid "Exited active"
 msgstr "Đã thoát khi hoạt động"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "Hết hạn sau một giờ hoặc khi khởi động lại hub."
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "Xuất cấu hình"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "Xuất cấu hình hệ thống hiện tại của bạn."
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "Xuất cấu hình hệ thống hiện tại của bạn."
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Máy chủ / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "Không hoạt động"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "Nếu bạn đã mất mật khẩu cho tài khoản quản trị viên của mình, bạn có thể đặt lại bằng cách sử dụng lệnh sau."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "Địa chỉ email không hợp lệ."
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "Ngôn ngữ"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "Sử dụng Bộ nhớ"
 msgid "Memory usage of containers"
 msgstr "Mức sử dụng bộ nhớ của các container"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "Mô hình"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "Đơn vị mạng"
 msgid "No"
 msgstr "Không"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Không có dữ liệu chi tiết cho pool này."
@@ -1287,6 +1424,7 @@ msgstr "Không có thuộc tính S.M.A.R.T. nào khả dụng cho thiết bị n
 msgid "No systems found."
 msgstr "Không tìm thấy hệ thống."
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "Không có"
@@ -1301,13 +1439,21 @@ msgstr "Thông báo"
 msgid "Notifications may include recent container log excerpts."
 msgstr "Thông báo có thể bao gồm các đoạn trích gần đây từ nhật ký container."
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "Hỗ trợ OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "Mỗi khi khởi động lại, các hệ thống trong cơ sở dữ liệu sẽ được cập nhật để khớp với các hệ thống được định nghĩa trong tệp."
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "Mỗi khi khởi động lại, các hệ thống trong cơ sở dữ liệu sẽ được cập nhật để khớp với các hệ thống được định nghĩa trong tệp."
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "Khác"
 msgid "Overwrite existing alerts"
 msgstr "Ghi đè các cảnh báo hiện có"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "Trang / Cài đặt"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "Mật khẩu"
 
@@ -1388,6 +1547,10 @@ msgstr "Quá khứ"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Tạm dừng"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "Vĩnh viễn"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "Tính bền vững"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "Ngôn ngữ Ưa thích"
 msgid "Process started"
 msgstr "Tiến trình đã khởi động"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "Lỗi đọc"
 msgid "Received"
 msgstr "Đã nhận"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "Được yêu cầu bởi"
 msgid "Requires"
 msgstr "Yêu cầu"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "Đặt lại Mật khẩu"
@@ -1592,6 +1775,14 @@ msgstr "Khởi động lại"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Tiếp tục"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "Trạng thái"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "Tab"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "Sau đó đăng nhập vào backend và đặt lại mật khẩu tài k
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "Hành động này không thể hoàn tác. Điều này sẽ xóa vĩnh viễn tất cả các bản ghi hiện tại cho {name} khỏi cơ sở dữ liệu."
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "Thao tác này sẽ xóa vĩnh viễn tất cả các bản ghi đã chọn khỏi cơ sở dữ liệu."
@@ -1892,6 +2089,10 @@ msgstr "Thông lượng của {extraFsName}"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "Thông lượng ZFS pool {poolName}"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "Đến email(s)"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr ""
@@ -2093,8 +2295,13 @@ msgstr "Tải lên"
 msgid "Uptime"
 msgstr "Thời gian hoạt động"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "Mức sử dụng ZFS pool {poolName}"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "Đã sử dụng"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "Muốn giúp chúng tôi cải thiện bản dịch của mình? Xem <0>
 msgid "Wants"
 msgstr "Muốn"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "Cảnh báo (%)"
@@ -2170,6 +2385,10 @@ msgstr "Cảnh báo (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "Ngưỡng cảnh báo"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/vi/vi.po
+++ b/internal/site/src/locales/vi/vi.po
@@ -126,6 +126,11 @@ msgstr "Trạng thái hoạt động"
 msgid "Add {foo}"
 msgstr "Thêm {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "Thêm URL"
@@ -327,6 +332,7 @@ msgstr "Có thể khởi động"
 msgid "Can stop"
 msgstr "Có thể dừng"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "Cẩn thận - có thể mất dữ liệu"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "Độ C (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "Kiểm tra dịch vụ giám sát của bạn"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "Kiểm tra dịch vụ thông báo của bạn"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "Chu kỳ"
 msgid "Daily"
 msgstr "Hàng ngày"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "Mặc định"
 msgid "Default time period"
 msgstr "Thời gian mặc định"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "Chỉnh sửa"
 msgid "Edit {foo}"
 msgstr "Chỉnh sửa {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "Xuất cấu hình"
 msgid "Export your current systems configuration."
 msgstr "Xuất cấu hình hệ thống hiện tại của bạn."
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "Độ F (°F)"
@@ -916,6 +943,10 @@ msgstr "Lệnh FreeBSD"
 msgid "Full"
 msgstr "Đầy pin"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Lệnh Homebrew"
 msgid "Host / IP"
 msgstr "Máy chủ / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "Phương thức HTTP"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "Sử dụng I/O"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "Không hoạt động"
 msgid "Interval"
 msgstr "Khoảng thời gian"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "Địa chỉ email không hợp lệ."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "Mức sử dụng bộ nhớ của các container"
 msgid "Model"
 msgstr "Mô hình"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "Điểm gắn kết"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "Tên"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "Không"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "Không có dữ liệu chi tiết cho pool này."
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "Yêu cầu đặt lại mật khẩu đã được nhận"
 msgid "Past"
 msgstr "Quá khứ"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "Tạm dừng"
@@ -1391,6 +1467,14 @@ msgstr "Mức sử dụng pool"
 msgid "Port"
 msgstr "Cổng"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "Lỗi đọc"
 msgid "Received"
 msgstr "Đã nhận"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "Đặt lại Mật khẩu"
 msgid "Resolved"
 msgstr "Đã giải quyết"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "Khởi động lại"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "Tiếp tục"
@@ -1511,6 +1608,10 @@ msgstr "Xoay vòng token"
 msgid "Rows per page"
 msgstr "Số hàng mỗi trang"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "Chỉ số thời gian chạy"
@@ -1522,6 +1623,10 @@ msgstr "Chi tiết S.M.A.R.T."
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "Tự kiểm tra S.M.A.R.T."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "Chọn {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "Gửi một ping heartbeat duy nhất để xác minh điểm cuối của bạn đang hoạt động."
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "Tab"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "Tác vụ"
@@ -1779,6 +1896,14 @@ msgstr "Thông lượng ZFS pool {poolName}"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "Định dạng thời gian"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "Kích hoạt khi trạng thái chuyển đổi giữa lên và xuống"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "Kích hoạt khi sử dụng bất kỳ đĩa nào vượt quá ngưỡng"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "Không xác định"
 msgid "Unlimited"
 msgstr "Không giới hạn"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "Tải lên"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "Thời gian hoạt động"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/zh-CN/zh-CN.po
+++ b/internal/site/src/locales/zh-CN/zh-CN.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} 可用"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "已选择 {0} / {1} 行"
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30 天"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 分钟"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "客户端"
 msgid "Alert History"
 msgstr "警报历史"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有客户端"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您确定要删除 {name} 吗？"
@@ -196,6 +238,10 @@ msgstr "您确定要删除 {name} 吗？"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "您确定吗？"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "备份"
 msgid "Bandwidth"
 msgstr "带宽"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "电池"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "电池"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "可停止"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "摄氏度 (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "图表宽度"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "检查 {email} 以获取重置链接。"
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "容器健康"
 msgid "Containers"
 msgstr "容器"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "创建时间"
 msgid "Critical (%)"
 msgstr "临界 (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "启动以来读取的数据量"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "每日"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "默认时间段"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "删除"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "下载"
 msgid "Duration"
 msgstr "持续时间"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "未在<0>config.yml</0>中定义的客户端将被删除。请定期备�
 msgid "Exited active"
 msgstr "退出活动状态"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "将在一小时后，或Hub重启时失效。"
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "导出配置"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "导出您当前的系统配置。"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "导出您当前的系统配置。"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "主机/IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "闲置"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "如果您丢失了管理员账户的密码，可以使用以下命令重置。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "无效的电子邮件地址。"
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "语言"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "内存使用率"
 msgid "Memory usage of containers"
 msgstr "容器内存使用量"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "型号"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "网络单位"
 msgid "No"
 msgstr "否"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此存储池没有可用的详细数据。"
@@ -1287,6 +1424,7 @@ msgstr "此设备没有可用的 S.M.A.R.T. 属性。"
 msgid "No systems found."
 msgstr "未找到系统。"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "无"
@@ -1301,13 +1439,21 @@ msgstr "通知"
 msgid "Notifications may include recent container log excerpts."
 msgstr "通知可能包含近期的容器日志片段。"
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "支持 OAuth 2/OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "每次重启时，数据库中的系统将更新以匹配文件中定义的系统。"
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "每次重启时，数据库中的系统将更新以匹配文件中定义的系统。"
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "其他"
 msgid "Overwrite existing alerts"
 msgstr "覆盖现有警报"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "页面 / 设置"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "密码"
 
@@ -1388,6 +1547,10 @@ msgstr "过去"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暂停"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "永久"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "持久性"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "首选语言"
 msgid "Process started"
 msgstr "进程启动"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "公钥"
@@ -1535,6 +1706,10 @@ msgstr "读取错误"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "被需要"
 msgid "Requires"
 msgstr "需要"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "重置密码"
@@ -1592,6 +1775,14 @@ msgstr "重启次数"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "恢复"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "状态"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "标签页"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "然后登录到后台并在用户表中重置您的用户账户密码。
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "此操作无法撤销。这将永久删除数据库中{name}的所有当前记录。"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "这将永久删除数据库中所有选定的记录。"
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName}的吞吐量"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS 存储池 {poolName} 吞吐量"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "发送到电子邮件"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "令牌"
@@ -2093,8 +2295,13 @@ msgstr "上传"
 msgid "Uptime"
 msgstr "运行时间"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS 存储池 {poolName} 使用率"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "已用"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "想帮助我们改进翻译吗？查看<0>Crowdin</0>以获取更多详�
 msgid "Wants"
 msgstr "希望"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "警告 (%)"
@@ -2170,6 +2385,10 @@ msgstr "警告 (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "警告阈值"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/zh-CN/zh-CN.po
+++ b/internal/site/src/locales/zh-CN/zh-CN.po
@@ -126,6 +126,11 @@ msgstr "活动状态"
 msgid "Add {foo}"
 msgstr "添加 {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "添加 URL"
@@ -327,6 +332,7 @@ msgstr "可启动"
 msgid "Can stop"
 msgstr "可停止"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "注意 - 潜在数据已经丢失"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "摄氏度 (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "检查您的监控服务"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "检查您的通知服务"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "循环次数"
 msgid "Daily"
 msgstr "每日"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "默认"
 msgid "Default time period"
 msgstr "默认时间段"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "编辑"
 msgid "Edit {foo}"
 msgstr "编辑 {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "导出配置"
 msgid "Export your current systems configuration."
 msgstr "导出您当前的系统配置。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "华氏度 (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD 命令"
 msgid "Full"
 msgstr "全宽"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew 安装命令"
 msgid "Host / IP"
 msgstr "主机/IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP 方法"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O 利用率"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "非活跃"
 msgid "Interval"
 msgstr "间隔"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "无效的电子邮件地址。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "容器内存使用量"
 msgid "Model"
 msgstr "型号"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "挂载点"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "名称"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "否"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此存储池没有可用的详细数据。"
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "已收到密码重置请求"
 msgid "Past"
 msgstr "过去"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暂停"
@@ -1391,6 +1467,14 @@ msgstr "存储池使用率"
 msgid "Port"
 msgstr "端口"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "读取错误"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "重置密码"
 msgid "Resolved"
 msgstr "已解决"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "重启次数"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "恢复"
@@ -1511,6 +1608,10 @@ msgstr "轮换令牌"
 msgid "Rows per page"
 msgstr "每页行数"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "运行时指标"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. 详情"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. 自检"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "选择 {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "发送单个 心跳ping 以验证您的端点是否正常工作。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "标签页"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "任务数"
@@ -1779,6 +1896,14 @@ msgstr "ZFS 存储池 {poolName} 吞吐量"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "时间格式"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "当状态在上线与掉线之间切换时触发"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "当任何磁盘的使用率超过阈值时触发"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "未知"
 msgid "Unlimited"
 msgstr "无限制"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "上传"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "运行时间"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/zh-HK/zh-HK.po
+++ b/internal/site/src/locales/zh-HK/zh-HK.po
@@ -126,6 +126,11 @@ msgstr "活動狀態"
 msgid "Add {foo}"
 msgstr "新增 {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "添加 URL"
@@ -327,6 +332,7 @@ msgstr "可啟動"
 msgid "Can stop"
 msgstr "可停止"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "注意 - 可能遺失資料"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "攝氏 (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "檢查您的監控服務"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "檢查您的通知服務"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "週期"
 msgid "Daily"
 msgstr "每日"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "預設"
 msgid "Default time period"
 msgstr "預設時間段"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "編輯"
 msgid "Edit {foo}"
 msgstr "編輯 {foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "匯出設定"
 msgid "Export your current systems configuration."
 msgstr "匯出您現在的系統設定。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "華氏 (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD 指令"
 msgid "Full"
 msgstr "滿電"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew 指令"
 msgid "Host / IP"
 msgstr "主機 / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP 方法"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O 利用率"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "未啟用"
 msgid "Interval"
 msgstr "間隔"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "無效的電子郵件地址。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "容器記憶體使用量"
 msgid "Model"
 msgstr "型號"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "掛載點"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "名稱"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "否"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此 pool 沒有可用的詳細資料。"
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "已收到密碼重設請求"
 msgid "Past"
 msgstr "過去"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暫停"
@@ -1391,6 +1467,14 @@ msgstr "Pool 使用量"
 msgid "Port"
 msgstr "端口"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "讀取錯誤"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "重設密碼"
 msgid "Resolved"
 msgstr "已解決"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "重啟次數"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "恢復"
@@ -1511,6 +1608,10 @@ msgstr "輪換令牌"
 msgid "Rows per page"
 msgstr "每頁行數"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "運行時指標"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. 詳情"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. 自檢"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "選擇 {foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "發送單次 heartbeat ping 以驗證您的端點是否正常運作。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "分頁"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "任務數"
@@ -1779,6 +1896,14 @@ msgstr "ZFS pool {poolName} 輸送量"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "時間格式"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "當狀態在上和下之間切換時觸發"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "當任何磁碟的使用超過閾值時觸發"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "未知"
 msgid "Unlimited"
 msgstr "無限制"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "上傳"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "運行時間"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/locales/zh-HK/zh-HK.po
+++ b/internal/site/src/locales/zh-HK/zh-HK.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} 可用"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "已選擇 {1} 個項目中的 {0} 個"
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30天"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 分鐘"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "客户端"
 msgid "Alert History"
 msgstr "警報歷史"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -196,6 +238,10 @@ msgstr "您確定要刪除 {name} 嗎？"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "您確定嗎？"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "備份"
 msgid "Bandwidth"
 msgstr "帶寬"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "電池"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "電池"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "可停止"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "攝氏 (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "圖表寬度"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "檢查 {email} 以獲取重置鏈接。"
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "容器健康狀態"
 msgid "Containers"
 msgstr "容器"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "已建立"
 msgid "Critical (%)"
 msgstr "嚴重 (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "自啟動以來累計讀取的資料"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "每日"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "預設時間段"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "刪除"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "下載"
 msgid "Duration"
 msgstr "持續時間"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "未在<0>config.yml</0>中定義的現有系統將被刪除。請定期�
 msgid "Exited active"
 msgstr "退出活動狀態"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "一小時後或重新啟動集線器時過期。"
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "匯出設定"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "匯出您現在的系統設定。"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "匯出您現在的系統設定。"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "主機 / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "閒置"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "如果您遺失了管理員帳號密碼，可以使用以下指令重設。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "無效的電子郵件地址。"
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "語言"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "記憶體使用"
 msgid "Memory usage of containers"
 msgstr "容器記憶體使用量"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "型號"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "網路單位"
 msgid "No"
 msgstr "否"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此 pool 沒有可用的詳細資料。"
@@ -1287,6 +1424,7 @@ msgstr "此裝置沒有可用的 S.M.A.R.T. 屬性。"
 msgid "No systems found."
 msgstr "未找到系統。"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "無"
@@ -1301,13 +1439,21 @@ msgstr "通知"
 msgid "Notifications may include recent container log excerpts."
 msgstr "通知可能包含最近的容器日誌片段。"
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "支援 OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "每次重新啟動時，將會以檔案中的系統定義更新資料庫。"
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "每次重新啟動時，將會以檔案中的系統定義更新資料庫。"
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "其他"
 msgid "Overwrite existing alerts"
 msgstr "覆蓋現有警報"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "頁面 / 設定"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "密碼"
 
@@ -1388,6 +1547,10 @@ msgstr "過去"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暫停"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "永久"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "持久性"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "首選語言"
 msgid "Process started"
 msgstr "進程啟動"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr ""
@@ -1535,6 +1706,10 @@ msgstr "讀取錯誤"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "被需要"
 msgid "Requires"
 msgstr "需要"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "重設密碼"
@@ -1592,6 +1775,14 @@ msgstr "重啟次數"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "恢復"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "狀態"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "分頁"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "然後登錄到後端並在用戶表中重置您的用戶帳戶密碼。
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "此操作無法撤銷。這將永久刪除數據庫中{name}的所有當前記錄。"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "這將從資料庫中永久刪除所有選定的記錄。"
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName}的吞吐量"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS pool {poolName} 輸送量"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "發送到電子郵件"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "令牌"
@@ -2093,8 +2295,13 @@ msgstr "上傳"
 msgid "Uptime"
 msgstr "運行時間"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS pool {poolName} 使用量"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "已用"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "想幫助我們改進翻譯嗎？查看<0>Crowdin</0>以獲取更多詳�
 msgid "Wants"
 msgstr "希望"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "警告 (%)"
@@ -2170,6 +2385,10 @@ msgstr "警告 (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "警告閾值"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/zh/zh.po
+++ b/internal/site/src/locales/zh/zh.po
@@ -18,17 +18,46 @@ msgstr ""
 "X-Crowdin-File: /main/internal/site/src/locales/en/en.po\n"
 "X-Crowdin-File-ID: 32\n"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "(leave empty to keep)"
+msgstr ""
+
 #. placeholder {0}: newVersion.v
 #: src/components/footer-repo-link.tsx
 msgctxt "New version available"
 msgid "{0} available"
 msgstr "{0} 現已推出"
 
+#. placeholder {0}: summary.counts.down
+#: src/components/monitors-summary.tsx
+msgid "{0} down"
+msgstr ""
+
+#. placeholder {0}: monitor.last_latency_ms.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "{0} ms"
+msgstr ""
+
 #. placeholder {0}: table.getFilteredSelectedRowModel().rows.length
 #. placeholder {1}: table.getFilteredRowModel().rows.length
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "{0} of {1} row(s) selected."
 msgstr "已選取 {1} 個項目中的 {0} 個"
+
+#. placeholder {0}: summary.counts.paused
+#: src/components/monitors-summary.tsx
+msgid "{0} paused"
+msgstr ""
+
+#. placeholder {0}: summary.counts.up
+#: src/components/monitors-summary.tsx
+msgid "{0} up"
+msgstr ""
+
+#. placeholder {0}: summary.counts.warn
+#: src/components/monitors-summary.tsx
+msgid "{0} warning"
+msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgid "{cores, plural, one {# core} other {# cores}}"
@@ -92,6 +121,10 @@ msgstr "30天"
 #: src/components/routes/system/charts/load-average-chart.tsx
 msgid "5 min"
 msgstr "5 分鐘"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Accepted codes"
+msgstr ""
 
 #. Table column
 #: src/components/routes/settings/quiet-hours.tsx
@@ -167,6 +200,10 @@ msgstr "Agent"
 msgid "Alert History"
 msgstr "警報歷史"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Alert when keyword is missing"
+msgstr ""
+
 #: src/components/alerts/alert-button.tsx
 #: src/components/alerts/alerts-sheet.tsx
 msgid "Alerts"
@@ -189,6 +226,11 @@ msgstr "所有容器"
 msgid "All Systems"
 msgstr "所有系統"
 
+#. placeholder {0}: monitor.name
+#: src/components/routes/monitors.tsx
+msgid "Are you sure you want to delete {0}?"
+msgstr ""
+
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Are you sure you want to delete {name}?"
 msgstr "您確定要刪除 {name} 嗎？"
@@ -196,6 +238,10 @@ msgstr "您確定要刪除 {name} 嗎？"
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Are you sure?"
 msgstr "您確定嗎？"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Auth"
+msgstr ""
 
 #: src/components/copy-to-clipboard.tsx
 msgid "Automatic copy requires a secure context."
@@ -260,6 +306,10 @@ msgstr "備份"
 msgid "Bandwidth"
 msgstr "網路流量"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Basic"
+msgstr ""
+
 #. Battery label in systems table header
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Bat"
@@ -270,6 +320,10 @@ msgstr "電池"
 #: src/lib/alerts.ts
 msgid "Battery"
 msgstr "電池"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Bearer token"
+msgstr ""
 
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Became active"
@@ -333,6 +387,7 @@ msgid "Can stop"
 msgstr "可停止"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -357,7 +412,20 @@ msgid "Celsius (°C)"
 msgstr "攝氏 (°C)"
 
 #: src/components/routes/monitors.tsx
-msgid "Cert"
+#~ msgid "Cert"
+#~ msgstr ""
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitors.tsx
+msgid "Cert expires in {0} days"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Cert thresholds must be positive with critical below warning."
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Certificate"
 msgstr ""
 
 #: src/components/routes/settings/general.tsx
@@ -388,6 +456,14 @@ msgstr "圖表寬度"
 #: src/components/login/forgot-pass-form.tsx
 msgid "Check {email} for a reset link."
 msgstr "檢查 {email} 以取得重設連結。"
+
+#: src/components/routes/monitors.tsx
+msgid "Check completed"
+msgstr ""
+
+#: src/components/routes/monitors.tsx
+msgid "Check failed"
+msgstr ""
 
 #: src/components/routes/settings/layout.tsx
 msgid "Check logs for more details."
@@ -471,6 +547,7 @@ msgstr "容器健康狀態"
 msgid "Containers"
 msgstr "容器"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Continue"
@@ -594,6 +671,10 @@ msgstr "已建立"
 msgid "Critical (%)"
 msgstr "嚴重 (%)"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Critical below (days)"
+msgstr ""
+
 #: src/components/routes/system/disk-io-sheet.tsx
 msgid "Cumulative data read since boot"
 msgstr "開機以來讀取的資料量"
@@ -636,8 +717,8 @@ msgid "Daily"
 msgstr "每日"
 
 #: src/components/routes/monitors.tsx
-msgid "days"
-msgstr ""
+#~ msgid "days"
+#~ msgstr ""
 
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
@@ -655,6 +736,10 @@ msgstr "預設時間段"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Delete"
 msgstr "刪除"
+
+#: src/components/routes/monitors.tsx
+msgid "Delete failed"
+msgstr ""
 
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Delete fingerprint"
@@ -737,6 +822,7 @@ msgstr "下載"
 msgid "Duration"
 msgstr "持續時間"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Edit"
@@ -831,9 +917,18 @@ msgstr "未在 <0>config.yml</0> 中定義的現有系統將會被刪除。請�
 msgid "Exited active"
 msgstr "結束"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Expected answer (optional)"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Expires after one hour or on hub restart."
 msgstr "在一個小時後或者重新啟動 Hub 時過期。"
+
+#. placeholder {0}: monitor.cert_days.toFixed(0)
+#: src/components/routes/monitor.tsx
+msgid "Expires in {0} days"
+msgstr ""
 
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "Export"
@@ -844,8 +939,12 @@ msgid "Export configuration"
 msgstr "匯出設定"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "Export your current systems configuration."
-msgstr "匯出您現在的系統設定。"
+msgid "Export your current systems and monitors configuration."
+msgstr ""
+
+#: src/components/routes/settings/config-yaml.tsx
+#~ msgid "Export your current systems configuration."
+#~ msgstr "匯出您現在的系統設定。"
 
 #: src/components/routes/monitor-dialog.tsx
 msgid "External uptime check executed from the hub."
@@ -1006,8 +1105,12 @@ msgid "Host / IP"
 msgstr "Host / IP"
 
 #: src/components/routes/monitor-dialog.tsx
-msgid "HTTP check that also looks for text in the response."
+msgid "HTTP check that also looks for text in the first 2 MB of the response."
 msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+#~ msgid "HTTP check that also looks for text in the response."
+#~ msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
@@ -1045,6 +1148,10 @@ msgstr "閒置"
 msgid "If you've lost the password to your admin account, you may reset it using the following command."
 msgstr "如果您遺失管理員帳號密碼，可以使用以下指令重設。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ignore TLS errors (insecure)"
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Docker image"
 msgid "Image"
@@ -1071,6 +1178,10 @@ msgid "Invalid email address."
 msgstr "無效的電子郵件地址。"
 
 #: src/components/routes/monitor-dialog.tsx
+msgid "Invert status (upside down)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
 msgid "Keyword"
 msgstr ""
 
@@ -1081,6 +1192,18 @@ msgstr ""
 #: src/components/routes/settings/general.tsx
 msgid "Language"
 msgstr "語言"
+
+#: src/components/routes/monitor.tsx
+msgid "Last latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency"
+msgstr ""
+
+#: src/components/routes/monitor.tsx
+msgid "Latency (ms)"
+msgstr ""
 
 #: src/components/systems-table/systems-table.tsx
 msgid "Layout"
@@ -1196,13 +1319,23 @@ msgstr "記憶體使用量"
 msgid "Memory usage of containers"
 msgstr "容器的記憶體使用量"
 
+#: src/components/routes/monitor.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Method"
+msgstr ""
+
 #. Device model
 #: src/components/routes/system/smart-table.tsx
 msgid "Model"
 msgstr "型號"
 
+#: src/components/monitors-summary.tsx
 #: src/components/navbar.tsx
 #: src/components/navbar.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/monitors.tsx
 #: src/components/routes/monitors.tsx
 msgid "Monitors"
@@ -1256,6 +1389,10 @@ msgstr "網路單位"
 msgid "No"
 msgstr "否"
 
+#: src/components/routes/monitor.tsx
+msgid "No checks recorded yet."
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此儲存池沒有可用的詳細資料。"
@@ -1287,6 +1424,7 @@ msgstr "此裝置沒有可用的 S.M.A.R.T. 屬性。"
 msgid "No systems found."
 msgstr "找不到任何系統。"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/system/zfs-table.tsx
 msgid "None"
 msgstr "無"
@@ -1301,13 +1439,21 @@ msgstr "通知"
 msgid "Notifications may include recent container log excerpts."
 msgstr "通知可能包含近期的容器日誌片段。"
 
+#: src/components/routes/monitors.tsx
+msgid "Notifications toggled"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "OAuth 2 / OIDC support"
 msgstr "支援 OAuth 2 / OIDC"
 
 #: src/components/routes/settings/config-yaml.tsx
-msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
-msgstr "每次重新啟動時，將會以檔案中的系統定義更新資料庫。"
+#~ msgid "On each restart, systems in the database will be updated to match the systems defined in the file."
+#~ msgstr "每次重新啟動時，將會以檔案中的系統定義更新資料庫。"
+
+#: src/components/routes/settings/config-yaml.tsx
+msgid "On each restart, systems in the database will be updated to match the systems defined in the file. Monitors defined under the <0>monitors</0> key are created or updated the same way, but monitors missing from the file are never deleted."
+msgstr ""
 
 #: src/lib/alerts.ts
 msgid "One or more containers are unhealthy"
@@ -1347,6 +1493,18 @@ msgstr "其他"
 msgid "Overwrite existing alerts"
 msgstr "覆蓋現有警報"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packet size must be between 0 and 65400."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Packets"
+msgstr ""
+
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
 #: src/components/command-palette.tsx
@@ -1365,6 +1523,7 @@ msgstr "頁面 / 設定"
 
 #: src/components/login/auth-form.tsx
 #: src/components/login/auth-form.tsx
+#: src/components/routes/monitor-dialog.tsx
 msgid "Password"
 msgstr "密碼"
 
@@ -1388,6 +1547,10 @@ msgstr "已過期"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暫停"
+
+#: src/components/routes/monitors.tsx
+msgid "Pause toggled"
+msgstr ""
 
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Paused"
@@ -1421,6 +1584,10 @@ msgstr "永久"
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Persistence"
 msgstr "持久性"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Ping count must be between 1 and 10."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Please <0>configure an SMTP server</0> to ensure alerts are delivered."
@@ -1498,6 +1665,10 @@ msgstr "首選語言"
 msgid "Process started"
 msgstr "進程啟動"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Protocol"
+msgstr ""
+
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Public key"
 msgstr "公鑰"
@@ -1535,6 +1706,10 @@ msgstr "讀取錯誤"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor.tsx
+msgid "Recent checks"
+msgstr ""
+
 #: src/components/routes/monitor-dialog.tsx
 msgid "Record type"
 msgstr ""
@@ -1566,6 +1741,14 @@ msgstr "被依賴"
 msgid "Requires"
 msgstr "依賴"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend delay must be between 0 and 1440 minutes."
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resend every (minutes, 0 = never)"
+msgstr ""
+
 #: src/components/login/forgot-pass-form.tsx
 msgid "Reset Password"
 msgstr "重設密碼"
@@ -1592,6 +1775,14 @@ msgstr "重啟次數"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "繼續"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries before down"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Retries must be between 0 and 10."
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -1758,6 +1949,7 @@ msgid "State"
 msgstr "狀態"
 
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor.tsx
 #: src/components/routes/system/smart-table.tsx
 #: src/components/systemd-table/systemd-table.tsx
 #: src/components/systems-table/systems-table.tsx
@@ -1827,6 +2019,7 @@ msgid "Tabs"
 msgstr "分頁"
 
 #: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitor.tsx
 msgid "Target"
 msgstr ""
 
@@ -1881,6 +2074,10 @@ msgstr "然後登入後台並在使用者列表中重設您的帳號密碼。"
 msgid "This action cannot be undone. This will permanently delete all current records for {name} from the database."
 msgstr "此操作無法復原。這將永久刪除資料庫中{name}的所有當前記錄。"
 
+#: src/components/routes/monitors.tsx
+msgid "This action cannot be undone. This will permanently delete the monitor and its check history."
+msgstr ""
+
 #: src/components/routes/settings/alerts-history-data-table.tsx
 msgid "This will permanently delete all selected records from the database."
 msgstr "這將從資料庫中永久刪除所有選定的記錄。"
@@ -1892,6 +2089,10 @@ msgstr "{extraFsName}的傳輸速率"
 #: src/components/routes/system/charts/zfs-charts.tsx
 msgid "Throughput of ZFS pool {poolName}"
 msgstr "ZFS 儲存池 {poolName} 吞吐量"
+
+#: src/components/routes/monitor.tsx
+msgid "Time"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
@@ -1910,6 +2111,7 @@ msgid "To email(s)"
 msgstr "發送到電子郵件"
 
 #: src/components/add-system.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/tokens-fingerprints.tsx
 msgid "Token"
 msgstr "Token"
@@ -2093,8 +2295,13 @@ msgstr "上傳"
 msgid "Uptime"
 msgstr "運行時間"
 
-#: src/components/routes/monitors.tsx
+#: src/components/routes/monitor.tsx
 msgid "Uptime 24h"
+msgstr ""
+
+#. placeholder {0}: monitor.uptime_24h > 0 ? monitor.uptime_24h.toFixed(1) : "—"
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h: {0}%"
 msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
@@ -2118,6 +2325,10 @@ msgstr "ZFS 儲存池 {poolName} 使用率"
 #: src/components/routes/system/zfs-table.tsx
 msgid "Used"
 msgstr "已使用"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Username"
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/navbar.tsx
@@ -2163,6 +2374,10 @@ msgstr "想幫助我們改善翻譯嗎？查看<0>Crowdin</0>以取得更多詳�
 msgid "Wants"
 msgstr "可選依賴"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Warn below (days)"
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Warning (%)"
 msgstr "警告 (%)"
@@ -2170,6 +2385,10 @@ msgstr "警告 (%)"
 #: src/components/routes/settings/general.tsx
 msgid "Warning thresholds"
 msgstr "警告閾值"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Watch certificate expiry"
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "Webhook / Push notifications"

--- a/internal/site/src/locales/zh/zh.po
+++ b/internal/site/src/locales/zh/zh.po
@@ -126,6 +126,11 @@ msgstr "活動狀態"
 msgid "Add {foo}"
 msgstr "新增{foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+#: src/components/routes/monitors.tsx
+msgid "Add monitor"
+msgstr ""
+
 #: src/components/routes/settings/notifications.tsx
 msgid "Add URL"
 msgstr "新增 URL"
@@ -327,6 +332,7 @@ msgstr "可啟動"
 msgid "Can stop"
 msgstr "可停止"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -349,6 +355,10 @@ msgstr "注意 - 可能遺失資料"
 #: src/components/routes/settings/general.tsx
 msgid "Celsius (°C)"
 msgstr "攝氏 (°C)"
+
+#: src/components/routes/monitors.tsx
+msgid "Cert"
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Change display units for metrics."
@@ -390,6 +400,10 @@ msgstr "檢查您的監控服務"
 #: src/components/routes/settings/notifications.tsx
 msgid "Check your notification service"
 msgstr "檢查您的通知服務"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Checks certificate expiry without an HTTP request."
+msgstr ""
 
 #: src/components/routes/system/zfs-table.tsx
 msgid "Checksum errors"
@@ -621,6 +635,10 @@ msgstr "循環"
 msgid "Daily"
 msgstr "每日"
 
+#: src/components/routes/monitors.tsx
+msgid "days"
+msgstr ""
+
 #: src/components/routes/system/info-bar.tsx
 msgctxt "Default system layout option"
 msgid "Default"
@@ -630,6 +648,7 @@ msgstr "預設"
 msgid "Default time period"
 msgstr "預設時間段"
 
+#: src/components/routes/monitors.tsx
 #: src/components/routes/settings/alerts-history-data-table.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -728,6 +747,10 @@ msgstr "編輯"
 msgid "Edit {foo}"
 msgstr "編輯{foo}"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Edit monitor"
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 #: src/components/login/forgot-pass-form.tsx
 #: src/components/login/otp-forms.tsx
@@ -824,6 +847,10 @@ msgstr "匯出設定"
 msgid "Export your current systems configuration."
 msgstr "匯出您現在的系統設定。"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "External uptime check executed from the hub."
+msgstr ""
+
 #: src/components/routes/settings/general.tsx
 msgid "Fahrenheit (°F)"
 msgstr "華氏 (°F)"
@@ -916,6 +943,10 @@ msgstr "FreeBSD 指令"
 msgid "Full"
 msgstr "滿電"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Full URL. Accepts 2xx by default."
+msgstr ""
+
 #. Context: General settings
 #: src/components/routes/settings/general.tsx
 #: src/components/routes/settings/layout.tsx
@@ -974,6 +1005,10 @@ msgstr "Homebrew 指令"
 msgid "Host / IP"
 msgstr "Host / IP"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "HTTP check that also looks for text in the response."
+msgstr ""
+
 #: src/components/routes/settings/heartbeat.tsx
 msgid "HTTP Method"
 msgstr "HTTP 方法"
@@ -997,6 +1032,10 @@ msgctxt "Percent of time the disk is busy with I/O"
 msgid "I/O Utilization"
 msgstr "I/O 利用率"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "ICMP echo. The hub may need NET_RAW capability in Docker."
+msgstr ""
+
 #. Context: Battery state
 #: src/lib/i18n.ts
 msgid "Idle"
@@ -1019,9 +1058,25 @@ msgstr "未啟用"
 msgid "Interval"
 msgstr "間隔"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Interval must be at least 20 seconds."
+msgstr ""
+
 #: src/components/login/auth-form.tsx
 msgid "Invalid email address."
 msgstr "無效的電子郵件地址。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Keyword is required for keyword monitors."
+msgstr ""
 
 #: src/components/routes/settings/general.tsx
 msgid "Language"
@@ -1146,17 +1201,33 @@ msgstr "容器的記憶體使用量"
 msgid "Model"
 msgstr "型號"
 
+#: src/components/navbar.tsx
+#: src/components/navbar.tsx
+#: src/components/routes/monitors.tsx
+#: src/components/routes/monitors.tsx
+msgid "Monitors"
+msgstr ""
+
 #: src/components/routes/system/zfs-table.tsx
 msgid "Mountpoint"
 msgstr "掛載點"
 
+#: src/components/routes/monitors.tsx
+msgid "Mute notifications"
+msgstr ""
+
 #: src/components/add-system.tsx
 #: src/components/alerts-history-columns.tsx
 #: src/components/containers-table/containers-table-columns.tsx
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/systemd-table/systemd-table-columns.tsx
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Name"
 msgstr "名稱"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Name is required."
+msgstr ""
 
 #: src/components/containers-table/containers-table-columns.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1188,6 +1259,10 @@ msgstr "否"
 #: src/components/routes/system/zfs-table.tsx
 msgid "No detail data for this pool."
 msgstr "此儲存池沒有可用的詳細資料。"
+
+#: src/components/routes/monitors.tsx
+msgid "No monitors yet. Add your first HTTP, DNS, ping or TLS check."
+msgstr ""
 
 #: src/components/command-palette.tsx
 #: src/components/systemd-table/systemd-table.tsx
@@ -1309,6 +1384,7 @@ msgstr "已收到密碼重設請求"
 msgid "Past"
 msgstr "已過期"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Pause"
 msgstr "暫停"
@@ -1391,6 +1467,14 @@ msgstr "儲存池使用率"
 msgid "Port"
 msgstr "Port"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port (default 443)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Port must be between 1 and 65535."
+msgstr ""
+
 #: src/components/containers-table/containers-table-columns.tsx
 msgctxt "Container ports"
 msgid "Ports"
@@ -1451,6 +1535,10 @@ msgstr "讀取錯誤"
 msgid "Received"
 msgstr "接收"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Record type"
+msgstr ""
+
 #: src/components/containers-table/containers-table.tsx
 #: src/components/containers-table/containers-table.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1488,10 +1576,19 @@ msgstr "重設密碼"
 msgid "Resolved"
 msgstr "已解決"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolver (optional)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Resolves a record type, optionally against a custom resolver."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Restarts"
 msgstr "重啟次數"
 
+#: src/components/routes/monitors.tsx
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Resume"
 msgstr "繼續"
@@ -1511,6 +1608,10 @@ msgstr "重設 Token"
 msgid "Rows per page"
 msgstr "每頁列數"
 
+#: src/components/routes/monitors.tsx
+msgid "Run check now"
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Runtime Metrics"
 msgstr "運行時指標"
@@ -1522,6 +1623,10 @@ msgstr "S.M.A.R.T. 詳細資訊"
 #: src/components/routes/system/smart-table.tsx
 msgid "S.M.A.R.T. Self-Test"
 msgstr "S.M.A.R.T. 自我測試"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Save"
+msgstr ""
 
 #: src/components/add-system.tsx
 msgid "Save {foo}"
@@ -1575,6 +1680,10 @@ msgstr "選取{foo}"
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send a single heartbeat ping to verify your endpoint is working."
 msgstr "發送單次 Heartbeat Ping 以驗證您的 Endpoint 是否運作正常。"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Send notifications"
+msgstr ""
 
 #: src/components/routes/settings/heartbeat.tsx
 msgid "Send periodic outbound pings to an external monitoring service so you can monitor Beszel without exposing it to the internet."
@@ -1717,6 +1826,14 @@ msgctxt "Tabs system layout option"
 msgid "Tabs"
 msgstr "分頁"
 
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Target is required."
+msgstr ""
+
 #: src/components/systemd-table/systemd-table.tsx
 msgid "Tasks"
 msgstr "任務數"
@@ -1779,6 +1896,14 @@ msgstr "ZFS 儲存池 {poolName} 吞吐量"
 #: src/components/routes/settings/general.tsx
 msgid "Time format"
 msgstr "時間格式"
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout (seconds)"
+msgstr ""
+
+#: src/components/routes/monitor-dialog.tsx
+msgid "Timeout must be positive and less than the interval."
+msgstr ""
 
 #: src/components/routes/settings/notifications.tsx
 msgid "To email(s)"
@@ -1894,6 +2019,7 @@ msgstr "當連線和離線時觸發"
 msgid "Triggers when usage of any disk exceeds a threshold"
 msgstr "當任何磁碟使用率超過閾值時觸發"
 
+#: src/components/routes/monitor-dialog.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/settings/quiet-hours.tsx
 #: src/components/routes/system/smart-table.tsx
@@ -1929,6 +2055,10 @@ msgstr "未知"
 msgid "Unlimited"
 msgstr "無限制"
 
+#: src/components/routes/monitors.tsx
+msgid "Unmute notifications"
+msgstr ""
+
 #. Context: System is up
 #: src/components/routes/system/info-bar.tsx
 #: src/components/systems-table/systems-table-columns.tsx
@@ -1962,6 +2092,10 @@ msgstr "上傳"
 #: src/components/systems-table/systems-table-columns.tsx
 msgid "Uptime"
 msgstr "運行時間"
+
+#: src/components/routes/monitors.tsx
+msgid "Uptime 24h"
+msgstr ""
 
 #: src/components/routes/system/charts/disk-charts.tsx
 #: src/components/routes/system/charts/disk-charts.tsx

--- a/internal/site/src/main.tsx
+++ b/internal/site/src/main.tsx
@@ -24,6 +24,7 @@ import {
 	defaultLayoutWidth,
 } from "@/lib/stores.ts"
 import * as systemsManager from "@/lib/systemsManager.ts"
+import * as monitorsManager from "@/lib/monitors.ts"
 import type { BeszelInfo, UpdateInfo } from "./types"
 
 const LoginPage = lazy(() => import("@/components/login/login.tsx"))
@@ -31,6 +32,7 @@ const Home = lazy(() => import("@/components/routes/home.tsx"))
 const Containers = lazy(() => import("@/components/routes/containers.tsx"))
 const Smart = lazy(() => import("@/components/routes/smart.tsx"))
 const Monitors = lazy(() => import("@/components/routes/monitors.tsx"))
+const MonitorDetail = lazy(() => import("@/components/routes/monitor.tsx"))
 const SystemDetail = lazy(() => import("@/components/routes/system.tsx"))
 const CopyToClipboardDialog = lazy(() => import("@/components/copy-to-clipboard.tsx"))
 
@@ -54,6 +56,7 @@ const App = memo(() => {
 		updateUserSettings()
 		// need to get system list before alerts
 		systemsManager.init()
+		monitorsManager.init()
 		systemsManager
 			// get current systems list
 			.refresh()
@@ -67,6 +70,7 @@ const App = memo(() => {
 			unsubscribeAuth()
 			alertManager.unsubscribe()
 			systemsManager.unsubscribe()
+			monitorsManager.cleanup()
 		}
 	}, [])
 
@@ -82,6 +86,8 @@ const App = memo(() => {
 		return <Smart />
 	} else if (page.route === "monitors") {
 		return <Monitors />
+	} else if (page.route === "monitor") {
+		return <MonitorDetail id={page.params.id} />
 	} else if (page.route === "settings") {
 		return <Settings />
 	}

--- a/internal/site/src/main.tsx
+++ b/internal/site/src/main.tsx
@@ -30,6 +30,7 @@ const LoginPage = lazy(() => import("@/components/login/login.tsx"))
 const Home = lazy(() => import("@/components/routes/home.tsx"))
 const Containers = lazy(() => import("@/components/routes/containers.tsx"))
 const Smart = lazy(() => import("@/components/routes/smart.tsx"))
+const Monitors = lazy(() => import("@/components/routes/monitors.tsx"))
 const SystemDetail = lazy(() => import("@/components/routes/system.tsx"))
 const CopyToClipboardDialog = lazy(() => import("@/components/copy-to-clipboard.tsx"))
 
@@ -79,6 +80,8 @@ const App = memo(() => {
 		return <Containers />
 	} else if (page.route === "smart") {
 		return <Smart />
+	} else if (page.route === "monitors") {
+		return <Monitors />
 	} else if (page.route === "settings") {
 		return <Settings />
 	}

--- a/internal/site/src/types.d.ts
+++ b/internal/site/src/types.d.ts
@@ -616,3 +616,42 @@ export interface UpdateInfo {
 	v: string // new version
 	url: string // url to new version
 }
+
+export type MonitorType = "http" | "keyword" | "ping" | "dns" | "tls"
+export type MonitorStatus = "up" | "down" | "warn" | "paused" | "pending"
+
+export interface MonitorRecord extends RecordModel {
+	name: string
+	type: MonitorType
+	target: string
+	interval: number
+	timeout: number
+	max_retries: number
+	upside_down: boolean
+	paused: boolean
+	notify: boolean
+	resend_after: number
+	users: string[]
+	config: Record<string, any>
+	status: MonitorStatus
+	last_check: string
+	last_latency_ms: number
+	uptime_24h: number
+	cert_days: number
+}
+
+export interface MonitorCheckRecord extends RecordModel {
+	monitor: string
+	status: "up" | "down" | "warn"
+	latency_ms: number
+	code?: number
+	message: string
+	details: Record<string, any>
+	cert_days?: number
+	created: string
+}
+
+export interface MonitorsSummary {
+	counts: Record<MonitorStatus, number>
+	down: { id: string; name: string }[]
+}

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ It has a friendly web interface, simple configuration, and is ready to use out o
 - **Docker stats**: Tracks CPU, memory, and network usage history for each container.
 - **ZFS**: Tracks pool capacity, health, and I/O, plus per-dataset usage.
 - **Alerts**: Configurable alerts for CPU, memory, disk, bandwidth, temperature, fan speed, load average, and status.
+- **Uptime monitors**: HTTP(S)/keyword, TLS certificate expiry, DNS and ping checks from the hub, with notifications on state changes. See [supplemental/guides/monitors.md](supplemental/guides/monitors.md).
 - **Multi-user**: Users manage their own systems. Admins can share systems across users.
 - **OAuth / OIDC**: Supports many OAuth2 providers. Password auth can be disabled.
 - **Automatic backups**: Save to and restore from disk or S3-compatible storage.

--- a/supplemental/CHANGELOG.md
+++ b/supplemental/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add external uptime monitors (HTTP/keyword, TLS certificate, DNS, ping) executed from the hub, with state-change notifications, history, and declarative `monitors:` config.yml support
+
 ## 0.19.0
 
 - **Potential breaking change:** Agents now verify HTTPS certificates. If an agent connects to a hub using a self-signed or otherwise untrusted certificate, configure `CA_CERT_FILE` with the appropriate CA certificate or the connection will be rejected.

--- a/supplemental/guides/monitors.md
+++ b/supplemental/guides/monitors.md
@@ -1,0 +1,105 @@
+# Uptime monitors
+
+Beszel can check external services from the hub, so you can retire a separate
+uptime tool for the common cases: **HTTP(S)** (+ keyword search), **TLS
+certificate expiry**, **DNS records** and **ping (ICMP)**.
+
+## Quick start
+
+1. Open the **Monitors** page from the navbar and click **Add monitor**.
+2. Pick a type, enter the target, keep the defaults (check every 60 s,
+   10 s timeout, down after 3 consecutive failures).
+3. Leave **Send notifications** on to reuse your existing email/webhook
+   channels on down/recovery transitions.
+
+Monitors run on the hub (no agent needed). Pause, test, mute or delete them
+from their cards; open a monitor for latency graphs and check history.
+
+## Monitor types
+
+### HTTP(S) and keyword
+
+Full URL target (`https://example.com/health`). Accepted status codes default
+to `200-299` (Kuma syntax also allows lists and ranges like `200,201,204` or
+`200-299,401`). Method, headers, body, basic/bearer auth, redirect following
+(max 10, re-validated per hop) and `ignore TLS errors` are configurable.
+`keyword` mode additionally requires (or forbids, when inverted) a text
+snippet in the first 2 MB of the response body.
+
+HTTPS checks also watch certificate expiry by default (warn below 21 days,
+down below 7 days, configurable).
+
+### TLS certificate
+
+`host[:port]` target (default port 443, SNI = host). No HTTP request is made,
+so it works for any TLS service. Same 21/7-day warn/critical thresholds.
+
+### DNS
+
+Hostname target, record type (A, AAAA, CNAME, MX, TXT, NS, SOA, SRV, CAA,
+PTR), optional custom resolver (`IP` or `IP:port`, UDP or TCP) and optional
+expected answer (`contains` or `exact` match). Success = NOERROR with at
+least one record (matching when expected).
+
+### Ping
+
+Hostname or IP target, 3 packets of 56 bytes by default. Success = at least
+one reply; min/avg/max and loss are recorded. Unprivileged mode is tried
+first; in Docker add `--cap-add=NET_RAW` (or set
+`net.ipv4.ping_group_range`) or checks report `missing NET_RAW capability`
+instead of a silent false down. Where ICMP is filtered, prefer an HTTP
+monitor.
+
+## Notifications
+
+Transitions (up → down, down → up, warning in/out) notify through your
+existing channels (emails + shoutrrr webhooks) with quiet hours honored.
+Steady down states renotify only if **Resend every** is set (minutes,
+0 = never). Turn **Send notifications** off to keep history without noise.
+
+## Declarative config
+
+Monitors can be defined in `config.yml` (same file as systems). Entries match
+by `(name, target)`, are created or updated at boot, and **never deleted**:
+monitors created in the UI survive a sync that does not mention them.
+
+```yaml
+monitors:
+  - name: homepage
+    type: http
+    target: https://example.com
+    interval: 60
+    timeout: 10
+    users: [you@example.com]
+    config:
+      accepted_status_codes: 200-299
+  - name: mail DNS
+    type: dns
+    target: example.com
+    users: [you@example.com]
+    config:
+      qtype: MX
+      resolver: 1.1.1.1
+      expected_answer: mail.
+  - name: gateway
+    type: ping
+    target: 192.168.1.1
+    users: [you@example.com]
+```
+
+Secrets (`password`, `token`, sensitive headers) are never exported back into
+`config.yml` and must be managed out of band.
+
+## Security notes
+
+By default the hub refuses to check private networks (loopback, RFC 1918,
+link-local, cloud metadata). Set `MONITORS_ALLOW_PRIVATE_NETWORK=true` only
+for lab use. Every redirect hop is re-validated and resolved IPs are pinned
+per attempt (DNS-rebinding resistant). Concurrency is capped at 10
+simultaneous checks (`MONITORS_MAX_CONCURRENT`, max 50).
+
+## History and retention
+
+Every attempt is stored (`monitor_checks`, 30-day retention, 500k-row safety
+cap) with latency, status code and typed details. The 24h uptime ratio is
+recomputed every 10 minutes. Manual **test** runs never pollute history.


### PR DESCRIPTION
## Motivation

Replace Uptime Kuma for the common cases with native Beszel monitors, in Go, fully integrated (same nav, notifications, graphs, declarative config, code style). PR1 is **hub-only**: zero changes to `agent/`, entities, or the WS/SSH/CBOR protocol.

## What this adds

4 checkers executed from the hub on a worker-pool scheduler (ticker + jitter + stagger, overlap skip, per-run timeout, panic recovery):
- **HTTP(S) + keyword** (stdlib only): methods, Kuma-style accepted codes (`200-299,401`), redirects re-validated per hop, headers, basic/bearer auth, 2 MB body cap, keyword/invert, integrated TLS expiry
- **TLS certificate** (stdlib): SNI, warn 21d / critical 7d, UP/warn/down states
- **DNS** (`miekg/dns`, the only generic Go option for MX/NS/SOA/SRV/CAA/PTR + custom resolver:port + udp/tcp): expected-answer contains/exact matching
- **Ping** (`prometheus-community/pro-bing`): unprivileged UDP first, explicit `missing NET_RAW capability` instead of silent false downs

Plus: `monitors` + `monitor_checks` PocketBase collections, 7 REST endpoints, transition notifications via the existing AlertManager pipeline (emails + shoutrrr + quiet hours), Monitors page + detail + dialog + home summary (FR included), `monitors:` config.yml support (never deletes UI data).

## Security

- SSRF deny-by-default (loopback, RFC1918, link-local, cloud metadata, IPv6 local), per-hop redirect re-validation, per-attempt DNS pinning (rebinding-resistant), http(s) schemes only
- Secrets redacted in API, preserved (never wiped) on PATCH/YAML re-sync, excluded from YAML export, never logged
- Timeouts always < interval, response bodies capped, test endpoint rate-limited

## Performance (measured)

- 1000 concurrent check writes (50 monitors x 20 cycles): **0.32 ms/cycle, zero `database is locked`**
- 50 scheduled monitors idle: **+49 KB heap** (~1 goroutine + ticker each)
- Single transaction per check cycle; 30-day retention + 500k-row safety cap; realtime on `monitors` rows only
- Kuma comparison: not benchmarked head-to-head here (no Node runtime in CI env); architectural bound is one Go binary, no Electron, bounded concurrency (default 10, `MONITORS_MAX_CONCURRENT` max 50)

## Tests

- `go test ./internal/hub/monitors/ ./internal/migrations/ ./internal/hub/config/ ./internal/records/ ./internal/alerts/` green (incl. `-race` on monitors, `testing.Short`-gated load test)
- `go vet` clean, `gofmt` clean on new files, `go build ./...` green, `vite build` green
- 2 `internal/hub` failures (agent websocket, universal token) are pre-existing on `main` (verified via clean worktree)
- Live-verified against a local hub: 3 real monitors (HTTP/DNS/TLS vs example.com) all `up` with history; UI list/detail/dialog screenshotted below

## Migration / breaking

New collections only (`monitors`, `monitor_checks`, with revert). No breaking change. New deps: `miekg/dns`, `prometheus-community/pro-bing`.

## Follow-ups (tracked, not in this PR)

- Distributed checks from agents (PR2, `agent` field already reserved nullable)
- Monitor rows in `alerts_history` (requires nullable `system` migration)
- Per-monitor notification channels, e2e browser tests

## Screenshots

Monitors list, detail page with latency graph + history, and add-monitor dialog (French locale strings included; FR catalog updated).
