### PR TITLE
feat(agent): cap update to hub version

### DIFF
--- a/agent/update.go
+++ b/agent/update.go
@@ -1,11 +1,21 @@
 package agent
 
 import (
+	"encoding/json"
+	"errors"
+	"io"
 	"log"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"runtime"
+	"strings"
+	"time"
 
+	"github.com/blang/semver"
+	"github.com/henrygd/beszel/agent/utils"
 	"github.com/henrygd/beszel/internal/ghupdate"
 )
 
@@ -74,8 +84,48 @@ func detectRestarter() restarter {
 	return nil
 }
 
+// fetchHubVersion queries the connected hub for its version. It returns a zero
+// version and an error if the hub is unreachable or does not expose its version
+// (e.g. an older hub without the /api/beszel/version endpoint).
+func fetchHubVersion() (semver.Version, error) {
+	hubURL, exists := utils.GetEnv("HUB_URL")
+	if !exists {
+		return semver.Version{}, errors.New("HUB_URL not set")
+	}
+	u, err := url.Parse(hubURL)
+	if err != nil || u.Host == "" {
+		return semver.Version{}, errors.New("invalid HUB_URL")
+	}
+	u.Path = path.Join(u.Path, "api/beszel/version")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(u.String())
+	if err != nil {
+		return semver.Version{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1024))
+	if err != nil {
+		return semver.Version{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return semver.Version{}, errors.New("hub returned " + resp.Status)
+	}
+
+	var data struct {
+		Version string `json:"v"`
+	}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return semver.Version{}, err
+	}
+	return semver.Parse(strings.TrimPrefix(data.Version, "v"))
+}
+
 // Update checks GitHub for a newer release of beszel-agent, applies it,
