### PR TITLE
fix(agent): skip disk.PartitionsWithContext on Windows to prevent startup hang (#2289)

### DIFF
--- a/agent/disk.go
+++ b/agent/disk.go
@@ -15,14 +15,22 @@ import (
 	"github.com/shirou/gopsutil/v4/disk"
 )
 
+// getDiskPartitions is a test seam for disk.PartitionsWithContext.
+var getDiskPartitions = disk.PartitionsWithContext
+
+// skipDiskPartitionsOnWindows avoids calling gopsutil's disk.PartitionsWithContext
+// on Windows, where it can hang or panic on unresponsive volumes. See
+// https://github.com/henrygd/beszel/issues/2289 and PR #2047.
+var skipDiskPartitionsOnWindows = runtime.GOOS == "windows"
+
 // fsRegistrationContext holds the shared lookup state needed to resolve a
 // filesystem into the tracked fsStats key and metadata.
 type fsRegistrationContext struct {
-	filesystem         string // device part of optional FILESYSTEM env var
-	filesystemName     string // optional custom name from FILESYSTEM=device__name
-	isWindows          bool
-	efPath             string // path to extra filesystems (default "/extra-filesystems")
-	diskIoCounters     map[string]disk.IOCountersStat
+	filesystem     string // device part of optional FILESYSTEM env var
+	filesystemName string // optional custom name from FILESYSTEM=device__name
+	isWindows      bool
+	efPath         string // path to extra filesystems (default "/extra-filesystems")
+	diskIoCounters map[string]disk.IOCountersStat
 }
 
 // diskDiscovery groups the transient state for a single initializeDiskInfo run so
@@ -306,9 +314,13 @@ func (a *Agent) initializeDiskInfo() {
 	hasRoot := false
 	isWindows := runtime.GOOS == "windows"
 
-	partitions, err := disk.PartitionsWithContext(context.Background(), true)
-	if err != nil {
-		slog.Error("Error getting disk partitions", "err", err)
+	var partitions []disk.PartitionStat
+	var err error
+	if !skipDiskPartitionsOnWindows {
+		partitions, err = getDiskPartitions(context.Background(), true)
+		if err != nil {
+			slog.Error("Error getting disk partitions", "err", err)
+		}
 	}
 	slog.Debug("Disk", "partitions", partitions)
 
@@ -325,11 +337,11 @@ func (a *Agent) initializeDiskInfo() {
 	}
 	slog.Debug("Disk I/O", "diskstats", diskIoCounters)
 	ctx := fsRegistrationContext{
-		filesystem:         filesystem,
-		filesystemName:     filesystemName,
-		isWindows:          isWindows,
-		diskIoCounters:     diskIoCounters,
-		efPath:             "/extra-filesystems",
+		filesystem:     filesystem,
+		filesystemName: filesystemName,
+		isWindows:      isWindows,
+		diskIoCounters: diskIoCounters,
+		efPath:         "/extra-filesystems",
 	}
 
 	// Get the appropriate root mount point for this system

--- a/agent/disk_test.go
+++ b/agent/disk_test.go
@@ -3,6 +3,8 @@
 package agent
 
 import (
+	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -1040,4 +1042,53 @@ func TestInitializeDiskIoStatsResetsTrackedDevices(t *testing.T) {
 	assert.Equal(t, []string{"sdb"}, agent.fsNames)
 	assert.Equal(t, uint64(50), agent.fsStats["sdb"].TotalRead)
 	assert.Equal(t, uint64(60), agent.fsStats["sdb"].TotalWrite)
+}
+
+func TestInitializeDiskInfoSkipsPartitionsOnWindows(t *testing.T) {
+	oldSkip := skipDiskPartitionsOnWindows
+	oldFn := getDiskPartitions
+	defer func() {
+		skipDiskPartitionsOnWindows = oldSkip
+		getDiskPartitions = oldFn
+	}()
+
+	skipDiskPartitionsOnWindows = true
+
+	called := false
+	getDiskPartitions = func(ctx context.Context, all bool) ([]disk.PartitionStat, error) {
+		called = true
+		// If the guard is accidentally removed, this function returning quickly
+		// lets the test fail on the `called` assertion instead of timing out.
+		return nil, errors.New("disk.PartitionsWithContext should not be called on Windows")
+	}
+
+	extraDir := t.TempDir()
+	t.Setenv("EXTRA_FILESYSTEMS", extraDir)
+
+	agent := &Agent{
+		fsStats: make(map[string]*system.FsStats),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		agent.initializeDiskInfo()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("initializeDiskInfo blocked when disk partition discovery should have been skipped")
+	}
+
+	assert.False(t, called, "getDiskPartitions should not be called when skipDiskPartitionsOnWindows is true")
+
+	var root *system.FsStats
+	for _, fs := range agent.fsStats {
+		if fs != nil && fs.Root {
+			root = fs
+			break
+		}
+	}
+	assert.NotNil(t, root, "root filesystem should still be registered without partition discovery")
 }


### PR DESCRIPTION
## Description

This PR fixes #2289 by avoiding gopsutil's `disk.PartitionsWithContext` on Windows during agent startup.

`disk.PartitionsWithContext` enumerates all volumes, including external USB and mapped network drives. On Windows, `GetVolumeInformationW` can hang indefinitely or panic when a volume is unresponsive or spinning down. This leaves the agent stuck before it can write any logs, which matches the `SERVICE_STOPPED` symptom reported when the agent is managed by NSSM.

The fix skips `disk.PartitionsWithContext` on Windows. The agent already has fallbacks to discover the root filesystem via `disk.IOCounters` (most active I/O device) and to register `EXTRA_FILESYSTEMS` entries via `disk.Usage`, so monitoring continues to work for the root device and any explicitly configured drives.

A regression test is added to verify that `initializeDiskInfo` does not call the partition discoverer on Windows and still registers a root filesystem.

## Changelog

### Fixed

- Agent no longer hangs or crashes on Windows when an unresponsive drive is present.

### Changed

- `disk.PartitionsWithContext` is skipped on Windows; `EXTRA_FILESYSTEMS` is now the preferred way to monitor non-root drives on Windows.

## Testing

- `go test -tags='testing no_ui' ./agent` passes.
- `go test -tags='testing no_ui' ./internal/cmd/agent ./agent/...` passes.
- `GOOS=windows GOARCH=amd64 go vet ./agent` passes.
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o /tmp/beszel-agent-windows.exe ./internal/cmd/agent` produces a valid `PE32+ executable (console) x86-64`.

Full `go test ./...` has a pre-existing environment/CI issue (`internal/site/dist` missing and a `systemd` CPU percent test that is sensitive to machine core count); these are unrelated to this change.