### PR TITLE
fix(agent): fall back to -d sat when smartctl returns identity-only data

### DIFF
--- a/agent/smart.go
+++ b/agent/smart.go
@@ -522,6 +522,26 @@ func (sm *SmartManager) CollectSmart(deviceInfo *DeviceInfo) error {
 
 	hasValidData := sm.parseSmartOutput(deviceInfo, output)
 
+	// If the query without an explicit type (scan-detected scsi/ata types are
+	// left off; see issue #1345) returned identity-only data, the drive is
+	// likely ATA behind a SCSI (SAT) layer. Re-query with -d sat before
+	// recording no data. See github.com/henrygd/beszel/issues/2295.
+	if !hasValidData && !deviceInfo.explicitType &&
+		(strings.EqualFold(deviceInfo.Type, "scsi") || strings.EqualFold(deviceInfo.Type, "ata")) {
+		satInfo := *deviceInfo
+		satInfo.Type = "sat"
+		satInfo.parserType = ""
+		satInfo.typeVerified = false
+
+		ctx4, cancel4 := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel4()
+		output, err = exec.CommandContext(ctx4, sm.smartctlPath, sm.smartctlArgs(&satInfo, false)...).CombinedOutput()
+		hasValidData = sm.parseSmartOutput(&satInfo, output)
+		if hasValidData {
+			*deviceInfo = satInfo
+		}
+	}
+
 	// If NVMe controller path failed, try namespace path as fallback.
 	// NVMe controllers (/dev/nvme0) don't always support SMART queries. See github.com/henrygd/beszel/issues/1504
 	if !hasValidData && err != nil && isNvmeControllerPath(deviceInfo.Name) {
@@ -891,6 +911,15 @@ func (sm *SmartManager) parseSmartForSata(output []byte, deviceType string) (boo
 		return false, data.Smartctl.ExitStatus
 	}
 
+	// Identity-only output (serial, model, capacity but no ATA health data)
+	// means smartctl could not read SMART through this device type. Accepting
+	// it stores silent zeros; see github.com/henrygd/beszel/issues/2295.
+	if len(data.AtaSmartAttributes.Table) == 0 && data.Temperature.Current == 0 &&
+		!hasJSONValue(data.AtaDeviceStatistics) {
+		slog.Debug("no ATA SMART data", "device", data.Device.Name)
+		return false, data.Smartctl.ExitStatus
+	}
+
 	sm.Lock()
 	defer sm.Unlock()
 
@@ -1006,6 +1035,14 @@ func (sm *SmartManager) parseSmartForScsi(output []byte, deviceType string) (boo
 	// Skip virtual devices (e.g., Kubernetes PVCs, QEMU, VirtualBox, etc.)
 	if sm.isVirtualDeviceScsi(&data) {
 		slog.Debug("skipping smart", "device", data.Device.Name, "model", data.ScsiModelName)
+		return false, data.Smartctl.ExitStatus
+	}
+
+	// Identity-only output means smartctl could not read health data through
+	// this device type. Accepting it stores silent zeros; see
+	// github.com/henrygd/beszel/issues/2295.
+	if data.Temperature.Current == 0 && data.PowerOnTime.Hours == 0 && !data.SmartStatus.Passed {
+		slog.Debug("no SCSI health data", "device", data.Device.Name)
 		return false, data.Smartctl.ExitStatus
 	}
 
@@ -1145,6 +1182,14 @@ func (sm *SmartManager) parseSmartForNvme(output []byte, deviceType string) (boo
 	// Skip virtual devices (e.g., Kubernetes PVCs, QEMU, VirtualBox, etc.)
 	if sm.isVirtualDeviceNvme(data) {
 		slog.Debug("skipping smart", "device", data.Device.Name, "model", data.ModelName)
+		return false, data.Smartctl.ExitStatus
+	}
+
+	// Identity-only output means smartctl could not read health data through
+	// this device type. Accepting it stores silent zeros; see
+	// github.com/henrygd/beszel/issues/2295.
+	if data.NVMeSmartHealthInformationLog.PowerOnHours == 0 && data.NVMeSmartHealthInformationLog.Temperature == 0 {
+		slog.Debug("no NVMe health data", "device", data.Device.Name)
 		return false, data.Smartctl.ExitStatus
 	}
 

--- a/agent/smart_test.go
+++ b/agent/smart_test.go
@@ -907,6 +907,135 @@ func assertAttrValue(t *testing.T, attributes []*smart.SmartAttribute, name stri
 	}
 }
 
+// TestParseSmartOutputRejectsIdentityOnlyData verifies that smartctl output
+// carrying identity fields but no health sections is treated as a failed
+// collection rather than a valid record of zeros (issue #2295).
+func TestParseSmartOutputRejectsIdentityOnlyData(t *testing.T) {
+	fixturePath := filepath.Join("test-data", "smart", "scsi_identity.json")
+	data, err := os.ReadFile(fixturePath)
+	require.NoError(t, err)
+
+	sm := &SmartManager{SmartDataMap: make(map[string]*smart.SmartData)}
+	device := &DeviceInfo{Name: "/dev/sda", Type: "scsi"}
+
+	assert.False(t, sm.parseSmartOutput(device, data))
+	assert.Empty(t, sm.SmartDataMap, "identity-only output must not be stored as zeroed SMART data")
+	assert.False(t, device.typeVerified)
+}
+
+// fakeSmartctl writes a fake smartctl binary that selects a fixture by
+// argument: "-d sat" / "-d scsi" arms match on the argument list, "" is the
+// default (typeless) response. Fixtures are copied from test-data into the
+// script's directory; argsFile, when set, records the arguments of each call.
+func fakeSmartctl(t *testing.T, responses map[string]string, argsFile string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n"
+	for _, arg := range []string{"-d sat", "-d scsi"} {
+		if fixture, ok := responses[arg]; ok {
+			script += "case \" $* \" in *\"" + arg + "\"*) cat '" + filepath.Join(dir, fixture) + "'; exit ;; esac\n"
+		}
+	}
+	if argsFile != "" {
+		script += "printf '%s' \"$*\" > '" + filepath.Join(dir, argsFile) + "'\n"
+	}
+	if fixture, ok := responses[""]; ok {
+		script += "cat '" + filepath.Join(dir, fixture) + "'\n"
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "smartctl"), []byte(script), 0o755))
+
+	for _, fixture := range responses {
+		data, err := os.ReadFile(filepath.Join("test-data", "smart", fixture))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fixture), data, 0o644))
+	}
+	return filepath.Join(dir, "smartctl")
+}
+
+// TestCollectSmartSatRetry is a table test over the issue #2295 scenarios.
+// Each case drives the real CollectSmart entry point against a fake smartctl
+// that returns identity-only data for the typeless query (scan reports the
+// SATA drive as -d scsi), and varies only what the -d sat query returns.
+func TestCollectSmartSatRetry(t *testing.T) {
+	tests := []struct {
+		name      string
+		responses map[string]string // smartctl arg suffix -> fixture name
+		argsFile  string
+		explicit  bool
+		wantErr   bool
+		validate  func(t *testing.T, sm *SmartManager, device *DeviceInfo, args string)
+	}{
+		{
+			// The reporter's case: -d sat answers with full SMART data, so the
+			// disk must be stored with real values instead of UNKNOWN / 0 °C / 0 h.
+			name:      "sat query recovers health data",
+			responses: map[string]string{"": "scsi_identity.json", "-d sat": "sat.json"},
+			validate: func(t *testing.T, sm *SmartManager, device *DeviceInfo, args string) {
+				smartData, ok := sm.SmartDataMap["Z4K2A01FS"]
+				require.True(t, ok, "sat query data should be stored")
+				assert.Equal(t, "TOSHIBA MG03ACA200", smartData.ModelName)
+				assert.Equal(t, "sat", smartData.DiskType)
+				assert.Equal(t, uint8(38), smartData.Temperature)
+				assert.Equal(t, "PASSED", smartData.SmartStatus)
+				assertAttrValue(t, smartData.Attributes, "Power_On_Hours", 43953)
+				assert.Equal(t, "sat", device.Type)
+				assert.Equal(t, "sat", device.parserType)
+				assert.True(t, device.typeVerified, "successful sat query should mark the device verified")
+			},
+		},
+		{
+			// A drive where even -d sat yields nothing usable must surface an
+			// explicit failure, never a silently stored zeroed record.
+			name:      "sat query also empty",
+			responses: map[string]string{"": "scsi_identity.json", "-d sat": "scsi_identity.json"},
+			wantErr:   true,
+			validate: func(t *testing.T, sm *SmartManager, device *DeviceInfo, args string) {
+				assert.Empty(t, sm.SmartDataMap, "no zeroed record may be stored when both queries fail")
+			},
+		},
+		{
+			// The #2102 contract: an explicit SMART_DEVICES ":type" hint is a
+			// deliberate override and must not be second-guessed by the retry.
+			name:      "explicit type skips sat retry",
+			responses: map[string]string{"": "scsi_identity.json"},
+			argsFile:  "args.txt",
+			explicit:  true,
+			wantErr:   true,
+			validate: func(t *testing.T, sm *SmartManager, device *DeviceInfo, args string) {
+				assert.Equal(t, "-d scsi -a --json=c /dev/sda", args,
+					"explicit type must be passed and not retried with sat")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := &SmartManager{
+				SmartDataMap: make(map[string]*smart.SmartData),
+				smartctlPath: fakeSmartctl(t, tt.responses, tt.argsFile),
+			}
+			device := &DeviceInfo{Name: "/dev/sda", Type: "scsi", explicitType: tt.explicit}
+
+			err := sm.CollectSmart(device)
+			if tt.wantErr {
+				assert.ErrorIs(t, err, errNoValidSmartData)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			args := ""
+			if tt.argsFile != "" {
+				content, readErr := os.ReadFile(filepath.Join(filepath.Dir(sm.smartctlPath), tt.argsFile))
+				require.NoError(t, readErr)
+				args = string(content)
+			}
+			if tt.validate != nil {
+				tt.validate(t, sm, device, args)
+			}
+		})
+	}
+}
+
 func findAttr(attributes []*smart.SmartAttribute, name string) *smart.SmartAttribute {
 	for _, attr := range attributes {
 		if attr != nil && attr.Name == name {

--- a/agent/test-data/smart/sat.json
+++ b/agent/test-data/smart/sat.json
@@ -1,0 +1,26 @@
+{
+  "smartctl": {
+    "exit_status": 0
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda [SAT]",
+    "type": "sat",
+    "protocol": "ATA"
+  },
+  "model_name": "TOSHIBA MG03ACA200",
+  "serial_number": "Z4K2A01FS",
+  "firmware_version": "5701",
+  "user_capacity": { "blocks": 5860533168, "bytes": 3000592982016 },
+  "smart_status": { "passed": true },
+  "temperature": { "current": 38 },
+  "ata_smart_attributes": {
+    "revision": 16,
+    "table": [
+      { "id": 1, "name": "Raw_Read_Error_Rate", "value": 100, "worst": 100, "thresh": 16, "when_failed": "", "raw": { "value": 0, "string": "0" } },
+      { "id": 5, "name": "Reallocated_Sector_Ct", "value": 100, "worst": 100, "thresh": 5, "when_failed": "", "raw": { "value": 0, "string": "0" } },
+      { "id": 9, "name": "Power_On_Hours", "value": 1, "worst": 1, "thresh": 0, "when_failed": "", "raw": { "value": 43953, "string": "43953" } },
+      { "id": 194, "name": "Temperature_Celsius", "value": 62, "worst": 47, "thresh": 0, "when_failed": "", "raw": { "value": 38, "string": "38" } }
+    ]
+  }
+}

--- a/agent/test-data/smart/scsi_identity.json
+++ b/agent/test-data/smart/scsi_identity.json
@@ -1,0 +1,20 @@
+{
+  "smartctl": {
+    "exit_status": 0
+  },
+  "device": {
+    "name": "/dev/sda",
+    "info_name": "/dev/sda",
+    "type": "scsi",
+    "protocol": "SCSI"
+  },
+  "scsi_vendor": "TOSHIBA",
+  "scsi_product": "MG03ACA200",
+  "scsi_model_name": "TOSHIBA MG03ACA200",
+  "scsi_revision": "5701",
+  "serial_number": "Z4K2A01FS",
+  "user_capacity": { "blocks": 5860533168, "bytes": 3000592982016 },
+  "smart_status": { "passed": null },
+  "temperature": { "current": 0, "drive_trip": 0 },
+  "power_on_time": { "hours": 0, "minutes": 0 }
+}


### PR DESCRIPTION
## 📃 Description

On hosts where `smartctl --scan` reports SATA drives as `-d scsi` (Synology DSM, per #2295), the agent runs smartctl without `-d` (scan-detected scsi/ata types are left off so smartctl can auto-detect, #1345). That query returns identity fields but no health sections, and the parsers accepted it as valid data, so every disk was silently recorded as UNKNOWN / 0 °C / 0 hours, with nothing in the agent log.

This change does two things in the agent:

- **Reject identity-only output.** Each parser (SAT, SCSI, NVMe) now treats output that carries a serial number but no health data for its schema (no `ata_smart_attributes` table / devstat / temperature for ATA; no `smart_status.passed` field for SCSI; no health log for NVMe) as a failed collection instead of storing zeros.
- **Retry with `-d sat`.** When the scan-detected type is `scsi` or `ata` and the first query yields no valid data, the agent re-queries with `-d sat`. The drive is an ATA device behind a SAT layer, which is exactly what `-d sat` is for. The retry is skipped for explicit `SMART_DEVICES` `:type` hints, which remain deliberate user overrides (#2102). On success the device is marked verified with type `sat`, so later refreshes query it directly.

When both queries parse successfully but contain no usable health data, the agent logs `no valid SMART data found` and skips the device. Command errors retain the existing `smartctl failed` handling.

The two new fixtures (`scsi_identity.json`, `sat.json`) are representative payloads derived from the fields reported in #2295, not complete smartctl captures. They model identity-only output and SAT health data (PASSED, 38 °C, 43953 power-on hours).

## 🪵 Changelog

### 🔧 Fixed

- SATA disks reported by `smartctl --scan` as `-d scsi` (e.g. Synology DSM) no longer record silent UNKNOWN / 0 °C / 0 h: the agent detects identity-only smartctl output, retries with `-d sat`, and reports the drive's real health data
- Drives where no parser finds health data are logged and skipped instead of being stored as zeroed records

## Verification

- `go test -tags='testing no_ui' ./agent/ -run 'Smart'`: all SMART tests pass, including the new regression tests for the identity-only and SAT fixture cases (`TestParseSmartOutputRejectsIdentityOnlyData`, `TestCollectSmartSatRetry`: sat recovery, sat-also-empty, explicit-type skip)
- Both new tests fail on the pre-fix code (verified by temporarily reverting `agent/smart.go`)
- Existing fixtures (`scsi.json`, `sda.json`, `nvme0.json`, `apple_nvme.json`) and devstat temperature tests unchanged and passing

Fixes #2295