-// fixes SELinux context if needed, and restarts the service.
+// fixes SELinux context if needed, and restarts the service. When the agent
+// knows its hub's version, the update is capped at the hub's release so the
+// agent never runs ahead of the hub.
 func Update(useMirror bool) error {
 	exePath, _ := os.Executable()
 
@@ -83,10 +133,18 @@ func Update(useMirror bool) error {
 	if err != nil {
 		dataDir = os.TempDir()
 	}
+
+	var maxVersion string
+	if hubVersion, err := fetchHubVersion(); err == nil && hubVersion.GT(semver.Version{}) {
+		maxVersion = hubVersion.String()
+		ghupdate.ColorPrintf(ghupdate.ColorYellow, "Capping update at hub version %s.", maxVersion)
+	}
+
 	updated, err := ghupdate.Update(ghupdate.Config{
 		ArchiveExecutable: "beszel-agent",
 		DataDir:           dataDir,
 		UseMirror:         useMirror,
+		MaxVersion:        maxVersion,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/agent/update_test.go
+++ b/agent/update_test.go
@@ -1,0 +1,84 @@
+//go:build testing
+
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func unsetHubURL(t *testing.T) {
+	t.Helper()
+	t.Setenv("BESZEL_AGENT_HUB_URL", "")
+	os.Unsetenv("BESZEL_AGENT_HUB_URL")
+	t.Setenv("HUB_URL", "")
+	os.Unsetenv("HUB_URL")
+}
+
+func TestFetchHubVersion(t *testing.T) {
+	t.Run("hub returns version", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/api/beszel/version", r.URL.Path)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"v":"0.19.0"}`))
+		}))
+		defer server.Close()
+
+		t.Setenv("BESZEL_AGENT_HUB_URL", server.URL)
+		version, err := fetchHubVersion()
+		require.NoError(t, err)
+		assert.Equal(t, "0.19.0", version.String())
+	})
+
+	t.Run("hub url with base path", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/beszel/api/beszel/version", r.URL.Path)
+			w.Write([]byte(`{"v":"0.19.0"}`))
+		}))
+		defer server.Close()
+
+		t.Setenv("BESZEL_AGENT_HUB_URL", server.URL+"/beszel")
+		version, err := fetchHubVersion()
+		require.NoError(t, err)
+		assert.Equal(t, "0.19.0", version.String())
+	})
+
+	t.Run("hub without version endpoint errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		defer server.Close()
+
+		t.Setenv("BESZEL_AGENT_HUB_URL", server.URL)
+		_, err := fetchHubVersion()
+		require.Error(t, err)
+	})
+
+	t.Run("invalid version errors", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"v":"not-a-version"}`))
+		}))
+		defer server.Close()
+
+		t.Setenv("BESZEL_AGENT_HUB_URL", server.URL)
+		_, err := fetchHubVersion()
+		require.Error(t, err)
+	})
+
+	t.Run("hub url not set errors", func(t *testing.T) {
+		unsetHubURL(t)
+		_, err := fetchHubVersion()
+		require.Error(t, err)
+	})
+
+	t.Run("invalid hub url errors", func(t *testing.T) {
+		t.Setenv("BESZEL_AGENT_HUB_URL", "://invalid")
+		_, err := fetchHubVersion()
+		require.Error(t, err)
+	})
+}

--- a/internal/ghupdate/ghupdate.go
+++ b/internal/ghupdate/ghupdate.go
@@ -74,6 +74,12 @@ type Config struct {
 	// UseMirror specifies whether to use the beszel.dev mirror instead of GitHub API.
 	// When false (default), always uses api.github.com. When true, uses gh.beszel.dev.
 	UseMirror bool
+
+	// MaxVersion optionally caps the update target. When set, the updater will
+	// not update past this version even if a newer release exists, fetching the
+	// release matching MaxVersion from GitHub/Mirror instead. Leave empty to
+	// always update to the latest release.
+	MaxVersion string
 }
 
 type updater struct {
@@ -126,7 +132,28 @@ func (p *updater) update() (updated bool, err error) {
 	}
 
 	currentVersion := semver.MustParse(strings.TrimPrefix(p.currentVersion, "v"))
-	newVersion := semver.MustParse(strings.TrimPrefix(latest.Tag, "v"))
+	newVersion, err := releaseVersion(latest)
+	if err != nil {
+		return false, err
+	}
+
+	// Cap the update target at the configured max version (if any). This allows
+	// the agent to stay in lockstep with its hub, which may be older than the
+	// latest GitHub release.
+	if cap, capped, capErr := capVersion(newVersion, p.config.MaxVersion); capErr != nil {
+		return false, capErr
+	} else if capped {
+		ColorPrintf(ColorYellow, "Latest release is version %s; capping update at version %s.", newVersion, cap)
+		tagURL := getTagReleaseURL(p.config.UseMirror, p.config.Owner, p.config.Repo, "v"+cap.String())
+		latest, err = fetchRelease(p.config.Context, p.config.HttpClient, tagURL)
+		if err != nil {
+			return false, fmt.Errorf("failed to fetch release for max version %s: %w", cap, err)
+		}
+		newVersion, err = releaseVersion(latest)
+		if err != nil {
+			return false, err
+		}
+	}
 
 	if newVersion.LTE(currentVersion) {
 		ColorPrintf(ColorGreen, "You already have the latest version %s.", p.currentVersion)
@@ -238,7 +265,10 @@ func FetchLatestRelease(ctx context.Context, client HttpClient, url string) (*re
 	if url == "" {
 		url = getApiURL(false, "henrygd", "beszel")
 	}
+	return fetchRelease(ctx, client, url)
+}
 
+func fetchRelease(ctx context.Context, client HttpClient, url string) (*release, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -270,6 +300,30 @@ func FetchLatestRelease(ctx context.Context, client HttpClient, url string) (*re
 	}
 
 	return result, nil
+}
+
+// releaseVersion parses the semver version from a release's tag,
+// tolerating a leading "v" prefix (e.g. "v0.19.0").
+func releaseVersion(r *release) (semver.Version, error) {
+	return semver.Parse(strings.TrimPrefix(r.Tag, "v"))
+}
+
+// capVersion returns the effective update target given a max version. It returns
+// the second value as true when the new version should be capped at maxVersion.
+// An empty maxVersion means no cap.
+func capVersion(newVersion semver.Version, maxVersion string) (semver.Version, bool, error) {
+	if maxVersion == "" {
+		return newVersion, false, nil
+	}
+	maxVersion = strings.TrimPrefix(maxVersion, "v")
+	cap, err := semver.Parse(maxVersion)
+	if err != nil {
+		return newVersion, false, fmt.Errorf("invalid max version %q: %w", maxVersion, err)
+	}
+	if cap.LT(newVersion) {
+		return cap, true, nil
+	}
+	return newVersion, false, nil
 }
 
 func downloadFile(
@@ -393,4 +447,11 @@ func getApiURL(useMirror bool, owner, repo string) string {
 		return fmt.Sprintf("https://gh.beszel.dev/repos/%s/%s/releases/latest?api=true", owner, repo)
 	}
 	return fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
+}
+
+func getTagReleaseURL(useMirror bool, owner, repo, tag string) string {
+	if useMirror {
+		return fmt.Sprintf("https://gh.beszel.dev/repos/%s/%s/releases/tags/%s?api=true", owner, repo, tag)
+	}
+	return fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/tags/%s", owner, repo, tag)
 }

--- a/internal/ghupdate/ghupdate_test.go
+++ b/internal/ghupdate/ghupdate_test.go
@@ -3,9 +3,15 @@ package ghupdate
 import (
 	"archive/tar"
 	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/blang/semver"
 )
 
 func TestArchiveSuffix(t *testing.T) {
@@ -50,6 +56,114 @@ func TestReleaseFindAssetBySuffix(t *testing.T) {
 
 	if asset.Id != 2 {
 		t.Fatalf("Expected asset with id %d, got %v", 2, asset)
+	}
+}
+
+func TestReleaseVersion(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"with v prefix", "v0.19.0", "0.19.0"},
+		{"without prefix", "0.19.0", "0.19.0"},
+		{"prerelease", "v0.19.0-beta1", "0.19.0-beta1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := releaseVersion(&release{Tag: tt.tag})
+			if err != nil {
+				t.Fatalf("releaseVersion(%q) returned error: %v", tt.tag, err)
+			}
+			if v.String() != tt.want {
+				t.Errorf("releaseVersion(%q) = %q, want %q", tt.tag, v.String(), tt.want)
+			}
+		})
+	}
+
+	if _, err := releaseVersion(&release{Tag: "not-a-version"}); err == nil {
+		t.Error("expected error for invalid tag")
+	}
+}
+
+func TestCapVersion(t *testing.T) {
+	latest := semver.MustParse("4.0.0")
+	tests := []struct {
+		name      string
+		max       string
+		want      string
+		wantCapped bool
+		wantErr   bool
+	}{
+		{"no max version means no cap", "", "4.0.0", false, false},
+		{"max version above latest is ignored", "5.0.0", "4.0.0", false, false},
+		{"max version equal to latest is ignored", "4.0.0", "4.0.0", false, false},
+		{"max version below latest caps", "3.2.0", "3.2.0", true, false},
+		{"max version with v prefix caps", "v3.2.0", "3.2.0", true, false},
+		{"prerelease max version caps", "3.2.0-beta.1", "3.2.0-beta.1", true, false},
+		{"invalid max version errors", "abc", "", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, capped, err := capVersion(latest, tt.max)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if capped != tt.wantCapped {
+				t.Errorf("capped = %v, want %v", capped, tt.wantCapped)
+			}
+			if got.String() != tt.want {
+				t.Errorf("result version = %q, want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAPIURLs(t *testing.T) {
+	latestURLs := map[bool]string{
+		false: "https://api.github.com/repos/henrygd/beszel/releases/latest",
+		true:  "https://gh.beszel.dev/repos/henrygd/beszel/releases/latest?api=true",
+	}
+	for mirror, want := range latestURLs {
+		if got := getApiURL(mirror, "henrygd", "beszel"); got != want {
+			t.Errorf("getApiURL(%v) = %q, want %q", mirror, got, want)
+		}
+	}
+
+	tagURLs := map[bool]string{
+		false: "https://api.github.com/repos/henrygd/beszel/releases/tags/v3.2.0",
+		true:  "https://gh.beszel.dev/repos/henrygd/beszel/releases/tags/v3.2.0?api=true",
+	}
+	for mirror, want := range tagURLs {
+		if got := getTagReleaseURL(mirror, "henrygd", "beszel", "v3.2.0"); got != want {
+			t.Errorf("getTagReleaseURL(%v) = %q, want %q", mirror, got, want)
+		}
+	}
+}
+
+func TestFetchReleaseByTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/henrygd/beszel/releases/tags/v3.2.0" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"tag_name":"v3.2.0","assets":[]}`)
+	}))
+	defer server.Close()
+
+	rel, err := FetchLatestRelease(context.Background(), &http.Client{}, server.URL+"/repos/henrygd/beszel/releases/tags/v3.2.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rel.Tag != "v3.2.0" {
+		t.Errorf("tag = %q, want %q", rel.Tag, "v3.2.0")
 	}
 }
 

