### PR TITLE
fix(site): discard pending history when switching to live charts

### DIFF
--- a/internal/site/src/components/routes/system/use-system-data.ts
+++ b/internal/site/src/components/routes/system/use-system-data.ts
@@ -171,6 +171,7 @@ export function useSystemData(id: string) {
 	// get stats when system "changes." (Not just system to system,
 	// also when new info comes in via systemManager realtime connection, indicating an update)
 	useEffect(() => {
+		const requestId = ++statsRequestId.current
 		if (!system.id || !chartTime || chartTime === "1m") {
 			return
 		}
@@ -179,7 +180,6 @@ export function useSystemData(id: string) {
 		const { expectedInterval } = chartTimeData[chartTime]
 		const ss_cache_key = `${systemId}_${chartTime}_system_stats`
 		const cs_cache_key = `${systemId}_${chartTime}_container_stats`
-		const requestId = ++statsRequestId.current
 
 		const cachedSystemStats = cache.get(ss_cache_key) as SystemStatsRecord[] | undefined
 		const cachedContainerData = cache.get(cs_cache_key) as ChartData["containerData"] | undefined
@@ -203,7 +203,7 @@ export function useSystemData(id: string) {
 			getStats<SystemStatsRecord>("system_stats", systemId, chartTime),
 			getStats<ContainerStatsRecord>("container_stats", systemId, chartTime),
 		]).then(([systemStats, containerStats]) => {
-			// If another request has been made since this one, ignore the results
+			// Ignore responses for a previous system or chart time
 			if (requestId !== statsRequestId.current) {
 				return
 			}


### PR DESCRIPTION
Switching to the 1-minute live chart while a historical request is pending can replace live points with old data when that request finishes. The effect returns before incrementing the request ID, so the previous response still passes the stale-request check. Moving the increment above the early return invalidates it when entering live mode too.

Reproduced in Chromium using the actual hook and controlled PocketBase responses: hold a 1-hour request, switch to 1 minute, deliver a live CPU sample of 20%, then complete the historical request with a 30-minute-old sample of 81%. The original code replaces 20% with 81%; this change keeps 20%. These are sample responses, without a running hub or agent.

The browser regression check, Biome check, catalog compilation, and Vite production build pass.
