### PR TITLE
fix(agent): skip ZFS collection when /dev/zfs is not mapped

### DIFF
--- a/agent/storage_pool.go
+++ b/agent/storage_pool.go
@@ -3,9 +3,11 @@ package agent
 import (
 	"errors"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/henrygd/beszel/agent/btrfs"
@@ -28,6 +30,12 @@ const datasetUsageRefreshInterval = 5 * time.Minute
 // capacity. Health and I/O are read from procfs on Linux, so the utility only
 // needs to refresh slow-moving space accounting.
 const poolStatsRefreshInterval = time.Minute
+
+// zfsDevicePath is the character device node the OpenZFS utilities need.
+// When it is not mapped into the container, commands like `zpool list` hang
+// until the command timeout expires. Probing it lets the agent skip the
+// long-blocking calls entirely. See beszel#2324.
+const zfsDevicePath = "/dev/zfs"
 
 // btrfsFilesystems is the btrfs source; overridable in tests.
 var btrfsFilesystems = btrfs.Filesystems
@@ -67,6 +75,14 @@ type poolBackend struct {
 	detail            *zfsentity.ZfsData
 	lastDetailRefresh time.Time
 	detailFailed      bool
+
+	// devZfsPath is the path to the ZFS character device node. It is set to
+	// zfsDevicePath by newZfsBackend. Tests can override it to simulate a
+	// missing or present device; an empty path disables the probe.
+	devZfsPath string
+	// available is set to true the first time devZfsPath is seen and never
+	// reset for the lifetime of the backend.
+	available atomic.Bool
 }
 
 func newStoragePoolManager() *StoragePoolManager {
@@ -83,7 +99,27 @@ func newZfsBackend() *poolBackend {
 		datasetsFn:     zfs.Datasets,
 		kernelStatsFn:  optionalPoolSource(zfs.PoolKernelStats),
 		poolStatusesFn: optionalPoolSource(zfs.PoolStatuses),
+		devZfsPath:     zfsDevicePath,
 	}
+}
+
+// backendAvailable probes devZfsPath once and caches the result. When /dev/zfs
+// is absent (common on the alpine agent when the user did not mount it), the
+// backend skips the 10s-blocking `zpool list` calls instead of paying the
+// timeout every minute. See beszel#2324.
+func (b *poolBackend) backendAvailable() bool {
+	if !b.available.Load() {
+		if b.devZfsPath == "" {
+			// Tests and callers that bypass newZfsBackend do not require the
+			// device probe; treat the backend as available and let the
+			// injected fns simulate absence.
+			return true
+		}
+		if _, err := os.Stat(b.devZfsPath); err == nil {
+			b.available.Store(true)
+		}
+	}
+	return b.available.Load()
 }
 
 func newBtrfsBackend() *poolBackend {
@@ -141,6 +177,9 @@ func (m *StoragePoolManager) Update(systemStats *system.Stats) {
 }
 
 func (b *poolBackend) updateBackendStats(systemStats *system.Stats) {
+	if !b.backendAvailable() {
+		return
+	}
 	pools := b.poolStats()
 	if len(pools) == 0 {
 		b.kernelSamples = nil
@@ -227,6 +266,9 @@ func (b *poolBackend) kernelStats() (map[string]zfs.PoolKernelStat, map[string]z
 // refreshDatasetUsage re-runs `zfs list` when the refresh window has elapsed
 // and rebuilds the mountpoint-keyed usage map.
 func (b *poolBackend) refreshDatasetUsage() {
+	if !b.backendAvailable() {
+		return
+	}
 	if !b.lastUsageRefresh.IsZero() && time.Since(b.lastUsageRefresh) < datasetUsageRefreshInterval {
 		return
 	}
@@ -277,6 +319,10 @@ func (m *StoragePoolManager) GetDetail(force bool) *zfsentity.ZfsData {
 func (b *poolBackend) getBackendDetail(force bool, interval time.Duration) *zfsentity.ZfsData {
 	b.detailMu.Lock()
 	defer b.detailMu.Unlock()
+
+	if !b.backendAvailable() {
+		return &zfsentity.ZfsData{Pools: []*zfsentity.PoolDetail{}, Complete: true}
+	}
 
 	if force || b.detailFailed || b.detail == nil || time.Since(b.lastDetailRefresh) >= interval {
 		if data, err := b.collectDetail(b.detail); err != nil {

--- a/agent/storage_pool_test.go
+++ b/agent/storage_pool_test.go
@@ -5,7 +5,9 @@ package agent
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -502,4 +504,48 @@ func TestBtrfsPoolIdentities(t *testing.T) {
 	assert.Equal(t, "renamed", stats.ZfsPools[first].DisplayName)
 	assert.Equal(t, first, zm.GetDetail(true).Pools[1].Name)
 	assert.Equal(t, "renamed", zm.GetDetail(true).Pools[1].DisplayName)
+}
+
+// TestUpdateSkipsZfsWhenDevZfsMissing verifies that all ZFS collection is
+// skipped when the /dev/zfs device node is not mapped, avoiding the 10s
+// command timeout. See beszel#2324.
+func TestUpdateSkipsZfsWhenDevZfsMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "dev", "zfs")
+	state := &poolTestBackend{name: "tank"}
+	backend := state.backend()
+	backend.devZfsPath = missing
+
+	zm := &StoragePoolManager{detailInterval: time.Hour, backends: []*poolBackend{backend}}
+
+	var stats system.Stats
+	zm.Update(&stats)
+	zm.Update(&stats)
+	assert.Nil(t, stats.ZfsPools)
+	assert.Empty(t, backend.poolData, "Update should not call zpool list when /dev/zfs is missing")
+
+	usage := zm.DatasetUsage()
+	assert.Nil(t, usage)
+	assert.Empty(t, backend.datasetUsage, "DatasetUsage should not call zfs list when /dev/zfs is missing")
+
+	detail := zm.GetDetail(true)
+	assert.Empty(t, detail.Pools)
+	assert.True(t, detail.Complete)
+	assert.Empty(t, backend.detail, "GetDetail should not call zpool status when /dev/zfs is missing")
+}
+
+// TestUpdateCollectsWhenDevZfsPresent verifies that collection still happens
+// when the device node exists, so mapped /dev/zfs behaves as before.
+func TestUpdateCollectsWhenDevZfsPresent(t *testing.T) {
+	device := filepath.Join(t.TempDir(), "zfs")
+	require.NoError(t, os.WriteFile(device, []byte(""), 0o644))
+
+	state := &poolTestBackend{name: "tank"}
+	backend := state.backend()
+	backend.devZfsPath = device
+
+	zm := &StoragePoolManager{detailInterval: time.Hour, backends: []*poolBackend{backend}}
+	var stats system.Stats
+	zm.Update(&stats)
+	require.NotNil(t, stats.ZfsPools)
+	assert.Contains(t, stats.ZfsPools, "tank")
 }


### PR DESCRIPTION
When the alpine agent container starts without /dev/zfs mounted, commands like zpool list and zfs list hang until the 10s command timeout and log a debug error on every collection cadence. Probe /dev/zfs once at startup and short-circuit pool metrics, dataset usage, and detail collection when it is absent, so the agent no longer pays the timeout cost every minute.\n\nFixes #2324\n\n## Test plan\n- [x] go test -tags='testing' ./agent/zfs/... ./agent\n- [x] go vet ./agent/...\n- [x] make build-agent