### PR TITLE
fix(agent): avoid false warnings for vendor-specific ATA attributes

### DIFF
--- a/agent/smart.go
+++ b/agent/smart.go
@@ -931,7 +931,7 @@ func (sm *SmartManager) parseSmartForSata(output []byte, deviceType string) (boo
 		if parsed, ok := smart.ParseSmartRawValueString(attr.Raw.String); ok {
 			rawValue = parsed
 		}
-		if smartData.SmartStatus == "PASSED" && rawValue > 0 && (attr.ID == 5 || attr.ID == 197 || attr.ID == 198) {
+		if smartData.SmartStatus == "PASSED" && rawValue > 0 && shouldWarnForAtaAttribute(data, attr) {
 			smartData.SmartStatus = "WARNING"
 		}
 		smartAttr := &smart.SmartAttribute{
@@ -949,6 +949,42 @@ func (sm *SmartManager) parseSmartForSata(output []byte, deviceType string) (boo
 	sm.SmartDataMap[keyName] = smartData
 
 	return true, data.Smartctl.ExitStatus
+}
+
+// shouldWarnForAtaAttribute determines whether a non-zero ATA attribute warrants a warning based on its ID, name, and drive-database metadata.
+func shouldWarnForAtaAttribute(data smart.SmartInfoForSata, attr smart.AtaSmartAttribute) bool {
+	if attr.ID == 5 {
+		return true
+	}
+
+	name := strings.ToLower(attr.Name)
+	if name == "" {
+		return false
+	}
+
+	switch attr.ID {
+	case 197:
+		return strings.Contains(name, "pending") && strings.Contains(name, "sector")
+	case 198:
+		return data.InSmartctlDatabase && isOfflineUncorrectableAttribute(name)
+	default:
+		return false
+	}
+}
+
+func isOfflineUncorrectableAttribute(name string) bool {
+	name = strings.NewReplacer("_", "", "-", "", " ", "").Replace(name)
+	if strings.Contains(name, "offline") && strings.Contains(name, "uncorrect") {
+		return true
+	}
+
+	// These are smartmontools drive-database names for the same class of uncorrectable-sector counter
+	switch name {
+	case "offlinescanuncsectorct", "offlineuerrmediascan", "uncorreaderrorct":
+		return true
+	default:
+		return strings.Contains(name, "uncorrect") && strings.Contains(name, "sector")
+	}
 }
 
 func getSmartStatus(temperature uint8, passed bool) string {

--- a/agent/smart_test.go
+++ b/agent/smart_test.go
@@ -91,6 +91,11 @@ func TestParseSmartForSata(t *testing.T) {
 }
 
 func TestParseSmartForSataWarnsForCriticalAttributes(t *testing.T) {
+	attrNames := map[int]string{
+		5:   "Reallocated_Sector_Ct",
+		197: "Current_Pending_Sector",
+		198: "Offline_Uncorrectable",
+	}
 	for _, attrID := range []int{5, 197, 198} {
 		t.Run("attribute "+strconv.Itoa(attrID), func(t *testing.T) {
 			jsonPayload := []byte(fmt.Sprintf(`{
@@ -98,15 +103,49 @@ func TestParseSmartForSataWarnsForCriticalAttributes(t *testing.T) {
 				"device": {"name": "/dev/sda", "type": "sat"},
 				"model_name": "Example",
 				"serial_number": "WARNING%d",
+				"in_smartctl_database": true,
 				"smart_status": {"passed": true},
 				"temperature": {"current": 30},
-				"ata_smart_attributes": {"table": [{"id": %d, "raw": {"value": 1, "string": "1"}}]}
-			}`, attrID, attrID))
+				"ata_smart_attributes": {"table": [{"id": %d, "name": "%s", "raw": {"value": 1, "string": "1"}}]}
+			}`, attrID, attrID, attrNames[attrID]))
 
 			sm := &SmartManager{SmartDataMap: make(map[string]*smart.SmartData)}
 			hasData, _ := sm.parseSmartForSata(jsonPayload, "")
 			require.True(t, hasData)
 			assert.Equal(t, "WARNING", sm.SmartDataMap[fmt.Sprintf("WARNING%d", attrID)].SmartStatus)
+		})
+	}
+}
+
+func TestParseSmartForSataIgnoresVendorSpecificCriticalAttributeNames(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		inDatabase bool
+		attrID     int
+		attrName   string
+		wantState  string
+	}{
+		{name: "crucial pending ECC counter", inDatabase: true, attrID: 197, attrName: "Current_Pending_ECC_Cnt", wantState: "PASSED"},
+		{name: "unknown offline counter", inDatabase: false, attrID: 198, attrName: "Offline_Uncorrectable", wantState: "PASSED"},
+		{name: "known offline media counter", inDatabase: true, attrID: 198, attrName: "Offline_UErr_Media_Scan", wantState: "WARNING"},
+		{name: "crucial reallocated NAND blocks", inDatabase: true, attrID: 5, attrName: "Reallocate_NAND_Blk_Cnt", wantState: "WARNING"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			jsonPayload := []byte(fmt.Sprintf(`{
+				"smartctl": {"exit_status": 0},
+				"device": {"name": "/dev/sda", "type": "sat"},
+				"model_name": "Example",
+				"serial_number": "IGNORE%d",
+				"in_smartctl_database": %t,
+				"smart_status": {"passed": true},
+				"temperature": {"current": 30},
+				"ata_smart_attributes": {"table": [{"id": %d, "name": "%s", "raw": {"value": 1, "string": "1"}}]}
+			}`, test.attrID, test.inDatabase, test.attrID, test.attrName))
+
+			sm := &SmartManager{SmartDataMap: make(map[string]*smart.SmartData)}
+			hasData, _ := sm.parseSmartForSata(jsonPayload, "")
+			require.True(t, hasData)
+			assert.Equal(t, test.wantState, sm.SmartDataMap[fmt.Sprintf("IGNORE%d", test.attrID)].SmartStatus)
 		})
 	}
 }

--- a/internal/entities/smart/smart.go
+++ b/internal/entities/smart/smart.go
@@ -348,7 +348,7 @@ type SmartInfoForSata struct {
 	// RotationRate      int                `json:"rotation_rate"`
 	// FormFactor        FormFactorInfo     `json:"form_factor"`
 	// Trim                         TrimInfo                     `json:"trim"`
-	// InSmartctlDatabase           bool                         `json:"in_smartctl_database"`
+	InSmartctlDatabase bool `json:"in_smartctl_database"`
 	// AtaVersion                   AtaVersionInfo               `json:"ata_version"`
 	// SataVersion                  VersionStringInfo            `json:"sata_version"`
 	// InterfaceSpeed               InterfaceSpeedInfo           `json:"interface_speed"`


### PR DESCRIPTION
## Issue

Beszel currently marks any non-zero raw ATA attributes 5, 197, or 198 as `WARNING`, even when the drive vendor uses those IDs for unrelated counters.

This can produce false SMART alerts, such as Crucial MX500 attribute 197 (`Current_Pending_ECC_Cnt`) briefly reporting `1` while SMART remains `PASSED` and no sectors are pending.

This causes me to get constant stream of false warnings via my Discord webhook.

> Disk /dev/sda (Crucial_CT525MX300SSD1) SMART status changed to WARNING

## The fix

To fix this the logic reads the the SMART attribute name when evaluating attributes 197 and 198 to determine whether they are relevant to drive health or unrelated vendor attributes.

The logic is based on this [database metadata](https://github.com/smartmontools/smartmontools/blob/main/drivedb/drivedb.h) so it should generalize to other drives / vendors. We can always tweak the logic if more reports come in. 

Related: #2296