### PR TITLE
feat(site): display NVMe data units as human-readable GB/TB

### DIFF
--- a/internal/site/src/components/routes/system/smart-table.tsx
+++ b/internal/site/src/components/routes/system/smart-table.tsx
@@ -75,7 +75,12 @@ export const smartColumns: ColumnDef<SmartAttribute>[] = [
 		header: "Name",
 	},
 	{
-		accessorFn: (row) => row.rs || row.rv?.toString(),
+		accessorFn: (row) => {
+			if (row.n === "DataUnitsWritten" || row.n === "DataUnitsRead") {
+				return formatDataUnits(Number(row.rv ?? 0))
+			}
+			return row.rs || row.rv?.toString()
+		},
 		header: "Value",
 	},
 	{
@@ -101,6 +106,11 @@ export const smartColumns: ColumnDef<SmartAttribute>[] = [
 function formatCapacity(bytes: number): string {
 	const { value, unit } = formatBytes(bytes)
 	return `${toFixedFloat(value, value >= 10 ? 1 : 2)} ${unit}`
+}
+
+// Function to format NVMe data units as a human-readable size
+function formatDataUnits(units: number): string {
+	return formatCapacity(units * 1024 * 512)
 }
 
 const SMART_DEVICE_FIELDS = "id,system,name,model,state,capacity,temp,type,hours,cycles,updated"

--- a/internal/site/src/components/routes/system/smart-table.tsx
+++ b/internal/site/src/components/routes/system/smart-table.tsx
@@ -108,9 +108,10 @@ function formatCapacity(bytes: number): string {
 	return `${toFixedFloat(value, value >= 10 ? 1 : 2)} ${unit}`
 }
 
-// Function to format NVMe data units as a human-readable size
+// Function to format NVMe data units
+// (1 unit = 1000 * 512 bytes) as a human-readable size
 function formatDataUnits(units: number): string {
-	return formatCapacity(units * 1024 * 512)
+	return formatCapacity(units * 1000 * 512)
 }
 
 const SMART_DEVICE_FIELDS = "id,system,name,model,state,capacity,temp,type,hours,cycles,updated"


### PR DESCRIPTION
## 📃 Description

Displays NVMe Data Units Written and Data Units Read S.M.A.R.T. values as human-readable GB/TB instead of raw unit counts, reusing the existing `formatCapacity` function. Only these two attributes are affected.

## 📖 Documentation

No documentation changes required.

## 🪵 Changelog

### ✏️ Changed

- NVMe Data Units Written/Read now show as GB/TB in the S.M.A.R.T. details sheet.