--- a/internal/hub/api.go
+++ b/internal/hub/api.go
@@ -104,6 +104,10 @@ func (h *Hub) registerApiRoutes(se *core.ServeEvent) error {
 	// get public key and version
 	apiAuth.GET("/info", h.getInfo)
 	apiAuth.GET("/getkey", h.getInfo) // deprecated - keep for compatibility w/ integrations
+	// get the hub's current version (used by agents to cap their update to the hub's release)
+	apiNoAuth.GET("/version", func(e *core.RequestEvent) error {
+		return e.JSON(http.StatusOK, map[string]string{"v": beszel.Version})
+	})
 	// check for updates
 	if optIn, _ := utils.GetEnv("CHECK_UPDATES"); optIn == "true" {
 		var updateInfo UpdateInfo

--- a/internal/hub/api_test.go
+++ b/internal/hub/api_test.go
@@ -626,6 +626,14 @@ func TestApiRoutesAuthentication(t *testing.T) {
 			TestAppFactory:  testAppFactory,
 		},
 		{
+			Name:            "GET /version - no auth should succeed",
+			Method:          http.MethodGet,
+			URL:             "/api/beszel/version",
+			ExpectedStatus:  200,
+			ExpectedContent: []string{"\"v\":"},
+			TestAppFactory:  testAppFactory,
+		},
+		{
 			Name:            "GET /agent-connect - no auth should succeed (websocket upgrade fails but route is accessible)",
 			Method:          http.MethodGet,
 			URL:             "/api/beszel/agent-connect",


### PR DESCRIPTION
## 📃 Description

Currently the auto update of the hub or agent updates to the latest github version. This PR is a try at capping the agent version update to the current hub version, to prevent the agent updating to a newer version than the hub is.

I am a programmer, but sadly not one well versed in Go. So take the code here more as a very long description of what the idea is, since AI wrote it.

## 🪵 Changelog

### ➕ Added

- API endpoint `/api/beszel/version`, which allows fetching the current hub version.

### ✏️ Changed

- Agent: Capped the update version to the current hub version, if it is older than the latest github release.

